### PR TITLE
Implement plugin manager

### DIFF
--- a/plugin/integration_test.go
+++ b/plugin/integration_test.go
@@ -1,0 +1,71 @@
+package plugin
+
+import (
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"reflect"
+	"testing"
+)
+
+func preparePlugin(t *testing.T) string {
+	root := t.TempDir()
+	src, err := os.Open("./testdata/main.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer src.Close()
+
+	dst, err := os.Create(filepath.Join(root, "main.go"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer dst.Close()
+	_, err = io.Copy(dst, src)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = os.WriteFile(filepath.Join(root, "go.mod"), []byte("module main"), 0666)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = os.Mkdir(filepath.Join(root, "foo"), 0755)
+	if err != nil {
+		t.Fatal(err)
+	}
+	out := filepath.Join(root, "foo", "notation-foo")
+	out = addExeSuffix(out)
+	cmd := exec.Command("go", "build", "-o", out)
+	cmd.Dir = root
+	err = cmd.Run()
+	if err != nil {
+		t.Fatal(err)
+	}
+	return root
+}
+
+func TestIntegration(t *testing.T) {
+	if _, err := exec.LookPath("go"); err != nil {
+		t.Skip()
+	}
+	root := preparePlugin(t)
+	mgr := &Manager{os.DirFS(root), rootedCommander{root}}
+	p, err := mgr.Get("foo")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if p.Err != nil {
+		t.Fatal(p.Err)
+	}
+	list, err := mgr.List()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(list) != 1 {
+		t.Fatalf("Manager.List() len got %d, want 1", len(list))
+	}
+	if !reflect.DeepEqual(list[0].Metadata, p.Metadata) {
+		t.Errorf("Manager.List() got %v, want %v", list[0], p)
+	}
+}

--- a/plugin/manager.go
+++ b/plugin/manager.go
@@ -1,0 +1,100 @@
+package plugin
+
+import (
+	"io/fs"
+	"os"
+	"os/exec"
+	"path"
+)
+
+// commander is defined for mocking purposes.
+type commander interface {
+	Output(string, ...string) ([]byte, error)
+}
+
+type rootedCommander struct {
+	root string
+}
+
+func (c rootedCommander) Output(name string, args ...string) ([]byte, error) {
+	cmd := &exec.Cmd{
+		Path: path.Join(c.root, name),
+		Args: append([]string{path.Base(name)}, args...),
+	}
+	return cmd.Output()
+}
+
+// Manager manages plugins installed on the system.
+type Manager struct {
+	fsys  fs.FS
+	cmder commander
+}
+
+// NewManager returns a new manager.
+func NewManager() (*Manager, error) {
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		return nil, err
+	}
+	pluginDir := path.Join(homeDir, ".notation", "plugins")
+	return &Manager{os.DirFS(pluginDir), rootedCommander{pluginDir}}, nil
+}
+
+// Get returns a plugin on the system by its name.
+// The plugin might be incomplete if p.Err is not nil.
+func (mgr *Manager) Get(name string) (*Plugin, error) {
+	fullname, ok := mgr.isCandidate(name)
+	if !ok {
+		return nil, ErrNotFound
+	}
+	p := newPlugin(mgr.cmder, fullname, name)
+	return p, nil
+}
+
+// List produces a list of the plugins available on the system.
+// Some plugins might be incomplete if their Err is not nil.
+func (mgr *Manager) List() ([]*Plugin, error) {
+	var plugins []*Plugin
+	fs.WalkDir(mgr.fsys, ".", func(dir string, d fs.DirEntry, _ error) error {
+		if dir == "." || !d.IsDir() {
+			return nil
+		}
+		p, err := mgr.Get(d.Name())
+		if err == nil {
+			plugins = append(plugins, p)
+		}
+		return fs.SkipDir
+	})
+	return plugins, nil
+}
+
+// Command returns an "os/exec".Cmd which when .Run() will execute the named plugin.
+// The error returned is ErrNotFound if no plugin was found.
+func (mgr *Manager) Command(name string, args ...string) (*exec.Cmd, error) {
+	p, err := mgr.Get(name)
+	if err != nil {
+		return nil, err
+	}
+	if p.Err != nil {
+		return nil, p.Err
+	}
+	return exec.Command(p.Path, args...), nil
+}
+
+func (mgr *Manager) isCandidate(name string) (fullname string, ok bool) {
+	fullname = path.Join(name, "notation-"+name)
+	fi, err := fs.Stat(mgr.fsys, addExeSuffix(fullname))
+	if err != nil {
+		// Ignore any file which we cannot Stat
+		// (e.g. due to permissions or anything else).
+		return "", false
+	}
+	switch fi.Mode().Type() {
+	case 0, fs.ModeSymlink:
+		// Regular file or symlink, keep going.
+		return fullname, true
+	default:
+		// Something else, ignore.
+		return "", false
+	}
+}

--- a/plugin/manager_test.go
+++ b/plugin/manager_test.go
@@ -1,0 +1,234 @@
+package plugin
+
+import (
+	"encoding/json"
+	"errors"
+	"io/fs"
+	"reflect"
+	"strings"
+	"testing"
+	"testing/fstest"
+)
+
+type testCommander struct {
+	output []byte
+	err    error
+}
+
+func (t testCommander) Output(string, ...string) ([]byte, error) {
+	return t.output, t.err
+}
+
+var validMetadata = Metadata{
+	Name: "foo", Description: "friendly", Version: "1", URL: "example.com",
+	SupportedContractVersions: []string{"1"}, Capabilities: []string{"cap"},
+}
+
+func TestManager_Get(t *testing.T) {
+	type args struct {
+		name string
+	}
+	tests := []struct {
+		name    string
+		mgr     *Manager
+		args    args
+		want    *Plugin
+		err     string
+		invalid string
+	}{
+		{"empty fsys", &Manager{fstest.MapFS{}, nil}, args{"foo"}, nil, "plugin not found", ""},
+		{
+			"plugin not found",
+			&Manager{fstest.MapFS{
+				"baz": &fstest.MapFile{Mode: fs.ModeDir},
+			}, nil},
+			args{"foo"},
+			nil, "plugin not found", "",
+		},
+		{
+			"plugin executable does not exists",
+			&Manager{fstest.MapFS{
+				"foo": &fstest.MapFile{Mode: fs.ModeDir},
+			}, nil},
+			args{"foo"},
+			nil, "plugin not found", "",
+		},
+		{
+			"plugin executable invalid mode",
+			&Manager{fstest.MapFS{
+				"foo":                            &fstest.MapFile{Mode: fs.ModeDir},
+				addExeSuffix("foo/notation-foo"): &fstest.MapFile{Mode: fs.ModeDir},
+			}, testCommander{[]byte("content"), nil}},
+			args{"foo"},
+			nil, "plugin not found", "",
+		},
+		{
+			"discover error",
+			&Manager{fstest.MapFS{
+				"foo":                            &fstest.MapFile{Mode: fs.ModeDir},
+				addExeSuffix("foo/notation-foo"): new(fstest.MapFile),
+			}, testCommander{nil, errors.New("failed")}},
+			args{"foo"},
+			&Plugin{Path: addExeSuffix("foo/notation-foo")},
+			"", "failed to fetch metadata",
+		},
+		{
+			"invalid json",
+			&Manager{fstest.MapFS{
+				"foo":                            &fstest.MapFile{Mode: fs.ModeDir},
+				addExeSuffix("foo/notation-foo"): new(fstest.MapFile),
+			}, testCommander{[]byte("content"), nil}},
+			args{"foo"},
+			&Plugin{Path: addExeSuffix("foo/notation-foo")},
+			"", "metadata can't be decoded",
+		},
+		{
+			"invalid metadata name",
+			&Manager{fstest.MapFS{
+				"baz":                            &fstest.MapFile{Mode: fs.ModeDir},
+				addExeSuffix("baz/notation-baz"): new(fstest.MapFile),
+			}, testCommander{metadataJSON(validMetadata), nil}},
+			args{"baz"},
+			&Plugin{Metadata: Metadata{Name: "baz"}, Path: addExeSuffix("baz/notation-baz")},
+			"", "metadata name \"baz\" is not valid, must be \"foo\"",
+		},
+		{
+			"invalid metadata content",
+			&Manager{fstest.MapFS{
+				"foo":                            &fstest.MapFile{Mode: fs.ModeDir},
+				addExeSuffix("foo/notation-foo"): new(fstest.MapFile),
+			}, testCommander{metadataJSON(Metadata{Name: "foo"}), nil}},
+			args{"foo"},
+			&Plugin{Metadata: Metadata{Name: "foo"}, Path: addExeSuffix("foo/notation-foo")},
+			"", "invalid metadata",
+		},
+		{
+			"valid",
+			&Manager{fstest.MapFS{
+				"foo":                            &fstest.MapFile{Mode: fs.ModeDir},
+				addExeSuffix("foo/notation-foo"): new(fstest.MapFile),
+			}, testCommander{metadataJSON(validMetadata), nil}},
+			args{"foo"},
+			&Plugin{Metadata: validMetadata, Path: addExeSuffix("foo/notation-foo")}, "", "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := tt.mgr.Get(tt.args.name)
+			if tt.err != "" {
+				if err == nil {
+					t.Fatalf("Manager.Get() error = nil, want %s", tt.err)
+				}
+				if !strings.Contains(err.Error(), tt.err) {
+					t.Fatalf("Manager.Get() error = %v, want %v", err, tt.err)
+				}
+			} else if tt.invalid != "" {
+				if err != nil {
+					t.Fatalf("Manager.Get() error = %v, want nil", err)
+				}
+				if !strings.Contains(got.Err.Error(), tt.invalid) {
+					t.Fatalf("Manager.Get() error = %v, want %v", got.Err, tt.invalid)
+				}
+			} else {
+				if err != nil {
+					t.Fatalf("Manager.Get() error = %v, want nil", err)
+				}
+				if got.Err != nil {
+					t.Fatalf("Manager.Get() error = %v, want nil", got.Err)
+				}
+				if !reflect.DeepEqual(got.Metadata, tt.want.Metadata) {
+					t.Errorf("Manager.Get() = %v, want %v", got, tt.want)
+				}
+			}
+		})
+	}
+}
+
+func metadataJSON(m Metadata) []byte {
+	d, err := json.Marshal(m)
+	if err != nil {
+		panic(err)
+	}
+	return d
+}
+
+func TestManager_List(t *testing.T) {
+	tests := []struct {
+		name string
+		mgr  *Manager
+		want []*Plugin
+	}{
+		{"empty fsys", &Manager{fstest.MapFS{}, nil}, nil},
+		{"fsys without plugins", &Manager{fstest.MapFS{"a.go": &fstest.MapFile{}}, nil}, nil},
+		{
+			"fsys with some invalid plugins", &Manager{
+				fstest.MapFS{
+					"foo":                            &fstest.MapFile{Mode: fs.ModeDir},
+					addExeSuffix("foo/notation-foo"): new(fstest.MapFile),
+				}, testCommander{metadataJSON(validMetadata), nil}},
+			[]*Plugin{{Metadata: validMetadata}},
+		},
+		{
+			"fsys with plugins", &Manager{
+				fstest.MapFS{
+					"foo":                            &fstest.MapFile{Mode: fs.ModeDir},
+					addExeSuffix("foo/notation-foo"): new(fstest.MapFile),
+					"baz":                            &fstest.MapFile{Mode: fs.ModeDir},
+				}, testCommander{metadataJSON(validMetadata), nil}},
+			[]*Plugin{{Metadata: validMetadata}},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, _ := tt.mgr.List()
+			if len(got) != len(tt.want) {
+				t.Fatalf("Manager.List() len = %v, want len %v", len(got), len(tt.want))
+			}
+			for i := 0; i < len(got); i++ {
+				if !reflect.DeepEqual(got[i].Metadata, tt.want[i].Metadata) {
+					t.Errorf("Manager.List() got %d = %v, want %v", i, got[i], tt.want[i])
+				}
+			}
+		})
+	}
+}
+
+func TestManager_Command(t *testing.T) {
+	type args struct {
+		name string
+	}
+	tests := []struct {
+		name    string
+		mgr     *Manager
+		args    args
+		wantErr bool
+	}{
+		{"empty fsys", &Manager{fstest.MapFS{}, nil}, args{"foo"}, true},
+		{
+			"invalid plugin", &Manager{fstest.MapFS{
+				"foo":                            &fstest.MapFile{Mode: fs.ModeDir},
+				addExeSuffix("foo/notation-foo"): new(fstest.MapFile),
+			}, testCommander{nil, errors.New("err")}},
+			args{"foo"}, true,
+		},
+		{
+			"valid", &Manager{fstest.MapFS{
+				"foo":                            &fstest.MapFile{Mode: fs.ModeDir},
+				addExeSuffix("foo/notation-foo"): new(fstest.MapFile),
+			}, testCommander{metadataJSON(validMetadata), nil}},
+			args{"foo"}, false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := tt.mgr.Command(tt.args.name)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Manager.Command() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !tt.wantErr && got == nil {
+				t.Error("Manager.Command() want non-nil cmd")
+			}
+		})
+	}
+}

