### PR TITLE
feat: Use PackArtifact to push signature manifest

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,8 +8,8 @@ require (
 	github.com/notaryproject/notation-core-go v0.0.0-20220712013708-3c4b3efa03c5
 	github.com/opencontainers/go-digest v1.0.0
 	github.com/opencontainers/image-spec v1.0.2
-	github.com/oras-project/artifacts-spec v1.0.0-rc.1.0.20220707054150-eddd1d8790c9
-	oras.land/oras-go/v2 v2.0.0-rc.1.0.20220721090637-6c67e647b6d4
+	github.com/oras-project/artifacts-spec v1.0.0-rc.2
+	oras.land/oras-go/v2 v2.0.0-rc.1.0.20220727034506-eb13fdfeefa6
 )
 
 require (

--- a/go.mod
+++ b/go.mod
@@ -8,12 +8,14 @@ require (
 	github.com/notaryproject/notation-core-go v0.0.0-20220712013708-3c4b3efa03c5
 	github.com/opencontainers/go-digest v1.0.0
 	github.com/opencontainers/image-spec v1.0.2
-	github.com/oras-project/artifacts-spec v1.0.0-rc.1
-	oras.land/oras-go/v2 v2.0.0-20220620164807-8b2a54608a94
+	github.com/oras-project/artifacts-spec v1.0.0-rc.1.0.20220707054150-eddd1d8790c9
+	oras.land/oras-go/v2 v2.0.0-rc.1.0.20220721090637-6c67e647b6d4
 )
 
 require (
 	github.com/Azure/go-ntlmssp v0.0.0-20211209120228-48547f28849e // indirect
 	github.com/go-asn1-ber/asn1-ber v1.5.4 // indirect
+	github.com/opencontainers/distribution-spec/specs-go v0.0.0-20220620172159-4ab4752c3b86 // indirect
 	golang.org/x/crypto v0.0.0-20220331220935-ae2d96664a29 // indirect
+	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -15,8 +15,8 @@ github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8
 github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=
 github.com/opencontainers/image-spec v1.0.2 h1:9yCKha/T5XdGtO0q9Q9a6T5NUCsTn/DrBg0D7ufOcFM=
 github.com/opencontainers/image-spec v1.0.2/go.mod h1:BtxoFyWECRxE4U/7sNtV5W15zMzWCbyJoFRP3s7yZA0=
-github.com/oras-project/artifacts-spec v1.0.0-rc.1.0.20220707054150-eddd1d8790c9 h1:VucBcP8TBtYhqrquIcloJe7hUE+f6NumYEA7bzmJ5sc=
-github.com/oras-project/artifacts-spec v1.0.0-rc.1.0.20220707054150-eddd1d8790c9/go.mod h1:Xch2aLzSwtkhbFFN6LUzTfLtukYvMMdXJ4oZ8O7BOdc=
+github.com/oras-project/artifacts-spec v1.0.0-rc.2 h1:9SMCNSxkJEHqWGDiMCuy6TXHgvjgwXGdXZZGXLKQvVE=
+github.com/oras-project/artifacts-spec v1.0.0-rc.2/go.mod h1:Xch2aLzSwtkhbFFN6LUzTfLtukYvMMdXJ4oZ8O7BOdc=
 golang.org/x/crypto v0.0.0-20220331220935-ae2d96664a29 h1:tkVvjkPTB7pnW3jnid7kNyAMPVWllTNOf/qKDze4p9o=
 golang.org/x/crypto v0.0.0-20220331220935-ae2d96664a29/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
 golang.org/x/net v0.0.0-20211112202133-69e39bad7dc2/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
@@ -28,5 +28,5 @@ golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/text v0.3.6/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
-oras.land/oras-go/v2 v2.0.0-rc.1.0.20220721090637-6c67e647b6d4 h1:AbjrJlXD3j9kadU/t3hVkVAvBA6u0TYB1i3/CE56QFc=
-oras.land/oras-go/v2 v2.0.0-rc.1.0.20220721090637-6c67e647b6d4/go.mod h1:L0vZVPSGR2a8i6+tIiva8HGLroO4JF2ifeaBMy6dYa8=
+oras.land/oras-go/v2 v2.0.0-rc.1.0.20220727034506-eb13fdfeefa6 h1:fbJtzJbpZCtdaAvjPvjlTf8CGsUE1+mClxyh/MPne6I=
+oras.land/oras-go/v2 v2.0.0-rc.1.0.20220727034506-eb13fdfeefa6/go.mod h1:IZRIoIJqkAH6x0pL3tVnpyPUyZgthjSyPcH2kgJvBMo=

--- a/go.sum
+++ b/go.sum
@@ -9,13 +9,14 @@ github.com/golang-jwt/jwt/v4 v4.4.2 h1:rcc4lwaZgFMCZ5jxF9ABolDcIHdBytAFgqFPbSJQA
 github.com/golang-jwt/jwt/v4 v4.4.2/go.mod h1:m21LjoU+eqJr34lmDMbreY2eSTRJ1cv77w39/MY0Ch0=
 github.com/notaryproject/notation-core-go v0.0.0-20220712013708-3c4b3efa03c5 h1:tQ+lwjnQb4gD/a3YBlS7GmTEccW1w9nWem5fB3mITcg=
 github.com/notaryproject/notation-core-go v0.0.0-20220712013708-3c4b3efa03c5/go.mod h1:n+UjcUoYhvawO/JW5JfZerUUsGbHYTd4wH8ndGeeyas=
+github.com/opencontainers/distribution-spec/specs-go v0.0.0-20220620172159-4ab4752c3b86 h1:Oumw+lPnO8qNLTY2mrqPJZMoGExLi/0h/DdikoLTXVU=
+github.com/opencontainers/distribution-spec/specs-go v0.0.0-20220620172159-4ab4752c3b86/go.mod h1:aA4vdXRS8E1TG7pLZOz85InHi3BiPdErh8IpJN6E0x4=
 github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8Oi/yOhh5U=
 github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=
 github.com/opencontainers/image-spec v1.0.2 h1:9yCKha/T5XdGtO0q9Q9a6T5NUCsTn/DrBg0D7ufOcFM=
 github.com/opencontainers/image-spec v1.0.2/go.mod h1:BtxoFyWECRxE4U/7sNtV5W15zMzWCbyJoFRP3s7yZA0=
-github.com/oras-project/artifacts-spec v1.0.0-draft.1.1/go.mod h1:Xch2aLzSwtkhbFFN6LUzTfLtukYvMMdXJ4oZ8O7BOdc=
-github.com/oras-project/artifacts-spec v1.0.0-rc.1 h1:bCHf9mPbrgiNwQFyVzBX79BYZVAl0OUrmvICZOCOwts=
-github.com/oras-project/artifacts-spec v1.0.0-rc.1/go.mod h1:Xch2aLzSwtkhbFFN6LUzTfLtukYvMMdXJ4oZ8O7BOdc=
+github.com/oras-project/artifacts-spec v1.0.0-rc.1.0.20220707054150-eddd1d8790c9 h1:VucBcP8TBtYhqrquIcloJe7hUE+f6NumYEA7bzmJ5sc=
+github.com/oras-project/artifacts-spec v1.0.0-rc.1.0.20220707054150-eddd1d8790c9/go.mod h1:Xch2aLzSwtkhbFFN6LUzTfLtukYvMMdXJ4oZ8O7BOdc=
 golang.org/x/crypto v0.0.0-20220331220935-ae2d96664a29 h1:tkVvjkPTB7pnW3jnid7kNyAMPVWllTNOf/qKDze4p9o=
 golang.org/x/crypto v0.0.0-20220331220935-ae2d96664a29/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
 golang.org/x/net v0.0.0-20211112202133-69e39bad7dc2/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
@@ -27,5 +28,5 @@ golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/text v0.3.6/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
-oras.land/oras-go/v2 v2.0.0-20220620164807-8b2a54608a94 h1:fJ9MPKKbr2zUBg9b1kpq4Ysa7Is8WyABpxNS4Eu+4FA=
-oras.land/oras-go/v2 v2.0.0-20220620164807-8b2a54608a94/go.mod h1:0IQiLwHUJuMs0+QYGavaeQWw5FD4ABD/RP5YamXT/sc=
+oras.land/oras-go/v2 v2.0.0-rc.1.0.20220721090637-6c67e647b6d4 h1:AbjrJlXD3j9kadU/t3hVkVAvBA6u0TYB1i3/CE56QFc=
+oras.land/oras-go/v2 v2.0.0-rc.1.0.20220721090637-6c67e647b6d4/go.mod h1:L0vZVPSGR2a8i6+tIiva8HGLroO4JF2ifeaBMy6dYa8=

--- a/registry/interface.go
+++ b/registry/interface.go
@@ -16,7 +16,7 @@ type SignatureRepository interface {
 	Get(ctx context.Context, digest digest.Digest) ([]byte, error)
 
 	// PutSignatureManifest creates and uploads an signature artifact linking the manifest and the signature
-	PutSignatureManifest(ctx context.Context, signature []byte, manifest notation.Descriptor, annotaions map[string]string) (notation.Descriptor, SignatureManifest, error)
+	PutSignatureManifest(ctx context.Context, signature []byte, manifest notation.Descriptor, annotations map[string]string) (notation.Descriptor, SignatureManifest, error)
 }
 
 // Repository provides functions for verification and signing workflows

--- a/registry/repository.go
+++ b/registry/repository.go
@@ -92,20 +92,20 @@ func (c *RepositoryClient) Get(ctx context.Context, digest digest.Digest) ([]byt
 }
 
 // PutSignatureManifest creates and uploads an signature artifact linking the manifest and the signature
-func (c *RepositoryClient) PutSignatureManifest(ctx context.Context, signature []byte, manifest notation.Descriptor, annotaions map[string]string) (notation.Descriptor, SignatureManifest, error) {
+func (c *RepositoryClient) PutSignatureManifest(ctx context.Context, signature []byte, manifest notation.Descriptor, annotations map[string]string) (notation.Descriptor, SignatureManifest, error) {
 	signatureDesc, err := c.uploadSignature(ctx, signature)
 	if err != nil {
 		return notation.Descriptor{}, SignatureManifest{}, err
 	}
 
-	manifestDesc, err := c.uploadSignatureManifest(ctx, artifactDescriptorFromNotation(manifest), signatureDesc, annotaions)
+	manifestDesc, err := c.uploadSignatureManifest(ctx, artifactDescriptorFromNotation(manifest), signatureDesc, annotations)
 	if err != nil {
 		return notation.Descriptor{}, SignatureManifest{}, err
 	}
 
 	signatureManifest := SignatureManifest{
 		Blob:        notationDescriptorFromArtifact(signatureDesc),
-		Annotations: annotaions,
+		Annotations: annotations,
 	}
 	return notationDescriptorFromOCI(manifestDesc), signatureManifest, nil
 }
@@ -150,10 +150,10 @@ func (c *RepositoryClient) uploadSignature(ctx context.Context, signature []byte
 }
 
 // uploadSignatureManifest uploads the signature manifest to the registry
-func (c *RepositoryClient) uploadSignatureManifest(ctx context.Context, manifest, signatureDesc artifactspec.Descriptor, annotaions map[string]string) (ocispec.Descriptor, error) {
+func (c *RepositoryClient) uploadSignatureManifest(ctx context.Context, manifest, signatureDesc artifactspec.Descriptor, annotations map[string]string) (ocispec.Descriptor, error) {
 	opts := oras.PackArtifactOptions{
 		Subject:             &manifest,
-		ManifestAnnotations: annotaions,
+		ManifestAnnotations: annotations,
 	}
 
 	return oras.PackArtifact(

--- a/registry/repository.go
+++ b/registry/repository.go
@@ -56,7 +56,7 @@ func (c *RepositoryClient) ListSignatureManifests(ctx context.Context, manifestD
 	// TODO(shizhMSFT): filter artifact type at the server side
 	if err := c.Repository.Referrers(ctx, ocispec.Descriptor{
 		Digest: manifestDigest,
-	}, "", func(referrers []artifactspec.Descriptor) error {
+	}, ArtifactTypeNotation, func(referrers []artifactspec.Descriptor) error {
 		for _, desc := range referrers {
 			if desc.ArtifactType != ArtifactTypeNotation || desc.MediaType != artifactspec.MediaTypeArtifactManifest {
 				continue

--- a/registry/repository.go
+++ b/registry/repository.go
@@ -53,12 +53,11 @@ func (c *RepositoryClient) Resolve(ctx context.Context, reference string) (notat
 // ListSignatureManifests returns all signature manifests given the manifest digest
 func (c *RepositoryClient) ListSignatureManifests(ctx context.Context, manifestDigest digest.Digest) ([]SignatureManifest, error) {
 	var signatureManifests []SignatureManifest
-	// TODO(shizhMSFT): filter artifact type at the server side
 	if err := c.Repository.Referrers(ctx, ocispec.Descriptor{
 		Digest: manifestDigest,
 	}, ArtifactTypeNotation, func(referrers []artifactspec.Descriptor) error {
 		for _, desc := range referrers {
-			if desc.ArtifactType != ArtifactTypeNotation || desc.MediaType != artifactspec.MediaTypeArtifactManifest {
+			if desc.MediaType != artifactspec.MediaTypeArtifactManifest {
 				continue
 			}
 			artifact, err := c.getArtifactManifest(ctx, desc.Digest)

--- a/registry/repository.go
+++ b/registry/repository.go
@@ -92,13 +92,13 @@ func (c *RepositoryClient) Get(ctx context.Context, digest digest.Digest) ([]byt
 }
 
 // PutSignatureManifest creates and uploads an signature artifact linking the manifest and the signature
-func (c *RepositoryClient) PutSignatureManifest(ctx context.Context, signature []byte, manifest notation.Descriptor, annotations map[string]string) (notation.Descriptor, SignatureManifest, error) {
+func (c *RepositoryClient) PutSignatureManifest(ctx context.Context, signature []byte, subjectManifest notation.Descriptor, annotations map[string]string) (notation.Descriptor, SignatureManifest, error) {
 	signatureDesc, err := c.uploadSignature(ctx, signature)
 	if err != nil {
 		return notation.Descriptor{}, SignatureManifest{}, err
 	}
 
-	manifestDesc, err := c.uploadSignatureManifest(ctx, artifactDescriptorFromNotation(manifest), signatureDesc, annotations)
+	manifestDesc, err := c.uploadSignatureManifest(ctx, artifactDescriptorFromNotation(subjectManifest), signatureDesc, annotations)
 	if err != nil {
 		return notation.Descriptor{}, SignatureManifest{}, err
 	}
@@ -150,9 +150,9 @@ func (c *RepositoryClient) uploadSignature(ctx context.Context, signature []byte
 }
 
 // uploadSignatureManifest uploads the signature manifest to the registry
-func (c *RepositoryClient) uploadSignatureManifest(ctx context.Context, manifest, signatureDesc artifactspec.Descriptor, annotations map[string]string) (ocispec.Descriptor, error) {
+func (c *RepositoryClient) uploadSignatureManifest(ctx context.Context, subjectManifest, signatureDesc artifactspec.Descriptor, annotations map[string]string) (ocispec.Descriptor, error) {
 	opts := oras.PackArtifactOptions{
-		Subject:             &manifest,
+		Subject:             &subjectManifest,
 		ManifestAnnotations: annotations,
 	}
 


### PR DESCRIPTION
### What?
This PR refactors to use the new method `PackArtifact` to pack and push the signature manifest as mentioned in https://github.com/oras-project/oras-go/issues/175#issuecomment-1168158460

Signed-off-by: Binbin Li <libinbin@microsoft.com>