### PR TITLE
Updates based on signing scheme update in notation-go-core

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.17
 require (
 	github.com/go-ldap/ldap/v3 v3.4.3
 	github.com/golang-jwt/jwt/v4 v4.4.2
-	github.com/notaryproject/notation-core-go v0.0.0-20220803031124-6670fef9acec
+	github.com/notaryproject/notation-core-go v0.0.0-20220809210532-f0a54093ba32
 	github.com/opencontainers/go-digest v1.0.0
 	github.com/opencontainers/image-spec v1.0.2
 	github.com/oras-project/artifacts-spec v1.0.0-rc.2

--- a/go.sum
+++ b/go.sum
@@ -7,8 +7,8 @@ github.com/go-ldap/ldap/v3 v3.4.3/go.mod h1:7LdHfVt6iIOESVEe3Bs4Jp2sHEKgDeduAhgM
 github.com/golang-jwt/jwt/v4 v4.4.1/go.mod h1:m21LjoU+eqJr34lmDMbreY2eSTRJ1cv77w39/MY0Ch0=
 github.com/golang-jwt/jwt/v4 v4.4.2 h1:rcc4lwaZgFMCZ5jxF9ABolDcIHdBytAFgqFPbSJQAYs=
 github.com/golang-jwt/jwt/v4 v4.4.2/go.mod h1:m21LjoU+eqJr34lmDMbreY2eSTRJ1cv77w39/MY0Ch0=
-github.com/notaryproject/notation-core-go v0.0.0-20220803031124-6670fef9acec h1:TSv/NhArMA95eu8nrJexdtaWkGhctAwqUnM2hN5b4dw=
-github.com/notaryproject/notation-core-go v0.0.0-20220803031124-6670fef9acec/go.mod h1:n+UjcUoYhvawO/JW5JfZerUUsGbHYTd4wH8ndGeeyas=
+github.com/notaryproject/notation-core-go v0.0.0-20220809210532-f0a54093ba32 h1:dMZIRt5CMjl9eLJFywlBDDps3AWjgyy6axFnYONak8g=
+github.com/notaryproject/notation-core-go v0.0.0-20220809210532-f0a54093ba32/go.mod h1:n+UjcUoYhvawO/JW5JfZerUUsGbHYTd4wH8ndGeeyas=
 github.com/opencontainers/distribution-spec/specs-go v0.0.0-20220620172159-4ab4752c3b86 h1:Oumw+lPnO8qNLTY2mrqPJZMoGExLi/0h/DdikoLTXVU=
 github.com/opencontainers/distribution-spec/specs-go v0.0.0-20220620172159-4ab4752c3b86/go.mod h1:aA4vdXRS8E1TG7pLZOz85InHi3BiPdErh8IpJN6E0x4=
 github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8Oi/yOhh5U=

--- a/signature/plugin.go
+++ b/signature/plugin.go
@@ -119,7 +119,8 @@ func (s *pluginSigner) generateSignature(ctx context.Context, desc notation.Desc
 		SignatureProvider:   psp,
 		SigningTime:         time.Now(),
 		ExtendedSignedAttrs: nil,
-		SigningAgent:        "Notation/1.0.0", // TODO: include external signing plugin's name and version. https://github.com/notaryproject/notation-go/issues/80
+		SigningScheme:       signer.SigningSchemeX509,
+		SigningAgent:        "Notation/1.0.0",  // TODO: include external signing plugin's name and version. https://github.com/notaryproject/notation-go/issues/80
 	}
 	if !opts.Expiry.IsZero() {
 		signReq.Expiry = opts.Expiry

--- a/signature/plugin_test.go
+++ b/signature/plugin_test.go
@@ -298,7 +298,7 @@ func (s *mockEnvelopePlugin) Run(_ context.Context, req plugin.Request) (interfa
 		} else {
 			resolvedCertChain = certs
 		}
-		lsp, err := signer.GetLocalSignatureProvider(resolvedCertChain, key)
+		lsp, err := signer.NewLocalSignatureProvider(resolvedCertChain, key)
 		if err != nil {
 			return nil, err
 		}
@@ -312,6 +312,7 @@ func (s *mockEnvelopePlugin) Run(_ context.Context, req plugin.Request) (interfa
 			SignatureProvider:   lsp,
 			SigningTime:         time.Now(),
 			Expiry:              time.Now().AddDate(2,0,0),
+			SigningScheme:       signer.SigningSchemeX509SigningAuthority,
 			SigningAgent:        "",
 		})
 		if err != nil {

--- a/signature/signer.go
+++ b/signature/signer.go
@@ -50,7 +50,7 @@ func NewSignerFromFiles(keyPath, certPath string) (notation.Signer, error) {
 // The relation of the provided signing key and its certificate chain is not verified,
 // and should be verified by the caller.
 func NewSigner(key crypto.PrivateKey, certChain []*x509.Certificate) (notation.Signer, error) {
-	lsp, err := signer.GetLocalSignatureProvider(certChain, key)
+	lsp, err := signer.NewLocalSignatureProvider(certChain, key)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Updates to accommodate changes as part of https://github.com/notaryproject/notation-core-go/pull/17

- Closes https://github.com/notaryproject/roadmap/issues/28