--- a/plugin/metadata.go
+++ b/plugin/metadata.go
@@ -1,0 +1,58 @@
+package plugin
+
+import "errors"
+
+// Metadata provided by the plugin.
+type Metadata struct {
+	Name                      string   `json:"name"`
+	Description               string   `json:"description"`
+	Version                   string   `json:"version"`
+	URL                       string   `json:"url"`
+	SupportedContractVersions []string `json:"supported-contract-versions"`
+	Capabilities              []string `json:"capabilities"`
+}
+
+// Validate checks if the metadata is correctly populated.
+func (m *Metadata) Validate() error {
+	if m.Name == "" {
+		return errors.New("name must not be empty")
+	}
+	if m.Description == "" {
+		return errors.New("description name must not be empty")
+	}
+	if m.Version == "" {
+		return errors.New("version must not be empty")
+	}
+	if m.URL == "" {
+		return errors.New("url must not be empty")
+	}
+	if len(m.Capabilities) == 0 {
+		return errors.New("capabilities must not be empty")
+	}
+	if len(m.SupportedContractVersions) == 0 {
+		return errors.New("supported contract versions must not be empty")
+	}
+	return nil
+}
+
+// HasCapability return true if the metadata states that the
+// capability is supported.
+func (m *Metadata) HasCapability(capability string) bool {
+	for _, c := range m.Capabilities {
+		if c == capability {
+			return true
+		}
+	}
+	return false
+}
+
+// SupportsContract return true if the metadata states that the
+// major contract version is supported.
+func (m *Metadata) SupportsContract(major string) bool {
+	for _, v := range m.SupportedContractVersions {
+		if v == major {
+			return true
+		}
+	}
+	return false
+}

