### PR TITLE
Implement generate-envelope workflow

### DIFF
--- a/notation.go
+++ b/notation.go
@@ -10,7 +10,7 @@ import (
 	"github.com/opencontainers/go-digest"
 )
 
-// MediaTypePayload describes the media type of the descriptor.
+// Media type for Notary payload for OCI artifacts, which contains an artifact descriptor.
 const MediaTypePayload = "application/vnd.cncf.notary.payload.v1+json"
 
 // Descriptor describes the content signed or to be signed.

--- a/notation.go
+++ b/notation.go
@@ -10,6 +10,9 @@ import (
 	"github.com/opencontainers/go-digest"
 )
 
+// MediaTypeDescriptor describes the media type of the descriptor.
+const MediaTypeDescriptor = "application/vnd.oci.descriptor.v1+json"
+
 // Descriptor describes the content signed or to be signed.
 type Descriptor struct {
 	// The media type of the targeted content.

--- a/notation.go
+++ b/notation.go
@@ -10,8 +10,8 @@ import (
 	"github.com/opencontainers/go-digest"
 )
 
-// MediaTypeDescriptor describes the media type of the descriptor.
-const MediaTypeDescriptor = "application/vnd.oci.descriptor.v1+json"
+// MediaTypePayload describes the media type of the descriptor.
+const MediaTypePayload = "application/vnd.cncf.notary.payload.v1+json"
 
 // Descriptor describes the content signed or to be signed.
 type Descriptor struct {

--- a/plugin/metadata.go
+++ b/plugin/metadata.go
@@ -55,10 +55,10 @@ func (m *Metadata) HasCapability(capability Capability) bool {
 }
 
 // SupportsContract return true if the metadata states that the
-// major contract version is supported.
-func (m *Metadata) SupportsContract(major string) bool {
+// contract version is supported.
+func (m *Metadata) SupportsContract(ver string) bool {
 	for _, v := range m.SupportedContractVersions {
-		if v == major {
+		if v == ver {
 			return true
 		}
 	}

--- a/plugin/plugin.go
+++ b/plugin/plugin.go
@@ -114,7 +114,7 @@ type GenerateEnvelopeRequest struct {
 }
 
 func (GenerateEnvelopeRequest) Command() Command {
-	return CommandGenerateSignature
+	return CommandGenerateEnvelope
 }
 
 // GenerateSignatureResponse is the response of a generate-envelope request.

--- a/signature/jws/algorithm.go
+++ b/signature/jws/algorithm.go
@@ -7,20 +7,8 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/golang-jwt/jwt/v4"
 	"github.com/notaryproject/notation-go"
 )
-
-// signingMethodFromKey picks up a recommended algorithm for private and public keys.
-// Reference: RFC 7518 3.1 "alg" (Algorithm) Header Parameter Values for JWS.
-func signingMethodFromKey(key interface{}) (jwt.SigningMethod, error) {
-	keySpec, err := keySpecFromKey(key)
-	if err != nil {
-		return nil, err
-	}
-	method := jwt.GetSigningMethod(keySpec.SignatureAlgorithm().JWS())
-	return method, err
-}
 
 func keySpecFromKey(key interface{}) (notation.KeySpec, error) {
 	if k, ok := key.(interface {

--- a/signature/jws/plugin.go
+++ b/signature/jws/plugin.go
@@ -200,7 +200,7 @@ func (s *pluginSigner) generateSignatureEnvelope(ctx context.Context, desc notat
 		KeyID:                 s.keyID,
 		Payload:               rawDesc,
 		SignatureEnvelopeType: notation.MediaTypeJWSEnvelope,
-		PayloadType:           notation.MediaTypeDescriptor,
+		PayloadType:           notation.MediaTypePayload,
 		PluginConfig:          s.mergeConfig(opts.PluginConfig),
 	}
 	out, err := s.runner.Run(ctx, req)

--- a/signature/jws/plugin.go
+++ b/signature/jws/plugin.go
@@ -234,9 +234,9 @@ func (s *pluginSigner) generateSignatureEnvelope(ctx context.Context, desc notat
 	// Check algorithm is supported.
 	var protected notation.JWSProtectedHeader
 	if err = decodeBase64URLJSON(envelope.Protected, &protected); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("envelope protected header can't be decoded: %w", err)
 	}
-	if notation.SignatureAlgorithm(protected.Algorithm).JWS() == "" {
+	if notation.NewSignatureAlgorithmJWS(protected.Algorithm) == "" {
 		return nil, fmt.Errorf("signing algorithm %q not supported", protected.Algorithm)
 	}
 
@@ -244,7 +244,7 @@ func (s *pluginSigner) generateSignatureEnvelope(ctx context.Context, desc notat
 	var payload notation.JWSPayload
 	err = decodeBase64URLJSON(envelope.Payload, &payload)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("envelope payload can't be decoded: %w", err)
 	}
 	if !descriptorPartialEqual(desc, payload.Subject) {
 		return nil, errors.New("descriptor subject has changed")

--- a/signature/jws/plugin.go
+++ b/signature/jws/plugin.go
@@ -205,7 +205,7 @@ func (s *pluginSigner) generateSignatureEnvelope(ctx context.Context, desc notat
 	}
 	out, err := s.runner.Run(ctx, req)
 	if err != nil {
-		return nil, fmt.Errorf("generate-signature command failed: %w", err)
+		return nil, fmt.Errorf("generate-envelope command failed: %w", err)
 	}
 	resp, ok := out.(*plugin.GenerateEnvelopeResponse)
 	if !ok {

--- a/signature/jws/plugin.go
+++ b/signature/jws/plugin.go
@@ -200,8 +200,9 @@ func (s *pluginSigner) generateSignatureEnvelope(ctx context.Context, desc notat
 		KeyID:                 s.keyID,
 		Payload:               rawDesc,
 		SignatureEnvelopeType: notation.MediaTypeJWSEnvelope,
-		PayloadType:           notation.MediaTypePayload,
-		PluginConfig:          s.mergeConfig(opts.PluginConfig),
+		// TODO: Update payload type once https://github.com/notaryproject/notaryproject/pull/158 is approved.
+		PayloadType:  notation.MediaTypePayload,
+		PluginConfig: s.mergeConfig(opts.PluginConfig),
 	}
 	out, err := s.runner.Run(ctx, req)
 	if err != nil {

--- a/signature/jws/plugin.go
+++ b/signature/jws/plugin.go
@@ -246,7 +246,7 @@ func (s *pluginSigner) generateSignatureEnvelope(ctx context.Context, desc notat
 	if err != nil {
 		return nil, err
 	}
-	if !sameDesc(desc, payload.Subject) {
+	if !descriptorPartialEqual(desc, payload.Subject) {
 		return nil, errors.New("descriptor subject has changed")
 	}
 
@@ -267,13 +267,15 @@ func (s *pluginSigner) generateSignatureEnvelope(ctx context.Context, desc notat
 	return resp.SignatureEnvelope, nil
 }
 
-func sameDesc(original, desc notation.Descriptor) bool {
-	if !original.Equal(desc) {
+// descriptorPartialEqual checks if the both descriptors point to the same resource
+// and that newDesc hasn't replaced or overridden existing annotations.
+func descriptorPartialEqual(original, newDesc notation.Descriptor) bool {
+	if !original.Equal(newDesc) {
 		return false
 	}
-	// Plugins may append additional annotations but ust not replace/override existing.
+	// Plugins may append additional annotations but not replace/override existing.
 	for k, v := range original.Annotations {
-		if v2, ok := desc.Annotations[k]; !ok || v != v2 {
+		if v2, ok := newDesc.Annotations[k]; !ok || v != v2 {
 			return false
 		}
 	}

--- a/signature/jws/plugin_test.go
+++ b/signature/jws/plugin_test.go
@@ -22,7 +22,8 @@ import (
 
 var validMetadata = plugin.Metadata{
 	Name: "foo", Description: "friendly", Version: "1", URL: "example.com",
-	SupportedContractVersions: []string{plugin.ContractVersion}, Capabilities: []plugin.Capability{plugin.CapabilitySignatureGenerator},
+	SupportedContractVersions: []string{plugin.ContractVersion},
+	Capabilities:              []plugin.Capability{plugin.CapabilitySignatureGenerator},
 }
 
 type mockRunner struct {

--- a/signature/jws/plugin_test.go
+++ b/signature/jws/plugin_test.go
@@ -22,7 +22,7 @@ import (
 
 var validMetadata = plugin.Metadata{
 	Name: "foo", Description: "friendly", Version: "1", URL: "example.com",
-	SupportedContractVersions: []string{"1"}, Capabilities: []plugin.Capability{plugin.CapabilitySignatureGenerator},
+	SupportedContractVersions: []string{plugin.ContractVersion}, Capabilities: []plugin.Capability{plugin.CapabilitySignatureGenerator},
 }
 
 type mockRunner struct {

--- a/signature/jws/plugin_test.go
+++ b/signature/jws/plugin_test.go
@@ -336,7 +336,7 @@ func TestSigner_Sign_Valid(t *testing.T) {
 		t.Fatal(err)
 	}
 	want := notation.JWSEnvelope{
-		Protected: "eyJhbGciOiJQUzI1NiIsImN0eSI6ImFwcGxpY2F0aW9uL3ZuZC5jbmNmLm5vdGFyeS52Mi5qd3MudjEifQ",
+		Protected: "eyJhbGciOiJQUzI1NiIsImN0eSI6ImFwcGxpY2F0aW9uL3ZuZC5vY2kuZGVzY3JpcHRvci52MStqc29uIn0",
 		Header: notation.JWSUnprotectedHeader{
 			CertChain: [][]byte{cert.Raw},
 		},
@@ -393,7 +393,7 @@ func (s *mockEnvelopePlugin) Run(ctx context.Context, req plugin.Request) (inter
 			Method: method,
 			Header: map[string]interface{}{
 				"alg": method.Alg(),
-				"cty": notation.MediaTypeJWSEnvelope,
+				"cty": notation.MediaTypeDescriptor,
 			},
 			Claims: struct {
 				jwt.RegisteredClaims

--- a/signature/jws/plugin_test.go
+++ b/signature/jws/plugin_test.go
@@ -384,7 +384,7 @@ func (s *mockEnvelopePlugin) Run(ctx context.Context, req plugin.Request) (inter
 		if key == nil {
 			key = tmpkey
 		}
-		method, err := SigningMethodFromKey(key)
+		method, err := signingMethodFromKey(key)
 		if err != nil {
 			return nil, err
 		}
@@ -440,58 +440,58 @@ func (s *mockEnvelopePlugin) Run(ctx context.Context, req plugin.Request) (inter
 	panic("too many calls")
 }
 func TestPluginSigner_SignEnvelope_RunFailed(t *testing.T) {
-	signer := PluginSigner{
-		Runner: &mockEnvelopePlugin{err: errors.New("failed")},
-		KeyID:  "1",
+	signer := pluginSigner{
+		runner: &mockEnvelopePlugin{err: errors.New("failed")},
+		keyID:  "1",
 	}
 	_, err := signer.Sign(context.Background(), notation.Descriptor{
 		MediaType: notation.MediaTypePayload,
 		Size:      1,
 	}, notation.SignOptions{})
 	if err == nil || err.Error() != "generate-envelope command failed: failed" {
-		t.Errorf("PluginSigner.Sign() error = %v, wantErr nil", err)
+		t.Errorf("Signer.Sign() error = %v, wantErr nil", err)
 	}
 }
 
 func TestPluginSigner_SignEnvelope_InvalidEnvelopeType(t *testing.T) {
-	signer := PluginSigner{
-		Runner: &mockEnvelopePlugin{envelopeType: "other"},
-		KeyID:  "1",
+	signer := pluginSigner{
+		runner: &mockEnvelopePlugin{envelopeType: "other"},
+		keyID:  "1",
 	}
 	_, err := signer.Sign(context.Background(), notation.Descriptor{
 		MediaType: notation.MediaTypePayload,
 		Size:      1,
 	}, notation.SignOptions{})
 	if err == nil || err.Error() != "signatureEnvelopeType in generateEnvelope response \"other\" does not match request \"application/vnd.cncf.notary.v2.jws.v1\"" {
-		t.Errorf("PluginSigner.Sign() error = %v, wantErr nil", err)
+		t.Errorf("Signer.Sign() error = %v, wantErr nil", err)
 	}
 }
 
 func TestPluginSigner_SignEnvelope_EmptyCert(t *testing.T) {
-	signer := PluginSigner{
-		Runner: &mockEnvelopePlugin{certChain: make([][]byte, 0)},
-		KeyID:  "1",
+	signer := pluginSigner{
+		runner: &mockEnvelopePlugin{certChain: make([][]byte, 0)},
+		keyID:  "1",
 	}
 	_, err := signer.Sign(context.Background(), notation.Descriptor{
 		MediaType: notation.MediaTypePayload,
 		Size:      1,
 	}, notation.SignOptions{})
 	if err == nil || err.Error() != "envelope content does not match envelope format" {
-		t.Errorf("PluginSigner.Sign() error = %v, wantErr nil", err)
+		t.Errorf("Signer.Sign() error = %v, wantErr nil", err)
 	}
 }
 
 func TestPluginSigner_SignEnvelope_MalformedCertChain(t *testing.T) {
-	signer := PluginSigner{
-		Runner: &mockEnvelopePlugin{certChain: [][]byte{make([]byte, 0)}},
-		KeyID:  "1",
+	signer := pluginSigner{
+		runner: &mockEnvelopePlugin{certChain: [][]byte{make([]byte, 0)}},
+		keyID:  "1",
 	}
 	_, err := signer.Sign(context.Background(), notation.Descriptor{
 		MediaType: notation.MediaTypePayload,
 		Size:      1,
 	}, notation.SignOptions{})
 	if err == nil || err.Error() != "x509: malformed certificate" {
-		t.Errorf("PluginSigner.Sign() error = %v, wantErr nil", err)
+		t.Errorf("Signer.Sign() error = %v, wantErr nil", err)
 	}
 }
 
@@ -511,19 +511,19 @@ func TestPluginSigner_SignEnvelope_CertBasicConstraintCA(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	signer := PluginSigner{
-		Runner: &mockEnvelopePlugin{
+	signer := pluginSigner{
+		runner: &mockEnvelopePlugin{
 			key:       key,
 			certChain: [][]byte{certBytes},
 		},
-		KeyID: "1",
+		keyID: "1",
 	}
 	_, err = signer.Sign(context.Background(), notation.Descriptor{
 		MediaType: notation.MediaTypePayload,
 		Size:      1,
 	}, notation.SignOptions{})
 	if err == nil || err.Error() != "signing certificate does not meet the minimum requirements: keyUsage must have the bit positions for digitalSignature set" {
-		t.Errorf("PluginSigner.Sign() error = %v, wantErr nil", err)
+		t.Errorf("Signer.Sign() error = %v, wantErr nil", err)
 	}
 }
 
@@ -532,29 +532,29 @@ func TestPluginSigner_SignEnvelope_SignatureVerifyError(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	signer := PluginSigner{
-		Runner: &mockEnvelopePlugin{key: key},
-		KeyID:  "1",
+	signer := pluginSigner{
+		runner: &mockEnvelopePlugin{key: key},
+		keyID:  "1",
 	}
 	_, err = signer.Sign(context.Background(), notation.Descriptor{
 		MediaType: notation.MediaTypePayload,
 		Size:      1,
 	}, notation.SignOptions{})
 	if err == nil || err.Error() != "crypto/rsa: verification error" {
-		t.Errorf("PluginSigner.Sign() error = %v, wantErr nil", err)
+		t.Errorf("Signer.Sign() error = %v, wantErr nil", err)
 	}
 }
 
 func TestPluginSigner_SignEnvelope_Valid(t *testing.T) {
-	signer := PluginSigner{
-		Runner: &mockEnvelopePlugin{},
-		KeyID:  "1",
+	signer := pluginSigner{
+		runner: &mockEnvelopePlugin{},
+		keyID:  "1",
 	}
 	_, err := signer.Sign(context.Background(), notation.Descriptor{
 		MediaType: notation.MediaTypePayload,
 		Size:      1,
 	}, notation.SignOptions{})
 	if err != nil {
-		t.Errorf("PluginSigner.Sign() error = %v, wantErr nil", err)
+		t.Errorf("Signer.Sign() error = %v, wantErr nil", err)
 	}
 }

--- a/signature/jws/plugin_test.go
+++ b/signature/jws/plugin_test.go
@@ -384,15 +384,16 @@ func (s *mockEnvelopePlugin) Run(ctx context.Context, req plugin.Request) (inter
 		if key == nil {
 			key = tmpkey
 		}
-		method, err := signingMethodFromKey(key)
+		keySpec, err := keySpecFromKey(key)
 		if err != nil {
 			return nil, err
 		}
+		alg := keySpec.SignatureAlgorithm().JWS()
 		req1 := req.(*plugin.GenerateEnvelopeRequest)
 		t := &jwt.Token{
-			Method: method,
+			Method: jwt.GetSigningMethod(alg),
 			Header: map[string]interface{}{
-				"alg": method.Alg(),
+				"alg": alg,
 				"cty": notation.MediaTypePayload,
 			},
 			Claims: struct {

--- a/signature/jws/plugin_test.go
+++ b/signature/jws/plugin_test.go
@@ -393,7 +393,7 @@ func (s *mockEnvelopePlugin) Run(ctx context.Context, req plugin.Request) (inter
 			Method: method,
 			Header: map[string]interface{}{
 				"alg": method.Alg(),
-				"cty": notation.MediaTypeDescriptor,
+				"cty": notation.MediaTypePayload,
 			},
 			Claims: struct {
 				jwt.RegisteredClaims
@@ -445,7 +445,7 @@ func TestPluginSigner_SignEnvelope_RunFailed(t *testing.T) {
 		KeyID:  "1",
 	}
 	_, err := signer.Sign(context.Background(), notation.Descriptor{
-		MediaType: notation.MediaTypeDescriptor,
+		MediaType: notation.MediaTypePayload,
 		Size:      1,
 	}, notation.SignOptions{})
 	if err == nil || err.Error() != "generate-envelope command failed: failed" {
@@ -459,7 +459,7 @@ func TestPluginSigner_SignEnvelope_InvalidEnvelopeType(t *testing.T) {
 		KeyID:  "1",
 	}
 	_, err := signer.Sign(context.Background(), notation.Descriptor{
-		MediaType: notation.MediaTypeDescriptor,
+		MediaType: notation.MediaTypePayload,
 		Size:      1,
 	}, notation.SignOptions{})
 	if err == nil || err.Error() != "signatureEnvelopeType in generateEnvelope response \"other\" does not match request \"application/vnd.cncf.notary.v2.jws.v1\"" {
@@ -473,7 +473,7 @@ func TestPluginSigner_SignEnvelope_EmptyCert(t *testing.T) {
 		KeyID:  "1",
 	}
 	_, err := signer.Sign(context.Background(), notation.Descriptor{
-		MediaType: notation.MediaTypeDescriptor,
+		MediaType: notation.MediaTypePayload,
 		Size:      1,
 	}, notation.SignOptions{})
 	if err == nil || err.Error() != "envelope content does not match envelope format" {
@@ -487,7 +487,7 @@ func TestPluginSigner_SignEnvelope_MalformedCertChain(t *testing.T) {
 		KeyID:  "1",
 	}
 	_, err := signer.Sign(context.Background(), notation.Descriptor{
-		MediaType: notation.MediaTypeDescriptor,
+		MediaType: notation.MediaTypePayload,
 		Size:      1,
 	}, notation.SignOptions{})
 	if err == nil || err.Error() != "x509: malformed certificate" {
@@ -519,7 +519,7 @@ func TestPluginSigner_SignEnvelope_CertBasicConstraintCA(t *testing.T) {
 		KeyID: "1",
 	}
 	_, err = signer.Sign(context.Background(), notation.Descriptor{
-		MediaType: notation.MediaTypeDescriptor,
+		MediaType: notation.MediaTypePayload,
 		Size:      1,
 	}, notation.SignOptions{})
 	if err == nil || err.Error() != "signing certificate does not meet the minimum requirements: keyUsage must have the bit positions for digitalSignature set" {
@@ -537,7 +537,7 @@ func TestPluginSigner_SignEnvelope_SignatureVerifyError(t *testing.T) {
 		KeyID:  "1",
 	}
 	_, err = signer.Sign(context.Background(), notation.Descriptor{
-		MediaType: notation.MediaTypeDescriptor,
+		MediaType: notation.MediaTypePayload,
 		Size:      1,
 	}, notation.SignOptions{})
 	if err == nil || err.Error() != "crypto/rsa: verification error" {
@@ -551,7 +551,7 @@ func TestPluginSigner_SignEnvelope_Valid(t *testing.T) {
 		KeyID:  "1",
 	}
 	_, err := signer.Sign(context.Background(), notation.Descriptor{
-		MediaType: notation.MediaTypeDescriptor,
+		MediaType: notation.MediaTypePayload,
 		Size:      1,
 	}, notation.SignOptions{})
 	if err != nil {

--- a/signature/jws/plugin_test.go
+++ b/signature/jws/plugin_test.go
@@ -336,7 +336,7 @@ func TestSigner_Sign_Valid(t *testing.T) {
 		t.Fatal(err)
 	}
 	want := notation.JWSEnvelope{
-		Protected: "eyJhbGciOiJQUzI1NiIsImN0eSI6ImFwcGxpY2F0aW9uL3ZuZC5vY2kuZGVzY3JpcHRvci52MStqc29uIn0",
+		Protected: "eyJhbGciOiJQUzI1NiIsImN0eSI6ImFwcGxpY2F0aW9uL3ZuZC5jbmNmLm5vdGFyeS5wYXlsb2FkLnYxK2pzb24ifQ",
 		Header: notation.JWSUnprotectedHeader{
 			CertChain: [][]byte{cert.Raw},
 		},

--- a/signature/jws/signer.go
+++ b/signature/jws/signer.go
@@ -143,7 +143,7 @@ func jwtToken(alg string, claims jwt.Claims) *jwt.Token {
 	return &jwt.Token{
 		Header: map[string]interface{}{
 			"alg": alg,
-			"cty": notation.MediaTypeJWSEnvelope,
+			"cty": notation.MediaTypeDescriptor,
 		},
 		Claims: claims,
 	}

--- a/signature/jws/signer.go
+++ b/signature/jws/signer.go
@@ -143,7 +143,7 @@ func jwtToken(alg string, claims jwt.Claims) *jwt.Token {
 	return &jwt.Token{
 		Header: map[string]interface{}{
 			"alg": alg,
-			"cty": notation.MediaTypeDescriptor,
+			"cty": notation.MediaTypePayload,
 		},
 		Claims: claims,
 	}


### PR DESCRIPTION
This PR implements the `generate-envelope` workflow by reusing most of the `PluginSigner` logic.