### PR TITLE
refactor: refactor signer to support cose signature

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.17
 require (
 	github.com/go-ldap/ldap/v3 v3.4.3
 	github.com/golang-jwt/jwt/v4 v4.4.2
-	github.com/notaryproject/notation-core-go v0.0.0-20220712013708-3c4b3efa03c5
+	github.com/notaryproject/notation-core-go v0.0.0-20220810044915-2e99fe004a8c
 	github.com/opencontainers/go-digest v1.0.0
 	github.com/opencontainers/image-spec v1.0.2
 	github.com/oras-project/artifacts-spec v1.0.0-rc.2

--- a/go.sum
+++ b/go.sum
@@ -7,8 +7,8 @@ github.com/go-ldap/ldap/v3 v3.4.3/go.mod h1:7LdHfVt6iIOESVEe3Bs4Jp2sHEKgDeduAhgM
 github.com/golang-jwt/jwt/v4 v4.4.1/go.mod h1:m21LjoU+eqJr34lmDMbreY2eSTRJ1cv77w39/MY0Ch0=
 github.com/golang-jwt/jwt/v4 v4.4.2 h1:rcc4lwaZgFMCZ5jxF9ABolDcIHdBytAFgqFPbSJQAYs=
 github.com/golang-jwt/jwt/v4 v4.4.2/go.mod h1:m21LjoU+eqJr34lmDMbreY2eSTRJ1cv77w39/MY0Ch0=
-github.com/notaryproject/notation-core-go v0.0.0-20220712013708-3c4b3efa03c5 h1:tQ+lwjnQb4gD/a3YBlS7GmTEccW1w9nWem5fB3mITcg=
-github.com/notaryproject/notation-core-go v0.0.0-20220712013708-3c4b3efa03c5/go.mod h1:n+UjcUoYhvawO/JW5JfZerUUsGbHYTd4wH8ndGeeyas=
+github.com/notaryproject/notation-core-go v0.0.0-20220810044915-2e99fe004a8c h1:7iNoUdoVv+xhg5v7zhhHLoV6lEk1aX42UzSSSbaYvsA=
+github.com/notaryproject/notation-core-go v0.0.0-20220810044915-2e99fe004a8c/go.mod h1:n+UjcUoYhvawO/JW5JfZerUUsGbHYTd4wH8ndGeeyas=
 github.com/opencontainers/distribution-spec/specs-go v0.0.0-20220620172159-4ab4752c3b86 h1:Oumw+lPnO8qNLTY2mrqPJZMoGExLi/0h/DdikoLTXVU=
 github.com/opencontainers/distribution-spec/specs-go v0.0.0-20220620172159-4ab4752c3b86/go.mod h1:aA4vdXRS8E1TG7pLZOz85InHi3BiPdErh8IpJN6E0x4=
 github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8Oi/yOhh5U=

--- a/notation.go
+++ b/notation.go
@@ -9,8 +9,8 @@ import (
 	"github.com/opencontainers/go-digest"
 )
 
-// Media type for Notary payload for OCI artifacts, which contains an artifact descriptor.
-const MediaTypePayload = "application/vnd.cncf.notary.payload.v1+json"
+// SigningAgent is the unprotected header field used by signature
+const SigningAgent = "Notation/1.0.0"
 
 // Descriptor describes the artifact that needs to be signed.
 type Descriptor struct {

--- a/plugin/plugin.go
+++ b/plugin/plugin.go
@@ -3,8 +3,6 @@ package plugin
 import (
 	"context"
 	"time"
-
-	"github.com/notaryproject/notation-core-go/signer"
 )
 
 // Prefix is the prefix required on all plugin binary names.
@@ -117,17 +115,24 @@ type DescribeKeyResponse struct {
 
 	// One of following supported key types:
 	// https://github.com/notaryproject/notaryproject/blob/main/signature-specification.md#algorithm-selection
-	KeySpec signer.KeySpec `json:"keySpec"`
+	KeySpec string `json:"keySpec"`
+
+	// TODO: need to check new spec, now add a new field(CertificateChain) to response
+	// Ordered list of certificates starting with leaf certificate
+	// and ending with root certificate.
+	CertificateChain [][]byte `json:"certificateChain"`
 }
 
 // GenerateSignatureRequest contains the parameters passed in a generate-signature request.
+// TODO: need to check new spec
+// do we still need keyspec and hash?
 type GenerateSignatureRequest struct {
-	ContractVersion string                 `json:"contractVersion"`
-	KeyID           string                 `json:"keyId"`
-	KeySpec         signer.KeySpec         `json:"keySpec"`
-	Hash            string                 `json:"hashAlgorithm"`
-	Payload         []byte                 `json:"payload"`
-	PluginConfig    map[string]string      `json:"pluginConfig,omitempty"`
+	ContractVersion string            `json:"contractVersion"`
+	KeyID           string            `json:"keyId"`
+	Payload         []byte            `json:"payload"`
+	KeySpec         string            `json:"keySpec"`
+	Hash            string            `json:"hashAlgorithm"`
+	PluginConfig    map[string]string `json:"pluginConfig,omitempty"`
 }
 
 func (GenerateSignatureRequest) Command() Command {
@@ -135,10 +140,11 @@ func (GenerateSignatureRequest) Command() Command {
 }
 
 // GenerateSignatureResponse is the response of a generate-signature request.
+// TODO: need to check new spec
 type GenerateSignatureResponse struct {
-	KeyID            string                      `json:"keyId"`
-	Signature        []byte                      `json:"signature"`
-	SigningAlgorithm signer.SignatureAlgorithm   `json:"signingAlgorithm"`
+	KeyID            string `json:"keyId"`
+	Signature        []byte `json:"signature"`
+	SigningAlgorithm string `json:"signingAlgorithm"`
 
 	// Ordered list of certificates starting with leaf certificate
 	// and ending with root certificate.

--- a/signature/algorithm.go
+++ b/signature/algorithm.go
@@ -1,0 +1,97 @@
+package signature
+
+import "github.com/notaryproject/notation-core-go/signature"
+
+// one of the following key spec name
+// https://github.com/notaryproject/notaryproject/blob/main/signature-specification.md#algorithm-selection
+const (
+	RSA_2048 = "RSA_2048"
+	RSA_3072 = "RSA_3072"
+	RSA_4096 = "RSA_4096"
+	EC_256   = "EC_256"
+	EC_384   = "EC_384"
+	EC_521   = "EC_521"
+)
+
+// one of the following hash name
+// https://github.com/notaryproject/notaryproject/blob/main/signature-specification.md#algorithm-selection
+const (
+	SHA_256 = "SHA_256"
+	SHA_384 = "SHA_384"
+	SHA_512 = "SHA_512"
+)
+
+// KeySpecName returns the name of a keySpec according to the spec
+func KeySpecName(k signature.KeySpec) string {
+	switch k.Type {
+	case signature.KeyTypeEC:
+		switch k.Size {
+		case 256:
+			return EC_256
+		case 384:
+			return EC_384
+		case 521:
+			return EC_521
+		}
+	case signature.KeyTypeRSA:
+		switch k.Size {
+		case 2048:
+			return RSA_2048
+		case 3072:
+			return RSA_3072
+		case 4096:
+			return RSA_4096
+		}
+	}
+	return ""
+}
+
+// KeySpecHashName returns the name of hash function according to the spec
+func KeySpecHashName(k signature.KeySpec) string {
+	switch k.Type {
+	case signature.KeyTypeEC:
+		switch k.Size {
+		case 256:
+			return SHA_256
+		case 384:
+			return SHA_384
+		case 521:
+			return SHA_512
+		}
+	case signature.KeyTypeRSA:
+		switch k.Size {
+		case 2048:
+			return SHA_256
+		case 3072:
+			return SHA_384
+		case 4096:
+			return SHA_512
+		}
+	}
+	return ""
+}
+
+// ParseKeySpecFromName parses keyspec name to a signature.keySpec type
+func ParseKeySpecFromName(raw string) (keySpec signature.KeySpec) {
+	switch raw {
+	case RSA_2048:
+		keySpec.Size = 2048
+		keySpec.Type = signature.KeyTypeRSA
+	case RSA_3072:
+		keySpec.Size = 3072
+		keySpec.Type = signature.KeyTypeRSA
+	case RSA_4096:
+		keySpec.Size = 4096
+		keySpec.Type = signature.KeyTypeRSA
+	case EC_256:
+		keySpec.Size = 256
+		keySpec.Type = signature.KeyTypeEC
+	case EC_384:
+		keySpec.Size = 384
+		keySpec.Type = signature.KeyTypeEC
+	case EC_521:
+		keySpec.Size = 521
+		keySpec.Type = signature.KeyTypeEC
+	}
+	return
+}

--- a/signature/plugin_test.go
+++ b/signature/plugin_test.go
@@ -37,11 +37,11 @@ func (r *mockRunner) Run(_ context.Context, _ plugin.Request) (interface{}, erro
 }
 
 type mockSignerPlugin struct {
-	KeyID      string
-	KeySpec    signer.KeySpec
-	Sign       func(payload []byte) []byte
-	Certs      [][]byte
-	n          int
+	KeyID   string
+	KeySpec signer.KeySpec
+	Sign    func(payload []byte) []byte
+	Certs   [][]byte
+	n       int
 }
 
 func (s *mockSignerPlugin) Run(_ context.Context, req plugin.Request) (interface{}, error) {
@@ -163,8 +163,8 @@ func TestSigner_Sign_UnsuportedKeySpec(t *testing.T) {
 func TestSigner_Sign_NoCertChain(t *testing.T) {
 	signer := pluginSigner{
 		runner: &mockSignerPlugin{
-			KeyID:      "1",
-			KeySpec:    signer.RSA_2048,
+			KeyID:   "1",
+			KeySpec: signer.RSA_2048,
 		},
 		keyID: "1",
 	}
@@ -174,9 +174,9 @@ func TestSigner_Sign_NoCertChain(t *testing.T) {
 func TestSigner_Sign_MalformedCert(t *testing.T) {
 	signer := pluginSigner{
 		runner: &mockSignerPlugin{
-			KeyID:      "1",
-			KeySpec:    signer.RSA_2048,
-			Certs:      [][]byte{[]byte("mocked")},
+			KeyID:   "1",
+			KeySpec: signer.RSA_2048,
+			Certs:   [][]byte{[]byte("mocked")},
 		},
 		keyID: "1",
 	}
@@ -255,7 +255,6 @@ func TestSigner_Sign_Valid(t *testing.T) {
 		t.Errorf("Signer.Sign() payload changed")
 	}
 
-
 	if !reflect.DeepEqual(sigInfo.CertificateChain, cert) {
 		t.Errorf("Signer.Sign() cert chain changed")
 	}
@@ -307,12 +306,12 @@ func (s *mockEnvelopePlugin) Run(_ context.Context, req plugin.Request) (interfa
 		req1 := req.(*plugin.GenerateEnvelopeRequest)
 
 		data, err := env.Sign(signer.SignRequest{
-			Payload:             req1.Payload,
-			PayloadContentType:  signer.PayloadContentType(req1.PayloadType),
-			SignatureProvider:   lsp,
-			SigningTime:         time.Now(),
-			Expiry:              time.Now().AddDate(2,0,0),
-			SigningAgent:        "",
+			Payload:            req1.Payload,
+			PayloadContentType: signer.PayloadContentType(req1.PayloadType),
+			SignatureProvider:  lsp,
+			SigningTime:        time.Now(),
+			Expiry:             time.Now().AddDate(2, 0, 0),
+			SigningAgent:       "",
 		})
 		if err != nil {
 			return nil, err

--- a/signature/provider.go
+++ b/signature/provider.go
@@ -1,0 +1,186 @@
+package signature
+
+import (
+	"context"
+	"crypto"
+	"crypto/x509"
+	"fmt"
+
+	"github.com/notaryproject/notation-core-go/signature"
+	"github.com/notaryproject/notation-go/plugin"
+)
+
+// provider wraps a runner and a signature.Signer
+type provider interface {
+	plugin.Runner
+	signature.Signer
+	SetConfig(map[string]string)
+}
+
+// builtinPlugin is a builtin provider implementation
+// It only support describe key and metadata command
+// It wraps signature.Signature to support builtin signing method
+type builtinProvider struct {
+	signature.Signer
+}
+
+func newBuiltinProvider(key crypto.PrivateKey, certChain []*x509.Certificate) (provider, error) {
+	builtinSigner, err := signature.NewLocalSigner(certChain, key)
+	if err != nil {
+		return nil, err
+	}
+	return &builtinProvider{
+		builtinSigner,
+	}, nil
+}
+
+func (*builtinProvider) metadata() *plugin.Metadata {
+	// The only properties that are really relevant
+	// are the supported contract version and the capabilities.
+	// All other are just filled with meaningful data.
+	return &plugin.Metadata{
+		SupportedContractVersions: []string{plugin.ContractVersion},
+		Capabilities:              []plugin.Capability{plugin.CapabilitySignatureGenerator},
+		Name:                      "built-in",
+		Description:               "Notation built-in signer",
+		Version:                   plugin.ContractVersion,
+		URL:                       "https://github.com/notaryproject/notation-go",
+	}
+}
+
+// SetConfig set config when signing
+// no need to implement since builtin plugin never use config
+func (*builtinProvider) SetConfig(map[string]string) {
+
+}
+
+// Run implement the plugin workflow.
+// only support metadata and describe key
+// TODO: how to return key spec
+func (p *builtinProvider) Run(_ context.Context, req plugin.Request) (interface{}, error) {
+	switch req.Command() {
+	case plugin.CommandGetMetadata:
+		return p.metadata(), nil
+	case plugin.CommandDescribeKey:
+		req1 := req.(*plugin.DescribeKeyRequest)
+		return &plugin.DescribeKeyResponse{
+			KeyID: req1.KeyID,
+		}, nil
+	}
+	return nil, plugin.RequestError{
+		Code: plugin.ErrorCodeGeneric,
+		Err:  fmt.Errorf("command %q is not supported", req.Command()),
+	}
+}
+
+// builtinPlugin is a external provider implementation, which will interact with plugin
+// It supports all plugin commands
+// The detail implementation depends on the real plugin
+// It wraps a signature.Signature to support external signing
+type externalProvider struct {
+	plugin.Runner
+	keyID  string
+	config map[string]string
+}
+
+// SetConfig setup config used by signing
+func (p *externalProvider) SetConfig(cfg map[string]string) {
+	p.config = cfg
+}
+
+func newExternalProvider(runner plugin.Runner, keyID string) provider {
+	return &externalProvider{
+		Runner: runner,
+		keyID:  keyID,
+	}
+}
+
+func (p *externalProvider) describeKey(ctx context.Context) (*plugin.DescribeKeyResponse, error) {
+	req := &plugin.DescribeKeyRequest{
+		ContractVersion: plugin.ContractVersion,
+		KeyID:           p.keyID,
+		PluginConfig:    p.config,
+	}
+	out, err := p.Run(ctx, req)
+	if err != nil {
+		return nil, fmt.Errorf("describe-key command failed: %w", err)
+	}
+	resp, ok := out.(*plugin.DescribeKeyResponse)
+	if !ok {
+		return nil, fmt.Errorf("plugin runner returned incorrect describe-key response type '%T'", out)
+	}
+	return resp, nil
+}
+
+// Sign sign the digest by calling the real plugin
+func (p *externalProvider) Sign(digest []byte) ([]byte, error) {
+	// Execute plugin sign command.
+	// TODO: do we still need keyspec and hash in request?
+	keySpec, err := p.KeySpec()
+	if err == nil {
+		return nil, err
+	}
+	req := &plugin.GenerateSignatureRequest{
+		ContractVersion: plugin.ContractVersion,
+		KeyID:           p.keyID,
+		KeySpec:         KeySpecName(keySpec),
+		Hash:            KeySpecHashName(keySpec),
+		Payload:         digest,
+		PluginConfig:    p.config,
+	}
+
+	out, err := p.Run(context.Background(), req)
+	if err != nil {
+		return nil, fmt.Errorf("generate-signature command failed: %w", err)
+	}
+
+	resp, ok := out.(*plugin.GenerateSignatureResponse)
+	if !ok {
+		return nil, fmt.Errorf("plugin runner returned incorrect generate-signature response type '%T'", out)
+	}
+
+	// Check keyID is honored.
+	if req.KeyID != resp.KeyID {
+		return nil, fmt.Errorf("keyID in generateSignature response %q does not match request %q", resp.KeyID, req.KeyID)
+	}
+
+	// TODO: do we still need cert chain in response?
+	if _, err = parseCertChain(resp.CertificateChain); err != nil {
+		return nil, err
+	}
+
+	return resp.Signature, nil
+}
+
+func (p *externalProvider) keyInfo() (signature.KeySpec, []*x509.Certificate, error) {
+	keyResp, err := p.describeKey(context.Background())
+	if err != nil {
+		return signature.KeySpec{}, nil, err
+	}
+
+	// Check keyID is honored.
+	if p.keyID != keyResp.KeyID {
+		return signature.KeySpec{}, nil, fmt.Errorf("keyID in describeKey response %q does not match request %q", keyResp.KeyID, p.keyID)
+	}
+	certs, err := parseCertChain(keyResp.CertificateChain)
+	if err != nil {
+		return signature.KeySpec{}, nil, err
+	}
+	return ParseKeySpecFromName(keyResp.KeySpec), certs, nil
+}
+
+func (p *externalProvider) CertificateChain() ([]*x509.Certificate, error) {
+	_, certs, err := p.keyInfo()
+	if err != nil {
+		return nil, err
+	}
+	return certs, nil
+}
+
+func (p *externalProvider) KeySpec() (signature.KeySpec, error) {
+	keySpec, _, err := p.keyInfo()
+	if err != nil {
+		return signature.KeySpec{}, err
+	}
+	return keySpec, nil
+}

--- a/signature/signer.go
+++ b/signature/signer.go
@@ -1,21 +1,18 @@
 package signature
 
 import (
-	"context"
 	"crypto"
 	"crypto/tls"
 	"crypto/x509"
 	"errors"
 	"fmt"
 
-	"github.com/notaryproject/notation-core-go/signer"
 	"github.com/notaryproject/notation-go"
-	"github.com/notaryproject/notation-go/plugin"
 )
 
 // NewSignerFromFiles creates a signer from key, certificate files
 // TODO: Add tests for this method. https://github.com/notaryproject/notation-go/issues/80
-func NewSignerFromFiles(keyPath, certPath string) (notation.Signer, error) {
+func NewSignerFromFiles(keyPath, certPath string, mediaTypeEnvelope string) (notation.Signer, error) {
 	if keyPath == "" {
 		return nil, errors.New("key path not specified")
 	}
@@ -42,148 +39,21 @@ func NewSignerFromFiles(keyPath, certPath string) (notation.Signer, error) {
 	}
 
 	// create signer
-	return NewSigner(cert.PrivateKey, certs)
+	return NewSigner(cert.PrivateKey, certs, mediaTypeEnvelope)
 }
 
 // NewSigner creates a signer with the recommended signing method and a signing key bundled
 // with a certificate chain.
 // The relation of the provided signing key and its certificate chain is not verified,
 // and should be verified by the caller.
-func NewSigner(key crypto.PrivateKey, certChain []*x509.Certificate) (notation.Signer, error) {
-	lsp, err := signer.GetLocalSignatureProvider(certChain, key)
+// TODO add comment
+func NewSigner(key crypto.PrivateKey, certChain []*x509.Certificate, mediaTypeEnvelope string) (notation.Signer, error) {
+	builtinProvider, err := newBuiltinProvider(key, certChain)
 	if err != nil {
 		return nil, err
 	}
-
 	return &pluginSigner{
-		runner: &builtinPlugin{ localSignatureProvider: lsp },
+		sigProvider:       builtinProvider,
+		mediaTypeEnvelope: mediaTypeEnvelope,
 	}, nil
 }
-
-// builtinPlugin is a plugin.Runner implementation which
-// signs supports the generate-signature workflow using
-// the provided key and certificates.
-type builtinPlugin struct {
-	localSignatureProvider *signer.LocalSignatureProvider
-	sigAlg                 signer.SignatureAlgorithm
-}
-
-func (builtinPlugin) metadata() *plugin.Metadata {
-	// The only properties that are really relevant
-	// are the supported contract version and the capabilities.
-	// All other are just filled with meaningful data.
-	return &plugin.Metadata{
-		SupportedContractVersions: []string{plugin.ContractVersion},
-		Capabilities:              []plugin.Capability{plugin.CapabilitySignatureGenerator},
-		Name:                      "built-in",
-		Description:               "Notation built-in signer",
-		Version:                   plugin.ContractVersion,
-		URL:                       "https://github.com/notaryproject/notation-go",
-	}
-}
-
-// Run implement the generate-signature workflow.
-func (r *builtinPlugin) Run(_ context.Context, req plugin.Request) (interface{}, error) {
-	switch req.Command() {
-	case plugin.CommandGetMetadata:
-		return r.metadata(), nil
-	case plugin.CommandDescribeKey:
-		req1 := req.(*plugin.DescribeKeyRequest)
-
-		ks, err := r.localSignatureProvider.KeySpec()
-		if err != nil {
-			return nil, plugin.RequestError{
-				Code: plugin.ErrorCodeGeneric,
-				Err:  err,
-			}
-		}
-
-		return &plugin.DescribeKeyResponse{
-			KeyID:   req1.KeyID,
-			KeySpec: ks,
-		}, nil
-	case plugin.CommandGenerateSignature:
-		req1 := req.(*plugin.GenerateSignatureRequest)
-
-		signed, certChain, err := r.localSignatureProvider.Sign(req1.Payload)
-		if err != nil {
-			return nil, plugin.RequestError{
-				Code: plugin.ErrorCodeGeneric,
-				Err:  err,
-			}
-		}
-
-		rawCerts := make([][]byte, len(certChain))
-		for i, cert := range certChain {
-			rawCerts[i] = cert.Raw
-		}
-
-		return &plugin.GenerateSignatureResponse{
-			KeyID:            req1.KeyID,
-			Signature:        signed,
-			SigningAlgorithm: r.sigAlg,
-			CertificateChain: rawCerts,
-		}, nil
-	}
-	return nil, plugin.RequestError{
-		Code: plugin.ErrorCodeGeneric,
-		Err:  fmt.Errorf("command %q is not supported", req.Command()),
-	}
-}
-
-// called from plugin.go
-// func jwsEnvelope(ctx context.Context, opts notation.SignOptions, compact string, certChain [][]byte) ([]byte, error) {
-// 	parts := strings.Split(compact, ".")
-// 	if len(parts) != 3 {
-// 		return nil, errors.New("invalid compact serialization")
-// 	}
-// 	envelope := notation.JWSEnvelope{
-// 		Protected: parts[0],
-// 		Payload:   parts[1],
-// 		Signature: parts[2],
-// 		Header: notation.JWSUnprotectedHeader{
-// 			CertChain: certChain,
-// 		},
-// 	}
-//
-// 	// timestamp JWT
-// 	if opts.TSA != nil {
-// 		token, err := timestampSignature(ctx, envelope.Signature, opts.TSA, opts.TSAVerifyOptions)
-// 		if err != nil {
-// 			return nil, fmt.Errorf("timestamp failed: %w", err)
-// 		}
-// 		envelope.Header.TimeStampToken = token
-// 	}
-//
-// 	// encode in flatten JWS JSON serialization
-// 	return json.Marshal(envelope)
-// }
-
-// local
-// timestampSignature sends a request to the TSA for timestamping the signature.
-// func timestampSignature(ctx context.Context, sig string, tsa timestamp.Timestamper, opts x509.VerifyOptions) ([]byte, error) {
-// 	// timestamp the signature
-// 	decodedSig, err := base64.RawURLEncoding.DecodeString(sig)
-// 	if err != nil {
-// 		return nil, err
-// 	}
-// 	req, err := timestamp.NewRequestFromBytes(decodedSig)
-// 	if err != nil {
-// 		return nil, err
-// 	}
-// 	resp, err := tsa.Timestamp(ctx, req)
-// 	if err != nil {
-// 		return nil, err
-// 	}
-// 	if status := resp.Status; status.Status != pki.StatusGranted {
-// 		return nil, fmt.Errorf("tsa: %d: %v", status.Status, status.StatusString)
-// 	}
-// 	tokenBytes := resp.TokenBytes()
-//
-// 	// verify the timestamp signature
-// 	if _, err := verifyTimestamp(decodedSig, tokenBytes, opts.Roots); err != nil {
-// 		return nil, err
-// 	}
-//
-// 	return tokenBytes, nil
-// }

--- a/signature/signer_test.go
+++ b/signature/signer_test.go
@@ -13,6 +13,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/notaryproject/notation-core-go/signature/jws"
 	"github.com/notaryproject/notation-core-go/signer"
 	"github.com/notaryproject/notation-core-go/testhelper"
 	"github.com/notaryproject/notation-go"
@@ -53,7 +54,7 @@ func TestSignWithTimestamp(t *testing.T) {
 	if err != nil {
 		t.Fatalf("generateKeyCertPair() error = %v", err)
 	}
-	s, err := NewSigner(key, certs)
+	s, err := NewSigner(key, certs, jws.MediaTypeEnvelope)
 	if err != nil {
 		t.Fatalf("NewSigner() error = %v", err)
 	}
@@ -82,7 +83,7 @@ func TestSignWithoutExpiry(t *testing.T) {
 	if err != nil {
 		t.Fatalf("generateKeyCertPair() error = %v", err)
 	}
-	s, err := NewSigner(key, certs)
+	s, err := NewSigner(key, certs, jws.MediaTypeEnvelope)
 	if err != nil {
 		t.Fatalf("NewSigner() error = %v", err)
 	}
@@ -147,13 +148,13 @@ func basicVerification(sig []byte, trust *x509.Certificate, t *testing.T) {
 
 	trustedCert, err := signer.VerifyAuthenticity(sigInfo, []*x509.Certificate{trust})
 
-	if err !=nil || !trustedCert.Equal(trust) {
+	if err != nil || !trustedCert.Equal(trust) {
 		t.Fatalf("VerifyAuthenticity failed. error = %v", err)
 	}
 }
 
 func validateSignWithCerts(t *testing.T, key crypto.PrivateKey, certs []*x509.Certificate) {
-	s, err := NewSigner(key, certs)
+	s, err := NewSigner(key, certs, jws.MediaTypeEnvelope)
 	if err != nil {
 		t.Fatalf("NewSigner() error = %v", err)
 	}

--- a/signature/verifier_test.go
+++ b/signature/verifier_test.go
@@ -6,6 +6,7 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/notaryproject/notation-core-go/signature/jws"
 	"github.com/notaryproject/notation-go"
 )
 
@@ -21,7 +22,7 @@ func TestVerifyWithCertChain(t *testing.T) {
 	if err != nil {
 		t.Fatalf("generateKeyCertPair() error = %v", err)
 	}
-	s, err := NewSigner(key, cert)
+	s, err := NewSigner(key, cert, jws.MediaTypeEnvelope)
 	if err != nil {
 		t.Fatalf("NewSigner() error = %v", err)
 	}


### PR DESCRIPTION
Signed-off-by: zaihaoyin <zaihaoyin@microsoft.com>

# What
Refactor notation-go to support cose signature

# How to review

1. plugin/plugin.go: Add some fields to the plugin contract struct to better support new interface. Need to update when new spec is ready.
2. signature/algorithm.go: Add `tostring` method for keyspec and hash function. Need to update when new spec is ready. If we don't need hash and keyspec in signing request, it can be deprecated.
3. signature/provider.go: A combination of original signature provider and runner. It implements runner and signer interface. For built-in provider, it use `LocalSigner` from `notation-core-go`. For external provider, it implements `signer` interface by using runner to interact with external plugin (sending`describle key` and `generate signature` request)
5. signature/plugin.go: replace runner with provider
6. signature/signer.go: construct a built-in provider with certs and key.
7. ignore any test file changes