--- a/plugin/metadata_test.go
+++ b/plugin/metadata_test.go
@@ -1,0 +1,75 @@
+package plugin
+
+import (
+	"strconv"
+	"testing"
+)
+
+func TestMetadata_Validate(t *testing.T) {
+	tests := []struct {
+		m       *Metadata
+		wantErr bool
+	}{
+		{&Metadata{}, true},
+		{&Metadata{Name: "name"}, true},
+		{&Metadata{Name: "name", Description: "friendly"}, true},
+		{&Metadata{Name: "name", Description: "friendly", Version: "1"}, true},
+		{&Metadata{Name: "name", Description: "friendly", Version: "1", URL: "example.com"}, true},
+		{&Metadata{Name: "name", Description: "friendly", Version: "1", URL: "example.com", Capabilities: []string{"cap"}}, true},
+		{&Metadata{Name: "name", Description: "friendly", Version: "1", URL: "example.com", SupportedContractVersions: []string{"1"}}, true},
+		{&Metadata{Name: "name", Description: "friendly", Version: "1", URL: "example.com", SupportedContractVersions: []string{"1"}, Capabilities: []string{"cap"}}, false},
+	}
+	for i, tt := range tests {
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			if err := tt.m.Validate(); (err != nil) != tt.wantErr {
+				t.Errorf("Metadata.Validate() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestMetadata_HasCapability(t *testing.T) {
+	type args struct {
+		capability string
+	}
+	tests := []struct {
+		name string
+		m    *Metadata
+		args args
+		want bool
+	}{
+		{"empty capabilities", &Metadata{}, args{"cap"}, false},
+		{"other capabilities", &Metadata{Capabilities: []string{"foo", "baz"}}, args{"cap"}, false},
+		{"found", &Metadata{Capabilities: []string{"foo", "baz"}}, args{"baz"}, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.m.HasCapability(tt.args.capability); got != tt.want {
+				t.Errorf("Metadata.HasCapability() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestMetadata_SupportsContract(t *testing.T) {
+	type args struct {
+		major string
+	}
+	tests := []struct {
+		name string
+		m    *Metadata
+		args args
+		want bool
+	}{
+		{"empty versions", &Metadata{}, args{"2"}, false},
+		{"other versions", &Metadata{SupportedContractVersions: []string{"1", "2"}}, args{"3"}, false},
+		{"found", &Metadata{SupportedContractVersions: []string{"1", "2"}}, args{"2"}, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.m.SupportsContract(tt.args.major); got != tt.want {
+				t.Errorf("Metadata.SupportsContract() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/plugin/plugin.go
+++ b/plugin/plugin.go
@@ -1,0 +1,56 @@
+package plugin
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"runtime"
+)
+
+// Plugin represents a potential plugin with all it's metadata.
+type Plugin struct {
+	Metadata
+
+	Path string `json:",omitempty"`
+
+	// Err is non-nil if the plugin failed one of the candidate tests.
+	Err error `json:",omitempty"`
+}
+
+// ErrNotFound by Manager.Get when the plugin is not found.
+var ErrNotFound = errors.New("plugin not found")
+
+// newPlugin determines if the given candidate is valid
+// and returns a Plugin.
+func newPlugin(cmder commander, binPath, name string) *Plugin {
+	p := &Plugin{
+		Path: addExeSuffix(binPath),
+	}
+
+	meta, err := cmder.Output(p.Path, "get-plugin-metadata")
+	if err != nil {
+		p.Err = fmt.Errorf("failed to fetch metadata: %w", err)
+		return p
+	}
+
+	if err := json.Unmarshal(meta, &p.Metadata); err != nil {
+		p.Err = fmt.Errorf("metadata can't be decoded: %w", err)
+		return p
+	}
+	if p.Name != name {
+		p.Err = fmt.Errorf("metadata name %q is not valid, must be %q", name, p.Name)
+		return p
+	}
+	if err := p.Metadata.Validate(); err != nil {
+		p.Err = fmt.Errorf("invalid metadata: %w", err)
+		return p
+	}
+	return p
+}
+
+func addExeSuffix(s string) string {
+	if runtime.GOOS == "windows" {
+		s += ".exe"
+	}
+	return s
+}

--- a/plugin/testdata/main.go
+++ b/plugin/testdata/main.go
@@ -1,0 +1,35 @@
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"os"
+)
+
+var fail = flag.Bool("fail", false, "")
+
+func main() {
+	flag.Parse()
+	if *fail {
+		os.Exit(1)
+	}
+	if flag.NArg() < 1 {
+		os.Exit(1)
+	}
+	if flag.Arg(0) == "get-plugin-metadata" {
+		// This does not import notation-go/plugin to simplify testing setup.
+		m := struct {
+			Name                      string   `json:"name"`
+			Description               string   `json:"description"`
+			Version                   string   `json:"version"`
+			URL                       string   `json:"url"`
+			SupportedContractVersions []string `json:"supported-contract-versions"`
+			Capabilities              []string `json:"capabilities"`
+		}{Name: "foo", Description: "friendly", Version: "1", URL: "example.com", SupportedContractVersions: []string{"1"}, Capabilities: []string{"cap"}}
+		data, err := json.Marshal(&m)
+		if err != nil {
+			panic(err)
+		}
+		os.Stdout.Write(data)
+	}
+}


### PR DESCRIPTION
This PR implements the common code of the [plugin-extensibility](https://github.com/notaryproject/notaryproject/blob/main/specs/plugin-extensibility.md) spec so it will be used by `notary` and others.

It also contains unit test and integration tests with ad-hoc plugins. Coverage is around 95%.

@SteveLasker

Signed-off-by: qmuntal <qmuntaldiaz@microsoft.com>