### PR TITLE
Load and Validate Trust Policy documents

### DIFF
--- a/verification/policy.go
+++ b/verification/policy.go
@@ -96,7 +96,6 @@ func ValidatePolicyDocument(policyDoc *PolicyDocument) error {
 			i := strings.Index(statement.TrustStore, ":")
 			if i < 0 || !isPresent(statement.TrustStore[:i], supportedTrustStorePrefixes) {
 				return fmt.Errorf("trust policy statement %q uses an unsupported trust store type %q in trust store value %q", statement.Name, statement.TrustStore[:i], statement.TrustStore)
-				return fmt.Errorf("%q has a trust store with an unsupported trust store type", statement.Name)
 			}
 		}
 
@@ -109,7 +108,6 @@ func ValidatePolicyDocument(policyDoc *PolicyDocument) error {
 		// If there is a wildcard in trusted identies, there shouldn't be any other identities
 		if len(statement.TrustedIdentities) > 1 && isPresent(wildcard, statement.TrustedIdentities) {
 			return fmt.Errorf("trust policy statement %q uses a wildcard trusted identity '*', a wildcard identity cannot be used in conjunction with other values", statement.Name)
-			return errors.New("wildcard trusted identity can not be shared with other identities")
 		}
 	}
 

--- a/verification/policy.go
+++ b/verification/policy.go
@@ -1,0 +1,153 @@
+/*
+Package verification provides the utilities for handling verification related logic
+like Trust Stores and Trust Policies. Few utilities include loading, parsing, and validating
+trust policies and trust stores.
+*/
+package verification
+
+import (
+	"encoding/json"
+	"errors"
+	"io/ioutil"
+	"os"
+	"strings"
+)
+
+// PolicyDocument represent a trust_policy.json document
+type PolicyDocument struct {
+	// Version of the policy document
+	Version string `json:"version"`
+	// TrustPolicies include each policy statement
+	TrustPolicies []TrustPolicy `json:"trustPolicies"`
+}
+
+type TrustPolicy struct {
+	// Name of the policy statement
+	Name string `json:"name"`
+	// RegistryScopes that this policy statement affects
+	RegistryScopes []string `json:"registryScopes"`
+	// SignatureVerification setting for this policy statement
+	SignatureVerification string `json:"signatureVerification"`
+	// TrustStore this policy stament uses
+	TrustStore string `json:"trustStore,omitempty"`
+	// TrustedIdentities this policy statement pins
+	TrustedIdentities []string `json:"trustedIdentities,omitempty"`
+}
+
+func isPresent(val string, values []string) bool {
+	for _, v := range values {
+		if v == val {
+			return true
+		}
+	}
+	return false
+}
+
+// ValidatePolicyDocument validates a policy document according to it's version's rule set.
+// if any rule is violated, returns an error
+func ValidatePolicyDocument(policyDoc *PolicyDocument) error {
+	// Constants
+	wildcardScope := "*"
+	supportedPolicyVersions := []string{"1.0"}
+	supportedVerificationPresets := []string{"strict", "permissive", "audit", "skip"}
+	supportedTrustStorePrefixes := []string{"ca", "signingservice"}
+
+	// Validate Version
+	if !isPresent(policyDoc.Version, supportedPolicyVersions) {
+		return errors.New("Version '" + policyDoc.Version + "' is not supported")
+	}
+
+	// Validate the policy according to 1.0 rules
+	if len(policyDoc.TrustPolicies) == 0 {
+		return errors.New("Trust Policy document can not have zero statements")
+	}
+	var uniqueStatementNames []string
+	registryScopeCount := make(map[string]int)
+	for _, statement := range policyDoc.TrustPolicies {
+
+		// Verify statement name is valid
+		if statement.Name == "" {
+			return errors.New("Policy statement is missing a name")
+		} else {
+			if !isPresent(statement.Name, uniqueStatementNames) {
+				uniqueStatementNames = append(uniqueStatementNames, statement.Name)
+			}
+		}
+
+		// Verify registry scopes are valid
+		if len(statement.RegistryScopes) == 0 {
+			return errors.New("Policy statement has zero registry scopes")
+		} else {
+			if len(statement.RegistryScopes) > 1 && isPresent(wildcardScope, statement.RegistryScopes) {
+				return errors.New("Wildcard scope can not be shared with other registry scopes")
+			}
+			for _, scope := range statement.RegistryScopes {
+				registryScopeCount[scope]++
+			}
+		}
+
+		// Verify signature verification preset is valid
+		if !isPresent(statement.SignatureVerification, supportedVerificationPresets) {
+			return errors.New("SignatureVerification '" + statement.SignatureVerification + "' is not supported")
+		}
+
+		// strict and permissive verification needs trust store to verify authenticity
+		if statement.SignatureVerification == "strict" || statement.SignatureVerification == "permissive" {
+			if statement.TrustStore == "" {
+				return errors.New("Verification statement with strict or permissive preset is missing a trust store")
+			}
+		}
+
+		// Verify trust store type is valid
+		if statement.TrustStore != "" {
+			i := strings.Index(statement.TrustStore, ":")
+			if i < 0 || !isPresent(statement.TrustStore[:i], supportedTrustStorePrefixes) {
+				return errors.New("Statement '" + statement.Name + "' has a trust store with an unsupported trust store type")
+			}
+		}
+
+		// If there are trusted identitied, verify they are not empty
+		if len(statement.TrustedIdentities) > 0 {
+			for _, identity := range statement.TrustedIdentities {
+				if identity == "" {
+					return errors.New("Policy statement has an empty trusted identity")
+				}
+			}
+		}
+	}
+
+	// Verify unique policy statement names across the policy document
+	if len(policyDoc.TrustPolicies) != len(uniqueStatementNames) {
+		return errors.New("Multiple policy statements have the same name")
+	}
+
+	// Verify one policy statement per registry scope
+	for key := range registryScopeCount {
+		if registryScopeCount[key] > 1 {
+			return errors.New("Registry '" + key + "' is present in multiple statements")
+		}
+	}
+
+	// No errors
+	return nil
+}
+
+// LoadPolicyDocument loads a policy document from the given path
+// If successful, returns a pointer to the PolicyDocument. Otherwise, an error
+func LoadPolicyDocument(path string) (*PolicyDocument, error) {
+	jsonFile, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer jsonFile.Close()
+
+	byteValue, _ := ioutil.ReadAll(jsonFile)
+	var policyDoc *PolicyDocument
+
+	err = json.Unmarshal(byteValue, &policyDoc)
+	if err != nil {
+		return nil, err
+	}
+
+	return policyDoc, nil
+}

