### PR TITLE
Rename go module

### DIFF
--- a/crypto/timestamp/http_test.go
+++ b/crypto/timestamp/http_test.go
@@ -14,8 +14,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/notaryproject/notation-go-lib/internal/crypto/hashutil"
-	"github.com/notaryproject/notation-go-lib/internal/crypto/pki"
+	"github.com/notaryproject/notation-go/internal/crypto/hashutil"
+	"github.com/notaryproject/notation-go/internal/crypto/pki"
 )
 
 var testRequest = []byte{

--- a/crypto/timestamp/request.go
+++ b/crypto/timestamp/request.go
@@ -7,7 +7,7 @@ import (
 	"errors"
 	"math/big"
 
-	"github.com/notaryproject/notation-go-lib/internal/crypto/oid"
+	"github.com/notaryproject/notation-go/internal/crypto/oid"
 	digest "github.com/opencontainers/go-digest"
 )
 

--- a/crypto/timestamp/response.go
+++ b/crypto/timestamp/response.go
@@ -4,7 +4,7 @@ import (
 	"encoding/asn1"
 	"errors"
 
-	"github.com/notaryproject/notation-go-lib/internal/crypto/pki"
+	"github.com/notaryproject/notation-go/internal/crypto/pki"
 )
 
 // Response is a time-stamping response.

--- a/crypto/timestamp/timestamptest/tsa.go
+++ b/crypto/timestamp/timestamptest/tsa.go
@@ -13,11 +13,11 @@ import (
 	"math/big"
 	"time"
 
-	"github.com/notaryproject/notation-go-lib/crypto/timestamp"
-	"github.com/notaryproject/notation-go-lib/internal/crypto/cms"
-	"github.com/notaryproject/notation-go-lib/internal/crypto/hashutil"
-	"github.com/notaryproject/notation-go-lib/internal/crypto/oid"
-	"github.com/notaryproject/notation-go-lib/internal/crypto/pki"
+	"github.com/notaryproject/notation-go/crypto/timestamp"
+	"github.com/notaryproject/notation-go/internal/crypto/cms"
+	"github.com/notaryproject/notation-go/internal/crypto/hashutil"
+	"github.com/notaryproject/notation-go/internal/crypto/oid"
+	"github.com/notaryproject/notation-go/internal/crypto/pki"
 )
 
 // responseRejection is a general response for request rejection.

--- a/crypto/timestamp/timestamptest/tsa_test.go
+++ b/crypto/timestamp/timestamptest/tsa_test.go
@@ -6,9 +6,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/notaryproject/notation-go-lib/crypto/timestamp"
-	"github.com/notaryproject/notation-go-lib/internal/crypto/oid"
-	"github.com/notaryproject/notation-go-lib/internal/crypto/pki"
+	"github.com/notaryproject/notation-go/crypto/timestamp"
+	"github.com/notaryproject/notation-go/internal/crypto/oid"
+	"github.com/notaryproject/notation-go/internal/crypto/pki"
 )
 
 func TestTSATimestampGranted(t *testing.T) {

--- a/crypto/timestamp/token.go
+++ b/crypto/timestamp/token.go
@@ -10,10 +10,10 @@ import (
 	"math/big"
 	"time"
 
-	"github.com/notaryproject/notation-go-lib/internal/crypto/cms"
-	"github.com/notaryproject/notation-go-lib/internal/crypto/hashutil"
-	"github.com/notaryproject/notation-go-lib/internal/crypto/oid"
-	asn1util "github.com/notaryproject/notation-go-lib/internal/encoding/asn1"
+	"github.com/notaryproject/notation-go/internal/crypto/cms"
+	"github.com/notaryproject/notation-go/internal/crypto/hashutil"
+	"github.com/notaryproject/notation-go/internal/crypto/oid"
+	asn1util "github.com/notaryproject/notation-go/internal/encoding/asn1"
 )
 
 // SignedToken is a parsed timestamp token with signatures.

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/notaryproject/notation-go-lib
+module github.com/notaryproject/notation-go
 
 go 1.17
 

--- a/internal/crypto/cms/signed.go
+++ b/internal/crypto/cms/signed.go
@@ -9,8 +9,8 @@ import (
 	"encoding/hex"
 	"time"
 
-	"github.com/notaryproject/notation-go-lib/internal/crypto/hashutil"
-	"github.com/notaryproject/notation-go-lib/internal/crypto/oid"
+	"github.com/notaryproject/notation-go/internal/crypto/hashutil"
+	"github.com/notaryproject/notation-go/internal/crypto/oid"
 )
 
 // ParsedSignedData is a parsed SignedData structure for golang friendly types.

--- a/notation.go
+++ b/notation.go
@@ -5,7 +5,7 @@ import (
 	"crypto/x509"
 	"time"
 
-	"github.com/notaryproject/notation-go-lib/crypto/timestamp"
+	"github.com/notaryproject/notation-go/crypto/timestamp"
 	"github.com/opencontainers/go-digest"
 )
 

--- a/signature/jws/signer.go
+++ b/signature/jws/signer.go
@@ -10,10 +10,10 @@ import (
 	"fmt"
 
 	"github.com/golang-jwt/jwt/v4"
-	"github.com/notaryproject/notation-go-lib"
-	"github.com/notaryproject/notation-go-lib/crypto/jwsutil"
-	"github.com/notaryproject/notation-go-lib/crypto/timestamp"
-	"github.com/notaryproject/notation-go-lib/internal/crypto/pki"
+	"github.com/notaryproject/notation-go"
+	"github.com/notaryproject/notation-go/crypto/jwsutil"
+	"github.com/notaryproject/notation-go/crypto/timestamp"
+	"github.com/notaryproject/notation-go/internal/crypto/pki"
 )
 
 // Signer signs artifacts and generates JWS signatures.

--- a/signature/jws/signer_test.go
+++ b/signature/jws/signer_test.go
@@ -11,8 +11,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/notaryproject/notation-go-lib"
-	"github.com/notaryproject/notation-go-lib/crypto/timestamp/timestamptest"
+	"github.com/notaryproject/notation-go"
+	"github.com/notaryproject/notation-go/crypto/timestamp/timestamptest"
 	"github.com/opencontainers/go-digest"
 )
 

