### PR TITLE
Add SignatureVerificationLevel type

### DIFF
--- a/verification/signature_verification_levels.go
+++ b/verification/signature_verification_levels.go
@@ -1,0 +1,105 @@
+package verification
+
+import "fmt"
+
+// VerificationType is an enum for signature verification types such as Integrity, Authenticity, etc.
+type VerificationType string
+
+// VerificationAction is an enum for signature verification actions such as Enforced, Logged, Skipped.
+type VerificationAction string
+
+// SignatureVerificationLevel encapsulates the signature verification preset and it's actions for each verification type
+type SignatureVerificationLevel struct {
+	Name            string
+	VerificationMap map[VerificationType]VerificationAction
+}
+
+const (
+	Integrity             VerificationType = "Integrity"
+	Authenticity          VerificationType = "Authenticity"
+	TrustedTimestampCheck VerificationType = "TrustedTimestampCheck"
+	ExpiryCheck           VerificationType = "ExpiryCheck"
+	RevocationCheck       VerificationType = "RevocationCheck"
+
+	Enforced VerificationAction = "Enforced"
+	Logged   VerificationAction = "Logged"
+	Skipped  VerificationAction = "Skipped"
+)
+
+var (
+	Strict = SignatureVerificationLevel{
+		"strict",
+		map[VerificationType]VerificationAction{
+			Integrity:             Enforced,
+			Authenticity:          Enforced,
+			TrustedTimestampCheck: Enforced,
+			ExpiryCheck:           Enforced,
+			RevocationCheck:       Enforced,
+		},
+	}
+
+	Permissive = SignatureVerificationLevel{
+		"permissive",
+		map[VerificationType]VerificationAction{
+			Integrity:             Enforced,
+			Authenticity:          Enforced,
+			TrustedTimestampCheck: Logged,
+			ExpiryCheck:           Logged,
+			RevocationCheck:       Logged,
+		},
+	}
+
+	Audit = SignatureVerificationLevel{
+		"audit",
+		map[VerificationType]VerificationAction{
+			Integrity:             Enforced,
+			Authenticity:          Logged,
+			TrustedTimestampCheck: Logged,
+			ExpiryCheck:           Logged,
+			RevocationCheck:       Logged,
+		},
+	}
+
+	Skip = SignatureVerificationLevel{
+		"skip",
+		map[VerificationType]VerificationAction{
+			Integrity:             Skipped,
+			Authenticity:          Skipped,
+			TrustedTimestampCheck: Skipped,
+			ExpiryCheck:           Skipped,
+			RevocationCheck:       Skipped,
+		},
+	}
+
+	VerificationTypes = []VerificationType{
+		Integrity,
+		Authenticity,
+		TrustedTimestampCheck,
+		ExpiryCheck,
+		RevocationCheck,
+	}
+
+	VerificationActions = []VerificationAction{
+		Enforced,
+		Logged,
+		Skipped,
+	}
+
+	SignatureVerificationLevels = []SignatureVerificationLevel{
+		Strict,
+		Permissive,
+		Audit,
+		Skip,
+	}
+)
+
+// FindSignatureVerificationLevel finds if the given string corresponds to a supported SignatureVerificationLevel, otherwise throws an error
+func FindSignatureVerificationLevel(s string) (*SignatureVerificationLevel, error) {
+
+	for _, level := range SignatureVerificationLevels {
+		if level.Name == s {
+			return &level, nil
+		}
+	}
+	return nil, fmt.Errorf("invalid SignatureVerification %q", s)
+}

--- a/verification/signature_verification_levels_test.go
+++ b/verification/signature_verification_levels_test.go
@@ -1,0 +1,36 @@
+package verification
+
+import (
+	"strconv"
+	"testing"
+)
+
+func TestFindSignatureVerificationLevel(t *testing.T) {
+	tests := []struct {
+		verificationLevel   string
+		wantErr             bool
+		verificationActions []VerificationAction
+	}{
+		{"strict", false, []VerificationAction{Enforced, Enforced, Enforced, Enforced, Enforced}},
+		{"permissive", false, []VerificationAction{Enforced, Enforced, Logged, Logged, Logged}},
+		{"audit", false, []VerificationAction{Enforced, Logged, Logged, Logged, Logged}},
+		{"skip", false, []VerificationAction{Skipped, Skipped, Skipped, Skipped, Skipped}},
+		{"invalid", true, []VerificationAction{}},
+	}
+	for i, tt := range tests {
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
+
+			level, err := FindSignatureVerificationLevel(tt.verificationLevel)
+
+			if tt.wantErr != (err != nil) {
+				t.Fatalf("TestFindSignatureVerificationLevel Error: %q WantErr: %v", err, tt.wantErr)
+			} else {
+				for index, action := range tt.verificationActions {
+					if action != level.VerificationMap[VerificationTypes[index]] {
+						t.Errorf("%q verification action should be %q for Verification Level %q", VerificationTypes[index], action, tt.verificationLevel)
+					}
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
Adding types for VerificationType, VerificationAction, SignatureVerificationLevel as spec'd in https://github.com/notaryproject/notaryproject/blob/main/trust-store-trust-policy-specification.md#signature-verification-details

Signed-off-by: rgnote <5878554+rgnote@users.noreply.github.com>