--- a/verification/policy.go
+++ b/verification/policy.go
@@ -6,14 +6,12 @@ trust policies and trust stores.
 package verification
 
 import (
-	"encoding/json"
 	"errors"
-	"io/ioutil"
-	"os"
+	"fmt"
 	"strings"
 )
 
-// PolicyDocument represent a trust_policy.json document
+// PolicyDocument represents a trust_policy.json document
 type PolicyDocument struct {
 	// Version of the policy document
 	Version string `json:"version"`
@@ -21,6 +19,7 @@ type PolicyDocument struct {
 	TrustPolicies []TrustPolicy `json:"trustPolicies"`
 }
 
+// TrustPolicy represents a policy statement in the policy document
 type TrustPolicy struct {
 	// Name of the policy statement
 	Name string `json:"name"`
@@ -47,107 +46,85 @@ func isPresent(val string, values []string) bool {
 // if any rule is violated, returns an error
 func ValidatePolicyDocument(policyDoc *PolicyDocument) error {
 	// Constants
-	wildcardScope := "*"
+	wildcard := "*"
 	supportedPolicyVersions := []string{"1.0"}
 	supportedVerificationPresets := []string{"strict", "permissive", "audit", "skip"}
 	supportedTrustStorePrefixes := []string{"ca", "signingservice"}
 
 	// Validate Version
 	if !isPresent(policyDoc.Version, supportedPolicyVersions) {
-		return errors.New("Version '" + policyDoc.Version + "' is not supported")
+		return fmt.Errorf("version '%s' is not supported", policyDoc.Version)
 	}
 
 	// Validate the policy according to 1.0 rules
 	if len(policyDoc.TrustPolicies) == 0 {
-		return errors.New("Trust Policy document can not have zero statements")
+		return errors.New("trust policy document can not have zero policy statements")
 	}
-	var uniqueStatementNames []string
+	policyStatementNameCount := make(map[string]int)
 	registryScopeCount := make(map[string]int)
 	for _, statement := range policyDoc.TrustPolicies {
 
 		// Verify statement name is valid
 		if statement.Name == "" {
-			return errors.New("Policy statement is missing a name")
-		} else {
-			if !isPresent(statement.Name, uniqueStatementNames) {
-				uniqueStatementNames = append(uniqueStatementNames, statement.Name)
-			}
+			return errors.New("policy statement is missing a name")
 		}
+		policyStatementNameCount[statement.Name]++
 
 		// Verify registry scopes are valid
 		if len(statement.RegistryScopes) == 0 {
-			return errors.New("Policy statement has zero registry scopes")
-		} else {
-			if len(statement.RegistryScopes) > 1 && isPresent(wildcardScope, statement.RegistryScopes) {
-				return errors.New("Wildcard scope can not be shared with other registry scopes")
-			}
-			for _, scope := range statement.RegistryScopes {
-				registryScopeCount[scope]++
-			}
+			return fmt.Errorf("policy statement '%s' has zero registry scopes", statement.Name)
+		}
+		if len(statement.RegistryScopes) > 1 && isPresent(wildcard, statement.RegistryScopes) {
+			return errors.New("wildcard registry scope can not be shared with other registries")
+		}
+		for _, scope := range statement.RegistryScopes {
+			registryScopeCount[scope]++
 		}
 
 		// Verify signature verification preset is valid
 		if !isPresent(statement.SignatureVerification, supportedVerificationPresets) {
-			return errors.New("SignatureVerification '" + statement.SignatureVerification + "' is not supported")
+			return fmt.Errorf("signatureVerification '%s' is not supported", statement.SignatureVerification)
 		}
 
-		// strict and permissive verification needs trust store to verify authenticity
-		if statement.SignatureVerification == "strict" || statement.SignatureVerification == "permissive" {
-			if statement.TrustStore == "" {
-				return errors.New("Verification statement with strict or permissive preset is missing a trust store")
-			}
+		// Any signature verification other than "skip" needs a trust store
+		if statement.SignatureVerification != "skip" && (statement.TrustStore == "" || len(statement.TrustedIdentities) == 0) {
+			return fmt.Errorf("'%s' is either missing a trust store or trusted identities", statement.Name)
 		}
 
 		// Verify trust store type is valid
 		if statement.TrustStore != "" {
 			i := strings.Index(statement.TrustStore, ":")
 			if i < 0 || !isPresent(statement.TrustStore[:i], supportedTrustStorePrefixes) {
-				return errors.New("Statement '" + statement.Name + "' has a trust store with an unsupported trust store type")
+				return fmt.Errorf("'%s' has a trust store with an unsupported trust store type", statement.Name)
 			}
 		}
 
-		// If there are trusted identitied, verify they are not empty
-		if len(statement.TrustedIdentities) > 0 {
-			for _, identity := range statement.TrustedIdentities {
-				if identity == "" {
-					return errors.New("Policy statement has an empty trusted identity")
-				}
+		// If there are trusted identities, verify they are not empty
+		for _, identity := range statement.TrustedIdentities {
+			if identity == "" {
+				return fmt.Errorf("'%s' has an empty trusted identity", statement.Name)
 			}
+		}
+		// If there is a wildcard in trusted identies, there shouldn't be any other identities
+		if len(statement.TrustedIdentities) > 1 && isPresent(wildcard, statement.TrustedIdentities) {
+			return errors.New("wildcard trusted identity can not be shared with other identities")
 		}
 	}
 
 	// Verify unique policy statement names across the policy document
-	if len(policyDoc.TrustPolicies) != len(uniqueStatementNames) {
-		return errors.New("Multiple policy statements have the same name")
+	for key := range policyStatementNameCount {
+		if policyStatementNameCount[key] > 1 {
+			return fmt.Errorf("multiple policy statements with same name : %s", key)
+		}
 	}
 
 	// Verify one policy statement per registry scope
 	for key := range registryScopeCount {
 		if registryScopeCount[key] > 1 {
-			return errors.New("Registry '" + key + "' is present in multiple statements")
+			return fmt.Errorf("registry '%s' is present in multiple policy statements", key)
 		}
 	}
 
 	// No errors
 	return nil
-}
-
-// LoadPolicyDocument loads a policy document from the given path
-// If successful, returns a pointer to the PolicyDocument. Otherwise, an error
-func LoadPolicyDocument(path string) (*PolicyDocument, error) {
-	jsonFile, err := os.Open(path)
-	if err != nil {
-		return nil, err
-	}
-	defer jsonFile.Close()
-
-	byteValue, _ := ioutil.ReadAll(jsonFile)
-	var policyDoc *PolicyDocument
-
-	err = json.Unmarshal(byteValue, &policyDoc)
-	if err != nil {
-		return nil, err
-	}
-
-	return policyDoc, nil
 }

--- a/verification/policy.go
+++ b/verification/policy.go
@@ -11,7 +11,7 @@ import (
 	"strings"
 )
 
-// PolicyDocument represents a trust_policy.json document
+// PolicyDocument represents a trustPolicy.json document
 type PolicyDocument struct {
 	// Version of the policy document
 	Version string `json:"version"`
@@ -27,7 +27,7 @@ type TrustPolicy struct {
 	RegistryScopes []string `json:"registryScopes"`
 	// SignatureVerification setting for this policy statement
 	SignatureVerification string `json:"signatureVerification"`
-	// TrustStore this policy stament uses
+	// TrustStore this policy statement uses
 	TrustStore string `json:"trustStore,omitempty"`
 	// TrustedIdentities this policy statement pins
 	TrustedIdentities []string `json:"trustedIdentities,omitempty"`
@@ -49,16 +49,16 @@ func ValidatePolicyDocument(policyDoc *PolicyDocument) error {
 	wildcard := "*"
 	supportedPolicyVersions := []string{"1.0"}
 	supportedVerificationPresets := []string{"strict", "permissive", "audit", "skip"}
-	supportedTrustStorePrefixes := []string{"ca", "signingservice"}
+	supportedTrustStorePrefixes := []string{"ca"}
 
 	// Validate Version
 	if !isPresent(policyDoc.Version, supportedPolicyVersions) {
-		return fmt.Errorf("version %q is not supported", policyDoc.Version)
+		return fmt.Errorf("trust policy document uses unsupported version %q", policyDoc.Version)
 	}
 
 	// Validate the policy according to 1.0 rules
 	if len(policyDoc.TrustPolicies) == 0 {
-		return errors.New("trust policy document can not have zero policy statements")
+		return errors.New("trust policy document can not have zero trust policy statements")
 	}
 	policyStatementNameCount := make(map[string]int)
 	registryScopeCount := make(map[string]int)
@@ -66,16 +66,16 @@ func ValidatePolicyDocument(policyDoc *PolicyDocument) error {
 
 		// Verify statement name is valid
 		if statement.Name == "" {
-			return errors.New("policy statement is missing a name")
+			return errors.New("a trust policy statement is missing a name, every statement requires a name")
 		}
 		policyStatementNameCount[statement.Name]++
 
 		// Verify registry scopes are valid
 		if len(statement.RegistryScopes) == 0 {
-			return fmt.Errorf("policy statement %q has zero registry scopes", statement.Name)
+			return fmt.Errorf("trust policy statement %q has zero registry scopes, it must specify registry scopes with at least one value", statement.Name)
 		}
 		if len(statement.RegistryScopes) > 1 && isPresent(wildcard, statement.RegistryScopes) {
-			return errors.New("wildcard registry scope can not be shared with other registries")
+			return fmt.Errorf("trust policy statement %q uses wildcard registry scope '*', a wildcard scope cannot be used in conjunction with other scope values", statement.Name)
 		}
 		for _, scope := range statement.RegistryScopes {
 			registryScopeCount[scope]++
@@ -83,18 +83,19 @@ func ValidatePolicyDocument(policyDoc *PolicyDocument) error {
 
 		// Verify signature verification preset is valid
 		if !isPresent(statement.SignatureVerification, supportedVerificationPresets) {
-			return fmt.Errorf("signatureVerification %q is not supported", statement.SignatureVerification)
+			return fmt.Errorf("trust policy statement %q uses unsupported signatureVerification value %q", statement.Name, statement.SignatureVerification)
 		}
 
 		// Any signature verification other than "skip" needs a trust store
 		if statement.SignatureVerification != "skip" && (statement.TrustStore == "" || len(statement.TrustedIdentities) == 0) {
-			return fmt.Errorf("%q is either missing a trust store or trusted identities", statement.Name)
+			return fmt.Errorf("trust policy statement %q is either missing a trust store or trusted identities, both must be specified", statement.Name)
 		}
 
 		// Verify trust store type is valid if it is present (trust store is optional for "skip" signature verification)
 		if statement.TrustStore != "" {
 			i := strings.Index(statement.TrustStore, ":")
 			if i < 0 || !isPresent(statement.TrustStore[:i], supportedTrustStorePrefixes) {
+				return fmt.Errorf("trust policy statement %q uses an unsupported trust store type %q in trust store value %q", statement.Name, statement.TrustStore[:i], statement.TrustStore)
 				return fmt.Errorf("%q has a trust store with an unsupported trust store type", statement.Name)
 			}
 		}
@@ -102,11 +103,12 @@ func ValidatePolicyDocument(policyDoc *PolicyDocument) error {
 		// If there are trusted identities, verify they are not empty
 		for _, identity := range statement.TrustedIdentities {
 			if identity == "" {
-				return fmt.Errorf("%q has an empty trusted identity", statement.Name)
+				return fmt.Errorf("trust policy statement %q has an empty trusted identity", statement.Name)
 			}
 		}
 		// If there is a wildcard in trusted identies, there shouldn't be any other identities
 		if len(statement.TrustedIdentities) > 1 && isPresent(wildcard, statement.TrustedIdentities) {
+			return fmt.Errorf("trust policy statement %q uses a wildcard trusted identity '*', a wildcard identity cannot be used in conjunction with other values", statement.Name)
 			return errors.New("wildcard trusted identity can not be shared with other identities")
 		}
 	}
@@ -114,14 +116,14 @@ func ValidatePolicyDocument(policyDoc *PolicyDocument) error {
 	// Verify unique policy statement names across the policy document
 	for key := range policyStatementNameCount {
 		if policyStatementNameCount[key] > 1 {
-			return fmt.Errorf("multiple policy statements with same name : %s", key)
+			return fmt.Errorf("multiple trust policy statements use the same name %q, statement names must be unique", key)
 		}
 	}
 
 	// Verify one policy statement per registry scope
 	for key := range registryScopeCount {
 		if registryScopeCount[key] > 1 {
-			return fmt.Errorf("registry %q is present in multiple policy statements", key)
+			return fmt.Errorf("registry scope %q is present in multiple trust policy statements, one registry scope value can only be associated with one statement", key)
 		}
 	}
 

--- a/verification/policy.go
+++ b/verification/policy.go
@@ -53,7 +53,7 @@ func ValidatePolicyDocument(policyDoc *PolicyDocument) error {
 
 	// Validate Version
 	if !isPresent(policyDoc.Version, supportedPolicyVersions) {
-		return fmt.Errorf("version '%s' is not supported", policyDoc.Version)
+		return fmt.Errorf("version %q is not supported", policyDoc.Version)
 	}
 
 	// Validate the policy according to 1.0 rules
@@ -72,7 +72,7 @@ func ValidatePolicyDocument(policyDoc *PolicyDocument) error {
 
 		// Verify registry scopes are valid
 		if len(statement.RegistryScopes) == 0 {
-			return fmt.Errorf("policy statement '%s' has zero registry scopes", statement.Name)
+			return fmt.Errorf("policy statement %q has zero registry scopes", statement.Name)
 		}
 		if len(statement.RegistryScopes) > 1 && isPresent(wildcard, statement.RegistryScopes) {
 			return errors.New("wildcard registry scope can not be shared with other registries")
@@ -83,26 +83,26 @@ func ValidatePolicyDocument(policyDoc *PolicyDocument) error {
 
 		// Verify signature verification preset is valid
 		if !isPresent(statement.SignatureVerification, supportedVerificationPresets) {
-			return fmt.Errorf("signatureVerification '%s' is not supported", statement.SignatureVerification)
+			return fmt.Errorf("signatureVerification %q is not supported", statement.SignatureVerification)
 		}
 
 		// Any signature verification other than "skip" needs a trust store
 		if statement.SignatureVerification != "skip" && (statement.TrustStore == "" || len(statement.TrustedIdentities) == 0) {
-			return fmt.Errorf("'%s' is either missing a trust store or trusted identities", statement.Name)
+			return fmt.Errorf("%q is either missing a trust store or trusted identities", statement.Name)
 		}
 
-		// Verify trust store type is valid
+		// Verify trust store type is valid if it is present (trust store is optional for "skip" signature verification)
 		if statement.TrustStore != "" {
 			i := strings.Index(statement.TrustStore, ":")
 			if i < 0 || !isPresent(statement.TrustStore[:i], supportedTrustStorePrefixes) {
-				return fmt.Errorf("'%s' has a trust store with an unsupported trust store type", statement.Name)
+				return fmt.Errorf("%q has a trust store with an unsupported trust store type", statement.Name)
 			}
 		}
 
 		// If there are trusted identities, verify they are not empty
 		for _, identity := range statement.TrustedIdentities {
 			if identity == "" {
-				return fmt.Errorf("'%s' has an empty trusted identity", statement.Name)
+				return fmt.Errorf("%q has an empty trusted identity", statement.Name)
 			}
 		}
 		// If there is a wildcard in trusted identies, there shouldn't be any other identities
@@ -121,7 +121,7 @@ func ValidatePolicyDocument(policyDoc *PolicyDocument) error {
 	// Verify one policy statement per registry scope
 	for key := range registryScopeCount {
 		if registryScopeCount[key] > 1 {
-			return fmt.Errorf("registry '%s' is present in multiple policy statements", key)
+			return fmt.Errorf("registry %q is present in multiple policy statements", key)
 		}
 	}
 

--- a/verification/policy_test.go
+++ b/verification/policy_test.go
@@ -64,7 +64,7 @@ func TestValidateInvalidPolicyDocument(t *testing.T) {
 	policyDoc := dummyPolicyDocument()
 	policyDoc.Version = "invalid"
 	err := ValidatePolicyDocument(&policyDoc)
-	if err == nil || err.Error() != "version 'invalid' is not supported" {
+	if err == nil || err.Error() != "version \"invalid\" is not supported" {
 		t.Fatalf("invalid version should return error")
 	}
 
@@ -92,7 +92,7 @@ func TestValidateInvalidPolicyDocument(t *testing.T) {
 	policyStatement.RegistryScopes = nil
 	policyDoc.TrustPolicies = []TrustPolicy{policyStatement}
 	err = ValidatePolicyDocument(&policyDoc)
-	if err == nil || err.Error() != "policy statement 'test-statement-name' has zero registry scopes" {
+	if err == nil || err.Error() != "policy statement \"test-statement-name\" has zero registry scopes" {
 		t.Fatalf("policy statement with registry scopes should return error")
 	}
 
@@ -103,7 +103,7 @@ func TestValidateInvalidPolicyDocument(t *testing.T) {
 	policyStatement2.Name = "test-statement-name-2"
 	policyDoc.TrustPolicies = []TrustPolicy{policyStatement1, policyStatement2}
 	err = ValidatePolicyDocument(&policyDoc)
-	if err == nil || err.Error() != "registry 'test-registry-scope' is present in multiple policy statements" {
+	if err == nil || err.Error() != "registry \"test-registry-scope\" is present in multiple policy statements" {
 		t.Fatalf("Policy statements with same registry scope should return error")
 	}
 
@@ -123,7 +123,7 @@ func TestValidateInvalidPolicyDocument(t *testing.T) {
 	policyStatement.SignatureVerification = "invalid"
 	policyDoc.TrustPolicies = []TrustPolicy{policyStatement}
 	err = ValidatePolicyDocument(&policyDoc)
-	if err == nil || err.Error() != "signatureVerification 'invalid' is not supported" {
+	if err == nil || err.Error() != "signatureVerification \"invalid\" is not supported" {
 		t.Fatalf("policy statement with invalid SignatureVerification should return error")
 	}
 
@@ -133,7 +133,7 @@ func TestValidateInvalidPolicyDocument(t *testing.T) {
 	policyStatement.TrustStore = ""
 	policyDoc.TrustPolicies = []TrustPolicy{policyStatement}
 	err = ValidatePolicyDocument(&policyDoc)
-	if err == nil || err.Error() != "'test-statement-name' is either missing a trust store or trusted identities" {
+	if err == nil || err.Error() != "\"test-statement-name\" is either missing a trust store or trusted identities" {
 		t.Fatalf("strict SignatureVerification should have a trust store")
 	}
 
@@ -143,7 +143,7 @@ func TestValidateInvalidPolicyDocument(t *testing.T) {
 	policyStatement.TrustedIdentities = []string{}
 	policyDoc.TrustPolicies = []TrustPolicy{policyStatement}
 	err = ValidatePolicyDocument(&policyDoc)
-	if err == nil || err.Error() != "'test-statement-name' is either missing a trust store or trusted identities" {
+	if err == nil || err.Error() != "\"test-statement-name\" is either missing a trust store or trusted identities" {
 		t.Fatalf("strict SignatureVerification should have trusted identities")
 	}
 
@@ -153,7 +153,7 @@ func TestValidateInvalidPolicyDocument(t *testing.T) {
 	policyStatement.TrustedIdentities = []string{""}
 	policyDoc.TrustPolicies = []TrustPolicy{policyStatement}
 	err = ValidatePolicyDocument(&policyDoc)
-	if err == nil || err.Error() != "'test-statement-name' has an empty trusted identity" {
+	if err == nil || err.Error() != "\"test-statement-name\" has an empty trusted identity" {
 		t.Fatalf("policy statement with empty trusted identity should return error")
 	}
 
@@ -174,7 +174,7 @@ func TestValidateInvalidPolicyDocument(t *testing.T) {
 	policyStatement.TrustStore = "invalid:test-trust-store"
 	policyDoc.TrustPolicies = []TrustPolicy{policyStatement}
 	err = ValidatePolicyDocument(&policyDoc)
-	if err == nil || err.Error() != "'test-statement-name' has a trust store with an unsupported trust store type" {
+	if err == nil || err.Error() != "\"test-statement-name\" has a trust store with an unsupported trust store type" {
 		t.Fatalf("policy statement with invalid trust store type should return error")
 	}
 

--- a/verification/policy_test.go
+++ b/verification/policy_test.go
@@ -64,7 +64,7 @@ func TestValidateInvalidPolicyDocument(t *testing.T) {
 	policyDoc := dummyPolicyDocument()
 	policyDoc.Version = "invalid"
 	err := ValidatePolicyDocument(&policyDoc)
-	if err == nil || err.Error() != "version \"invalid\" is not supported" {
+	if err == nil || err.Error() != "trust policy document uses unsupported version \"invalid\"" {
 		t.Fatalf("invalid version should return error")
 	}
 
@@ -72,7 +72,7 @@ func TestValidateInvalidPolicyDocument(t *testing.T) {
 	policyDoc = dummyPolicyDocument()
 	policyDoc.TrustPolicies = nil
 	err = ValidatePolicyDocument(&policyDoc)
-	if err == nil || err.Error() != "trust policy document can not have zero policy statements" {
+	if err == nil || err.Error() != "trust policy document can not have zero trust policy statements" {
 		t.Fatalf("zero policy statements should return error")
 	}
 
@@ -82,7 +82,7 @@ func TestValidateInvalidPolicyDocument(t *testing.T) {
 	policyStatement.Name = ""
 	policyDoc.TrustPolicies = []TrustPolicy{policyStatement}
 	err = ValidatePolicyDocument(&policyDoc)
-	if err == nil || err.Error() != "policy statement is missing a name" {
+	if err == nil || err.Error() != "a trust policy statement is missing a name, every statement requires a name" {
 		t.Fatalf("policy statement with no name should return an error")
 	}
 
@@ -92,7 +92,7 @@ func TestValidateInvalidPolicyDocument(t *testing.T) {
 	policyStatement.RegistryScopes = nil
 	policyDoc.TrustPolicies = []TrustPolicy{policyStatement}
 	err = ValidatePolicyDocument(&policyDoc)
-	if err == nil || err.Error() != "policy statement \"test-statement-name\" has zero registry scopes" {
+	if err == nil || err.Error() != "trust policy statement \"test-statement-name\" has zero registry scopes, it must specify registry scopes with at least one value" {
 		t.Fatalf("policy statement with registry scopes should return error")
 	}
 
@@ -103,7 +103,7 @@ func TestValidateInvalidPolicyDocument(t *testing.T) {
 	policyStatement2.Name = "test-statement-name-2"
 	policyDoc.TrustPolicies = []TrustPolicy{policyStatement1, policyStatement2}
 	err = ValidatePolicyDocument(&policyDoc)
-	if err == nil || err.Error() != "registry \"test-registry-scope\" is present in multiple policy statements" {
+	if err == nil || err.Error() != "registry scope \"test-registry-scope\" is present in multiple trust policy statements, one registry scope value can only be associated with one statement" {
 		t.Fatalf("Policy statements with same registry scope should return error")
 	}
 
@@ -113,7 +113,7 @@ func TestValidateInvalidPolicyDocument(t *testing.T) {
 	policyStatement.RegistryScopes = []string{"*", "test-registry-scope"}
 	policyDoc.TrustPolicies = []TrustPolicy{policyStatement}
 	err = ValidatePolicyDocument(&policyDoc)
-	if err == nil || err.Error() != "wildcard registry scope can not be shared with other registries" {
+	if err == nil || err.Error() != "trust policy statement \"test-statement-name\" uses wildcard registry scope '*', a wildcard scope cannot be used in conjunction with other scope values" {
 		t.Fatalf("policy statement with more than a wildcard registry scope should return error")
 	}
 
@@ -123,7 +123,7 @@ func TestValidateInvalidPolicyDocument(t *testing.T) {
 	policyStatement.SignatureVerification = "invalid"
 	policyDoc.TrustPolicies = []TrustPolicy{policyStatement}
 	err = ValidatePolicyDocument(&policyDoc)
-	if err == nil || err.Error() != "signatureVerification \"invalid\" is not supported" {
+	if err == nil || err.Error() != "trust policy statement \"test-statement-name\" uses unsupported signatureVerification value \"invalid\"" {
 		t.Fatalf("policy statement with invalid SignatureVerification should return error")
 	}
 
@@ -133,7 +133,7 @@ func TestValidateInvalidPolicyDocument(t *testing.T) {
 	policyStatement.TrustStore = ""
 	policyDoc.TrustPolicies = []TrustPolicy{policyStatement}
 	err = ValidatePolicyDocument(&policyDoc)
-	if err == nil || err.Error() != "\"test-statement-name\" is either missing a trust store or trusted identities" {
+	if err == nil || err.Error() != "trust policy statement \"test-statement-name\" is either missing a trust store or trusted identities, both must be specified" {
 		t.Fatalf("strict SignatureVerification should have a trust store")
 	}
 
@@ -143,7 +143,7 @@ func TestValidateInvalidPolicyDocument(t *testing.T) {
 	policyStatement.TrustedIdentities = []string{}
 	policyDoc.TrustPolicies = []TrustPolicy{policyStatement}
 	err = ValidatePolicyDocument(&policyDoc)
-	if err == nil || err.Error() != "\"test-statement-name\" is either missing a trust store or trusted identities" {
+	if err == nil || err.Error() != "trust policy statement \"test-statement-name\" is either missing a trust store or trusted identities, both must be specified" {
 		t.Fatalf("strict SignatureVerification should have trusted identities")
 	}
 
@@ -153,7 +153,7 @@ func TestValidateInvalidPolicyDocument(t *testing.T) {
 	policyStatement.TrustedIdentities = []string{""}
 	policyDoc.TrustPolicies = []TrustPolicy{policyStatement}
 	err = ValidatePolicyDocument(&policyDoc)
-	if err == nil || err.Error() != "\"test-statement-name\" has an empty trusted identity" {
+	if err == nil || err.Error() != "trust policy statement \"test-statement-name\" has an empty trusted identity" {
 		t.Fatalf("policy statement with empty trusted identity should return error")
 	}
 
@@ -174,7 +174,7 @@ func TestValidateInvalidPolicyDocument(t *testing.T) {
 	policyStatement.TrustStore = "invalid:test-trust-store"
 	policyDoc.TrustPolicies = []TrustPolicy{policyStatement}
 	err = ValidatePolicyDocument(&policyDoc)
-	if err == nil || err.Error() != "\"test-statement-name\" has a trust store with an unsupported trust store type" {
+	if err == nil || err.Error() != "trust policy statement \"test-statement-name\" uses an unsupported trust store type \"invalid\" in trust store value \"invalid:test-trust-store\"" {
 		t.Fatalf("policy statement with invalid trust store type should return error")
 	}
 
@@ -184,7 +184,7 @@ func TestValidateInvalidPolicyDocument(t *testing.T) {
 	policyStatement.TrustedIdentities = []string{"*", "test-identity"}
 	policyDoc.TrustPolicies = []TrustPolicy{policyStatement}
 	err = ValidatePolicyDocument(&policyDoc)
-	if err == nil || err.Error() != "wildcard trusted identity can not be shared with other identities" {
+	if err == nil || err.Error() != "trust policy statement \"test-statement-name\" uses a wildcard trusted identity '*', a wildcard identity cannot be used in conjunction with other values" {
 		t.Fatalf("policy statement with more than a wildcard trusted identity should return error")
 	}
 
@@ -194,7 +194,7 @@ func TestValidateInvalidPolicyDocument(t *testing.T) {
 	policyStatement2 = dummyPolicyStatement()
 	policyDoc.TrustPolicies = []TrustPolicy{policyStatement1, policyStatement2}
 	err = ValidatePolicyDocument(&policyDoc)
-	if err == nil || err.Error() != "multiple policy statements with same name : test-statement-name" {
+	if err == nil || err.Error() != "multiple trust policy statements use the same name \"test-statement-name\", statement names must be unique" {
 		t.Fatalf("policy statements with same name should return error")
 	}
 }

--- a/verification/policy_test.go
+++ b/verification/policy_test.go
@@ -1,0 +1,198 @@
+package verification
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	"os"
+	"testing"
+)
+
+func dummyPolicyStatement() (policyStatement TrustPolicy) {
+	policyStatement = TrustPolicy{
+		Name:                  "test-statement-name",
+		RegistryScopes:        []string{"test-registry-scope"},
+		SignatureVerification: "strict",
+		TrustStore:            "ca:test-store",
+		TrustedIdentities:     []string{"test-identity"},
+	}
+	return
+}
+
+func dummyPolicyDocument() (policyDoc PolicyDocument) {
+	policyDoc = PolicyDocument{
+		Version:       "1.0",
+		TrustPolicies: []TrustPolicy{dummyPolicyStatement()},
+	}
+	return
+}
+
+func writeToTempFile(policyDoc PolicyDocument) string {
+	tmpFile, _ := ioutil.TempFile(os.TempDir(), "notation-test-")
+	file, _ := json.MarshalIndent(policyDoc, "", " ")
+	_ = ioutil.WriteFile(tmpFile.Name(), file, 0644)
+	return tmpFile.Name()
+}
+
+// TestLoadPolicyDocument calls verification.LoadPolicyDocument with a path, checking
+// it succeeds in the happy path.
+func TestLoadValidFile(t *testing.T) {
+	path := writeToTempFile(dummyPolicyDocument())
+	defer os.Remove(path)
+	_, err := LoadPolicyDocument(path)
+	if err != nil {
+		t.Fatalf("Could not load the trust policy file")
+	}
+}
+
+// TestLoadPolicyDocument calls verification.LoadPolicyDocument with an invalid path
+func TestLoadInvalidFile(t *testing.T) {
+	policyDoc, _ := LoadPolicyDocument("path")
+	if policyDoc != nil {
+		t.Fatalf("Loaded an invalid trust policy file")
+	}
+}
+
+// TestValidateValidPolicyDocument tests a happy policy document
+func TestValidateValidPolicyDocument(t *testing.T) {
+	policyDoc := dummyPolicyDocument()
+
+	policyStatement1 := dummyPolicyStatement()
+
+	policyStatement2 := dummyPolicyStatement()
+	policyStatement2.Name = "test-statement-name-2"
+	policyStatement2.RegistryScopes = []string{"test-registry-scope-2"}
+	policyStatement2.SignatureVerification = "permissive"
+
+	policyStatement3 := dummyPolicyStatement()
+	policyStatement3.Name = "test-statement-name-3"
+	policyStatement3.RegistryScopes = []string{"test-registry-scope-3"}
+	policyStatement3.SignatureVerification = "skip"
+
+	policyStatement4 := dummyPolicyStatement()
+	policyStatement4.Name = "test-statement-name-4"
+	policyStatement4.RegistryScopes = []string{"*"}
+	policyStatement4.SignatureVerification = "audit"
+
+	policyDoc.TrustPolicies = []TrustPolicy{
+		policyStatement1,
+		policyStatement2,
+		policyStatement3,
+		policyStatement4,
+	}
+	err := ValidatePolicyDocument(&policyDoc)
+	if err != nil {
+		t.Fatalf("Validation failed on a good policy document")
+	}
+}
+
+// TestValidatePolicyDocument calls verification.ValidatePolicyDocument
+// and tests various validations
+func TestValidateInvalidPolicyDocument(t *testing.T) {
+
+	// Invalid Version
+	policyDoc := dummyPolicyDocument()
+	policyDoc.Version = "invalid"
+	err := ValidatePolicyDocument(&policyDoc)
+	if err == nil || err.Error() != "Version 'invalid' is not supported" {
+		t.Fatalf("Invalid version should return error")
+	}
+
+	// No Policy Satements
+	policyDoc = dummyPolicyDocument()
+	policyDoc.TrustPolicies = nil
+	err = ValidatePolicyDocument(&policyDoc)
+	if err == nil || err.Error() != "Trust Policy document can not have zero statements" {
+		t.Fatalf("Zero policy statements should return error")
+	}
+
+	// No Policy Satement Name
+	policyDoc = dummyPolicyDocument()
+	policyStatement := dummyPolicyStatement()
+	policyStatement.Name = ""
+	policyDoc.TrustPolicies = []TrustPolicy{policyStatement}
+	err = ValidatePolicyDocument(&policyDoc)
+	if err == nil || err.Error() != "Policy statement is missing a name" {
+		t.Fatalf("Policy statement with no name should return error")
+	}
+
+	// No Registry Scopes
+	policyDoc = dummyPolicyDocument()
+	policyStatement = dummyPolicyStatement()
+	policyStatement.RegistryScopes = nil
+	policyDoc.TrustPolicies = []TrustPolicy{policyStatement}
+	err = ValidatePolicyDocument(&policyDoc)
+	if err == nil || err.Error() != "Policy statement has zero registry scopes" {
+		t.Fatalf("Policy statement with registry scopes should return error")
+	}
+
+	// Multiple policy statements with same registry scope
+	policyDoc = dummyPolicyDocument()
+	policyStatement1 := dummyPolicyStatement()
+	policyStatement2 := dummyPolicyStatement()
+	policyStatement2.Name = "test-statement-name-2"
+	policyDoc.TrustPolicies = []TrustPolicy{policyStatement1, policyStatement2}
+	err = ValidatePolicyDocument(&policyDoc)
+	if err == nil || err.Error() != "Registry 'test-registry-scope' is present in multiple statements" {
+		t.Fatalf("Policy statements with same registry scope should return error")
+	}
+
+	// Registry scopes with a wildcard
+	policyDoc = dummyPolicyDocument()
+	policyStatement = dummyPolicyStatement()
+	policyStatement.RegistryScopes = []string{"*", "test-registry-scope"}
+	policyDoc.TrustPolicies = []TrustPolicy{policyStatement}
+	err = ValidatePolicyDocument(&policyDoc)
+	if err == nil || err.Error() != "Wildcard scope can not be shared with other registry scopes" {
+		t.Fatalf("Policy statement with more than a wildcard registry scope should return error")
+	}
+
+	// Invlaid SignatureVerification
+	policyDoc = dummyPolicyDocument()
+	policyStatement = dummyPolicyStatement()
+	policyStatement.SignatureVerification = "invalid"
+	policyDoc.TrustPolicies = []TrustPolicy{policyStatement}
+	err = ValidatePolicyDocument(&policyDoc)
+	if err == nil || err.Error() != "SignatureVerification 'invalid' is not supported" {
+		t.Fatalf("Policy statement with invalid SignatureVerification should return error")
+	}
+
+	// strict SignatureVerification should have a trust store
+	policyDoc = dummyPolicyDocument()
+	policyStatement = dummyPolicyStatement()
+	policyStatement.TrustStore = ""
+	policyDoc.TrustPolicies = []TrustPolicy{policyStatement}
+	err = ValidatePolicyDocument(&policyDoc)
+	if err == nil || err.Error() != "Verification statement with strict or permissive preset is missing a trust store" {
+		t.Fatalf("strict SignatureVerification should have a trust store")
+	}
+
+	// Invalid Trust Store prefix
+	policyDoc = dummyPolicyDocument()
+	policyStatement = dummyPolicyStatement()
+	policyStatement.TrustStore = "invalid:test-trust-store"
+	policyDoc.TrustPolicies = []TrustPolicy{policyStatement}
+	err = ValidatePolicyDocument(&policyDoc)
+	if err == nil || err.Error() != "Statement 'test-statement-name' has a trust store with an unsupported trust store type" {
+		t.Fatalf("Policy statement with invalid trust store type should return error")
+	}
+
+	// Empty Trusted Identity
+	policyDoc = dummyPolicyDocument()
+	policyStatement = dummyPolicyStatement()
+	policyStatement.TrustedIdentities = []string{""}
+	policyDoc.TrustPolicies = []TrustPolicy{policyStatement}
+	err = ValidatePolicyDocument(&policyDoc)
+	if err == nil || err.Error() != "Policy statement has an empty trusted identity" {
+		t.Fatalf("Policy statement with empty trusted identity should return error")
+	}
+
+	// Policy Document with duplicate policy statement names
+	policyDoc = dummyPolicyDocument()
+	policyStatement1 = dummyPolicyStatement()
+	policyStatement2 = dummyPolicyStatement()
+	policyDoc.TrustPolicies = []TrustPolicy{policyStatement1, policyStatement2}
+	err = ValidatePolicyDocument(&policyDoc)
+	if err == nil || err.Error() != "Multiple policy statements have the same name" {
+		t.Fatalf("Policy statements with same name should return error")
+	}
+}


### PR DESCRIPTION
* Implementing a parser for trust policy documents as specified in https://github.com/notaryproject/notaryproject/pull/149/files?short_path=bab1489#diff-bab14897801fe47838fadd7f0ebd867e81ce66e098785175f4c1ec368bbe406a
* Added unit tests and manually tested locally 
cc: @shizhMSFT @SteveLasker 