### PR TITLE
fix: dir package optimize

### DIFF
--- a/dir/fs_test.go
+++ b/dir/fs_test.go
@@ -183,7 +183,7 @@ func TestPath(t *testing.T) {
 			path:  []string{"plugin/a/a.exe"},
 		},
 		{name: "Path does not exist",
-			want:  "system/plugin/c/c.exe",
+			want:  "user/plugin/c/c.exe",
 			usrFS: fstest.MapFS{"plugin/a/a.exe": {Data: []byte("user a")}},
 			sysFS: fstest.MapFS{"plugin/a/b.exe": {Data: []byte("system b")}},
 			path:  []string{"plugin/c/c.exe"},

--- a/dir/path.go
+++ b/dir/path.go
@@ -2,21 +2,20 @@ package dir
 
 import (
 	"errors"
-	"fmt"
 	"io/fs"
 
 	"github.com/opencontainers/go-digest"
 )
 
 const (
-	// CertificateExtension defines the extension of the certificate files
-	CertificateExtension = ".crt"
-
 	// ConfigFile is the name of config file
 	ConfigFile = "config.json"
 
-	// KeyExtension defines the extension of the key files
-	KeyExtension = ".key"
+	// LocalCertificateExtension defines the extension of the certificate files
+	LocalCertificateExtension = ".crt"
+
+	// LocalKeyExtension defines the extension of the key files
+	LocalKeyExtension = ".key"
 
 	// LocalKeysDir is the directory name for local key store
 	LocalKeysDir = "localkeys"
@@ -60,17 +59,14 @@ func (p *PathManager) Config() string {
 	return path
 }
 
-// LocalKey returns path of the local private keys or certificate
+// LocalKey returns path of the local private key and it's certificate
 // in the localkeys directory
-//
-// extension: support .crt|.key
-func (p *PathManager) Localkey(name string, extension string) string {
-	if extension != KeyExtension && extension != CertificateExtension {
-		panic(fmt.Sprintf("doesn't support the extension `%s`", extension))
-	}
-	path, err := p.UserConfigFS.GetPath(LocalKeysDir, name+extension)
+func (p *PathManager) Localkey(name string) (keyPath, certPath string) {
+	keyPath, err := p.UserConfigFS.GetPath(LocalKeysDir, name+LocalKeyExtension)
 	checkError(err)
-	return path
+	certPath, err = p.UserConfigFS.GetPath(LocalKeysDir, name+LocalCertificateExtension)
+	checkError(err)
+	return keyPath, certPath
 }
 
 // SigningKeyConfig return the path of signingkeys.json files

--- a/dir/path_test.go
+++ b/dir/path_test.go
@@ -137,24 +137,13 @@ func TestPathManager_LocalKey(t *testing.T) {
 			NewRootedFS("/home/exampleuser/.config/notation/", nil),
 		),
 	}
-	localkeyPath := path.Localkey("key1", KeyExtension)
-	if localkeyPath != "/home/exampleuser/.config/notation/localkeys/key1"+KeyExtension {
+	keyPath, certPath := path.Localkey("key1")
+	if keyPath != "/home/exampleuser/.config/notation/localkeys/key1"+LocalKeyExtension {
 		t.Fatal("get Localkey() failed.")
 	}
-}
-
-func TestPathManager_LocalKeyFailed(t *testing.T) {
-	path := &PathManager{
-		UserConfigFS: NewUnionDirFS(
-			NewRootedFS("/home/exampleuser/.config/notation/", nil),
-		),
+	if certPath != "/home/exampleuser/.config/notation/localkeys/key1"+LocalCertificateExtension {
+		t.Fatal("get Localkey() failed.")
 	}
-	defer func() {
-		if d := recover(); d == nil {
-			t.Fatal("get Localkey() extension check failed.")
-		}
-	}()
-	path.Localkey("key1", ".acr")
 }
 
 func TestPathManager_SigningKeyConfig(t *testing.T) {


### PR DESCRIPTION
1. GetPath logic: if the given path doesn't exist, return the first
   possible path in the union directories, so when create a new file the
   UnionDirFS will select user directory which was provided as the first
   directory when create the UnionDirFS
2. change the constant name

Signed-off-by: Junjie Gao <junjiegao@microsoft.com>