--- a/signature/jws/spec.go
+++ b/signature/jws/spec.go
@@ -7,7 +7,7 @@ import (
 	"time"
 
 	"github.com/golang-jwt/jwt/v4"
-	"github.com/notaryproject/notation-go-lib"
+	"github.com/notaryproject/notation-go"
 )
 
 // unprotectedHeader contains the header parameters that are not integrity protected.

--- a/signature/jws/verifier.go
+++ b/signature/jws/verifier.go
@@ -11,9 +11,9 @@ import (
 	"time"
 
 	"github.com/golang-jwt/jwt/v4"
-	"github.com/notaryproject/notation-go-lib"
-	"github.com/notaryproject/notation-go-lib/crypto/jwsutil"
-	"github.com/notaryproject/notation-go-lib/crypto/timestamp"
+	"github.com/notaryproject/notation-go"
+	"github.com/notaryproject/notation-go/crypto/jwsutil"
+	"github.com/notaryproject/notation-go/crypto/timestamp"
 )
 
 // maxTimestampAccuracy specifies the max acceptable accuracy for timestamp.

--- a/signature/jws/verifier_test.go
+++ b/signature/jws/verifier_test.go
@@ -7,8 +7,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/notaryproject/notation-go-lib"
-	"github.com/notaryproject/notation-go-lib/crypto/timestamp/timestamptest"
+	"github.com/notaryproject/notation-go"
+	"github.com/notaryproject/notation-go/crypto/timestamp/timestamptest"
 )
 
 func TestVerifierInterface(t *testing.T) {


### PR DESCRIPTION
Rename go module from `github.com/notaryproject/notation-go-lib` to `github.com/notaryproject/notation-go` by #33 