### PR TITLE
Update data model with latest notation spec

### DIFF
--- a/jws.go
+++ b/jws.go
@@ -1,21 +1,11 @@
 package notation
 
+import "time"
+
 const (
 	// MediaTypeJWSEnvelope describes the media type of the JWS envelope.
 	MediaTypeJWSEnvelope = "application/vnd.cncf.notary.v2.jws.v1"
 )
-
-// JWSPayload contains the set of claims used by Notary V2.
-type JWSPayload struct {
-	// Private claim.
-	Subject Descriptor `json:"subject"`
-
-	// Identifies the number of seconds since Epoch at which the signature was issued.
-	IssuedAt int64 `json:"iat"`
-
-	// Identifies the number of seconds since Epoch at which the signature must not be considered valid.
-	ExpiresAt int64 `json:"exp,omitempty"`
-}
 
 // JWSProtectedHeader contains the set of protected headers.
 type JWSProtectedHeader struct {
@@ -24,16 +14,28 @@ type JWSProtectedHeader struct {
 
 	// Media type of the secured content (the payload).
 	ContentType string `json:"cty"`
+
+	// Lists the headers that implementation MUST understand and process.
+	Critical []string `json:"crit"`
+
+	// The time at which the signature was generated.
+	SigningTime time.Time `json:"io.cncf.notary.signingTime"`
+
+	// The "best by use" time for the artifact, as defined by the signer.
+	Expiry time.Time `json:"io.cncf.notary.expiry,omitempty"`
 }
 
 // JWSUnprotectedHeader contains the set of unprotected headers.
 type JWSUnprotectedHeader struct {
 	// RFC3161 time stamp token Base64-encoded.
-	TimeStampToken []byte `json:"timestamp,omitempty"`
+	TimestampSignature []byte `json:"io.cncf.notary.timestampSignature,omitempty"`
 
 	// List of X.509 Base64-DER-encoded certificates
 	// as defined at https://datatracker.ietf.org/doc/html/rfc7515#section-4.1.6.
 	CertChain [][]byte `json:"x5c"`
+
+	// The identifier of a client that produced the signature.
+	SigningAgent string `json:"io.cncf.notary.signingAgent,omitempty"`
 }
 
 // JWSEnvelope is the final signature envelope.

--- a/notation.go
+++ b/notation.go
@@ -13,6 +13,12 @@ import (
 // Media type for Notary payload for OCI artifacts, which contains an artifact descriptor.
 const MediaTypePayload = "application/vnd.cncf.notary.payload.v1+json"
 
+// Payload contains the set of claims used by Notary V2.
+type Payload struct {
+	// The descriptor of the target artifact manifest that is being signed.
+	TargetArtifact Descriptor `json:"targetArtifact"`
+}
+
 // Descriptor describes the content signed or to be signed.
 type Descriptor struct {
 	// The media type of the targeted content.

--- a/signature/jws/signer.go
+++ b/signature/jws/signer.go
@@ -132,16 +132,6 @@ func (r *builtinPlugin) Run(ctx context.Context, req plugin.Request) (interface{
 	}
 }
 
-func jwtToken(alg string, claims jwt.Claims) *jwt.Token {
-	return &jwt.Token{
-		Header: map[string]interface{}{
-			"alg": alg,
-			"cty": notation.MediaTypePayload,
-		},
-		Claims: claims,
-	}
-}
-
 func jwsEnvelope(ctx context.Context, opts notation.SignOptions, compact string, certChain [][]byte) ([]byte, error) {
 	parts := strings.Split(compact, ".")
 	if len(parts) != 3 {
@@ -162,7 +152,7 @@ func jwsEnvelope(ctx context.Context, opts notation.SignOptions, compact string,
 		if err != nil {
 			return nil, fmt.Errorf("timestamp failed: %w", err)
 		}
-		envelope.Header.TimeStampToken = token
+		envelope.Header.TimestampSignature = token
 	}
 
 	// encode in flatten JWS JSON serialization

--- a/signature/jws/spec.go
+++ b/signature/jws/spec.go
@@ -9,31 +9,7 @@ import (
 	"crypto/x509"
 	"errors"
 	"fmt"
-	"time"
-
-	"github.com/golang-jwt/jwt/v4"
-	"github.com/notaryproject/notation-go"
 )
-
-type notaryClaim struct {
-	jwt.RegisteredClaims
-	Subject notation.Descriptor `json:"subject"`
-}
-
-// packPayload generates JWS payload according the signing content and options.
-func packPayload(desc notation.Descriptor, opts notation.SignOptions) jwt.Claims {
-	var expiresAt *jwt.NumericDate
-	if !opts.Expiry.IsZero() {
-		expiresAt = jwt.NewNumericDate(opts.Expiry)
-	}
-	return notaryClaim{
-		RegisteredClaims: jwt.RegisteredClaims{
-			ExpiresAt: expiresAt,
-			IssuedAt:  jwt.NewNumericDate(time.Now()),
-		},
-		Subject: desc,
-	}
-}
 
 var (
 	oidExtensionKeyUsage = []int{2, 5, 29, 15}


### PR DESCRIPTION
This PR addresses some comments from previous plugin PRs and updates the data model to the latest version, defined in https://github.com/notaryproject/notaryproject/pull/158.

The main change is that `notation.Payload` is now agnostic to the envelope type thanks to the JWS specific claims being generalized and moved to `notation.JWSProtectedHeader`.

@Wwwsylvia @rgnote @gokarnm

Signed-off-by: qmuntal <qmuntaldiaz@microsoft.com>