### PR TITLE
refactor:refactor notation plugin runner to support cose

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,18 +4,21 @@ go 1.17
 
 require (
 	github.com/go-ldap/ldap/v3 v3.4.3
-	github.com/golang-jwt/jwt/v4 v4.4.2
-	github.com/notaryproject/notation-core-go v0.0.0-20220811064831-ab66bb390904
+	github.com/notaryproject/notation-core-go v0.0.0-20220817014858-be20e83ca2dc
 	github.com/opencontainers/go-digest v1.0.0
 	github.com/opencontainers/image-spec v1.0.2
 	github.com/oras-project/artifacts-spec v1.0.0-rc.2
+	github.com/veraison/go-cose v1.0.0-rc.1
 	oras.land/oras-go/v2 v2.0.0-rc.1.0.20220727034506-eb13fdfeefa6
 )
 
 require (
 	github.com/Azure/go-ntlmssp v0.0.0-20211209120228-48547f28849e // indirect
+	github.com/fxamacker/cbor/v2 v2.4.0 // indirect
 	github.com/go-asn1-ber/asn1-ber v1.5.4 // indirect
+	github.com/golang-jwt/jwt/v4 v4.4.2 // indirect
 	github.com/opencontainers/distribution-spec/specs-go v0.0.0-20220620172159-4ab4752c3b86 // indirect
+	github.com/x448/float16 v0.8.4 // indirect
 	golang.org/x/crypto v0.0.0-20220331220935-ae2d96664a29 // indirect
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,6 @@
 github.com/Azure/go-ntlmssp v0.0.0-20211209120228-48547f28849e h1:ZU22z/2YRFLyf/P4ZwUYSdNCWsMEI0VeyrFoI2rAhJQ=
 github.com/Azure/go-ntlmssp v0.0.0-20211209120228-48547f28849e/go.mod h1:chxPXzSsl7ZWRAuOIE23GDNzjWuZquvFlgA8xmpunjU=
+github.com/fxamacker/cbor/v2 v2.4.0 h1:ri0ArlOR+5XunOP8CRUowT0pSJOwhW098ZCUyskZD88=
 github.com/fxamacker/cbor/v2 v2.4.0/go.mod h1:TA1xS00nchWmaBnEIxPSE5oHLuJBAVvqrtAnWBwBCVo=
 github.com/go-asn1-ber/asn1-ber v1.5.4 h1:vXT6d/FNDiELJnLb6hGNa309LMsrCoYFvpwHDF0+Y1A=
 github.com/go-asn1-ber/asn1-ber v1.5.4/go.mod h1:hEBeB/ic+5LoWskz+yKT7vGhhPYkProFKoKdwZRWMe0=
@@ -8,8 +9,8 @@ github.com/go-ldap/ldap/v3 v3.4.3/go.mod h1:7LdHfVt6iIOESVEe3Bs4Jp2sHEKgDeduAhgM
 github.com/golang-jwt/jwt/v4 v4.4.1/go.mod h1:m21LjoU+eqJr34lmDMbreY2eSTRJ1cv77w39/MY0Ch0=
 github.com/golang-jwt/jwt/v4 v4.4.2 h1:rcc4lwaZgFMCZ5jxF9ABolDcIHdBytAFgqFPbSJQAYs=
 github.com/golang-jwt/jwt/v4 v4.4.2/go.mod h1:m21LjoU+eqJr34lmDMbreY2eSTRJ1cv77w39/MY0Ch0=
-github.com/notaryproject/notation-core-go v0.0.0-20220811064831-ab66bb390904 h1:MpDQVpCqDWUFZbk70aDr3nF0px5zqcVHHqd4VLjbrH4=
-github.com/notaryproject/notation-core-go v0.0.0-20220811064831-ab66bb390904/go.mod h1:KcUBZtOH3r3moiIbQ2h2ZJZ9QCOZ+W0rxHP8KBVnCbY=
+github.com/notaryproject/notation-core-go v0.0.0-20220817014858-be20e83ca2dc h1:5dHwsi8eIGa3y7GGceCUso6eFCQALCIlISWx4lnCGFw=
+github.com/notaryproject/notation-core-go v0.0.0-20220817014858-be20e83ca2dc/go.mod h1:KcUBZtOH3r3moiIbQ2h2ZJZ9QCOZ+W0rxHP8KBVnCbY=
 github.com/opencontainers/distribution-spec/specs-go v0.0.0-20220620172159-4ab4752c3b86 h1:Oumw+lPnO8qNLTY2mrqPJZMoGExLi/0h/DdikoLTXVU=
 github.com/opencontainers/distribution-spec/specs-go v0.0.0-20220620172159-4ab4752c3b86/go.mod h1:aA4vdXRS8E1TG7pLZOz85InHi3BiPdErh8IpJN6E0x4=
 github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8Oi/yOhh5U=
@@ -18,7 +19,9 @@ github.com/opencontainers/image-spec v1.0.2 h1:9yCKha/T5XdGtO0q9Q9a6T5NUCsTn/DrB
 github.com/opencontainers/image-spec v1.0.2/go.mod h1:BtxoFyWECRxE4U/7sNtV5W15zMzWCbyJoFRP3s7yZA0=
 github.com/oras-project/artifacts-spec v1.0.0-rc.2 h1:9SMCNSxkJEHqWGDiMCuy6TXHgvjgwXGdXZZGXLKQvVE=
 github.com/oras-project/artifacts-spec v1.0.0-rc.2/go.mod h1:Xch2aLzSwtkhbFFN6LUzTfLtukYvMMdXJ4oZ8O7BOdc=
+github.com/veraison/go-cose v1.0.0-rc.1 h1:4qA7dbFJGvt7gcqv5MCIyCQvN+NpHFPkW7do3EeDLb8=
 github.com/veraison/go-cose v1.0.0-rc.1/go.mod h1:7ziE85vSq4ScFTg6wyoMXjucIGOf4JkFEZi/an96Ct4=
+github.com/x448/float16 v0.8.4 h1:qLwI1I70+NjRFUR3zs1JPUCgaCXSh3SW62uAKT1mSBM=
 github.com/x448/float16 v0.8.4/go.mod h1:14CWIYCyZA/cWjXOioeEpHeN/83MdbZDRQHoFcYsOfg=
 golang.org/x/crypto v0.0.0-20220331220935-ae2d96664a29 h1:tkVvjkPTB7pnW3jnid7kNyAMPVWllTNOf/qKDze4p9o=
 golang.org/x/crypto v0.0.0-20220331220935-ae2d96664a29/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=

--- a/signature/envelope.go
+++ b/signature/envelope.go
@@ -1,0 +1,25 @@
+package signature
+
+import (
+	"errors"
+
+	"github.com/notaryproject/notation-core-go/signature/cose"
+	"github.com/notaryproject/notation-core-go/signature/jws"
+	gcose "github.com/veraison/go-cose"
+)
+
+// TODO: need inspect
+// don't know how to get envelope format if passed a local signature file
+// or verify with local signature
+// need a better way to inspect
+func GuessSignatureEnvelopeFormat(raw []byte) (string, error) {
+	var msg gcose.Sign1Message
+	if err := msg.UnmarshalCBOR(raw); err == nil {
+		return cose.MediaTypeEnvelope, nil
+	}
+	if len(raw) == 0 || raw[0] != '{' {
+		// very certain
+		return "", errors.New("unsupported signature format")
+	}
+	return jws.MediaTypeEnvelope, nil
+}

--- a/signature/plugin.go
+++ b/signature/plugin.go
@@ -16,7 +16,7 @@ import (
 // pluginSigner signs artifacts and generates signatures.
 type pluginSigner struct {
 	sigProvider       provider
-	mediaTypeEnvelope string
+	envelopeMediaType string
 	keyID             string
 	pluginConfig      map[string]string
 }
@@ -25,22 +25,38 @@ type pluginSigner struct {
 // by delegating the one or more operations to the named plugin,
 // as defined in
 // https://github.com/notaryproject/notaryproject/blob/main/specs/plugin-extensibility.md#signing-interfaces.
-func NewSignerPlugin(runner plugin.Runner, keyID string, mediaTypeEnvelope string, pluginConfig map[string]string) (notation.Signer, error) {
+func NewSignerPlugin(runner plugin.Runner, keyID string, pluginConfig map[string]string, envelopeMediaType string) (notation.Signer, error) {
 	if runner == nil {
 		return nil, errors.New("nil plugin runner")
 	}
 	if keyID == "" {
 		return nil, errors.New("nil signing keyID")
 	}
-	if mediaTypeEnvelope == "" {
-		return nil, errors.New("nil signing mediaTypeEnvelope")
+
+	extProvider, err := newExternalProvider(runner, keyID)
+	if err != nil {
+		return nil, err
 	}
-	return &pluginSigner{
-		sigProvider:       newExternalProvider(runner, keyID),
-		mediaTypeEnvelope: mediaTypeEnvelope,
+	signer := &pluginSigner{
+		sigProvider:       extProvider,
+		envelopeMediaType: envelopeMediaType,
 		keyID:             keyID,
 		pluginConfig:      pluginConfig,
-	}, nil
+	}
+	if err := signer.validate(); err != nil {
+		return nil, err
+	}
+	return signer, nil
+}
+
+// validate validate envelopeMediaType
+func (s *pluginSigner) validate() error {
+	for _, types := range signature.RegisteredEnvelopeTypes() {
+		if s.envelopeMediaType == types {
+			return nil
+		}
+	}
+	return errors.New("nil signing mediaTypeEnvelope")
 }
 
 // Sign signs the artifact described by its descriptor, and returns the signature.
@@ -92,6 +108,7 @@ func (s *pluginSigner) describeKey(ctx context.Context, config map[string]string
 	if !ok {
 		return nil, fmt.Errorf("plugin runner returned incorrect describe-key response type '%T'", out)
 	}
+	// TODO: validate cert chain here?
 	return resp, nil
 }
 
@@ -126,6 +143,7 @@ func (s *pluginSigner) generateSignature(ctx context.Context, desc notation.Desc
 		SigningTime:              time.Now(),
 		ExtendedSignedAttributes: nil,
 		SigningAgent:             notation.SigningAgent,
+		SigningScheme:            signature.SigningSchemeX509,
 	}
 
 	if !opts.Expiry.IsZero() {
@@ -133,7 +151,7 @@ func (s *pluginSigner) generateSignature(ctx context.Context, desc notation.Desc
 	}
 
 	// perform signing using pluginSigProvider
-	sigEnv, err := signature.NewEnvelope(s.mediaTypeEnvelope)
+	sigEnv, err := signature.NewEnvelope(s.envelopeMediaType)
 	if err != nil {
 		return nil, err
 	}
@@ -145,7 +163,7 @@ func (s *pluginSigner) generateSignature(ctx context.Context, desc notation.Desc
 
 	_, _, verErr := sigEnv.Verify()
 	if verErr != nil {
-		return nil, fmt.Errorf("signature returned by generateSignature cannot be verified: %v", err)
+		return nil, fmt.Errorf("signature returned by generateSignature cannot be verified: %v", verErr)
 	}
 
 	// TODO: re-enable timestamping https://github.com/notaryproject/notation-go/issues/78
@@ -176,7 +194,7 @@ func (s *pluginSigner) generateSignatureEnvelope(ctx context.Context, desc notat
 		ContractVersion:       plugin.ContractVersion,
 		KeyID:                 s.keyID,
 		Payload:               payloadBytes,
-		SignatureEnvelopeType: s.mediaTypeEnvelope,
+		SignatureEnvelopeType: s.envelopeMediaType,
 		PayloadType:           signature.MediaTypePayloadV1,
 		PluginConfig:          s.mergeConfig(opts.PluginConfig),
 	}
@@ -197,7 +215,7 @@ func (s *pluginSigner) generateSignatureEnvelope(ctx context.Context, desc notat
 		)
 	}
 
-	sigEnv, err := signature.ParseEnvelope(s.mediaTypeEnvelope, resp.SignatureEnvelope)
+	sigEnv, err := signature.ParseEnvelope(s.envelopeMediaType, resp.SignatureEnvelope)
 	if err != nil {
 		return nil, err
 	}

--- a/verification/types.go
+++ b/verification/types.go
@@ -2,7 +2,8 @@ package verification
 
 import (
 	"fmt"
-	nsigner "github.com/notaryproject/notation-core-go/signer"
+
+	"github.com/notaryproject/notation-core-go/signature"
 )
 
 // TrustStorePrefix is an enum for trust store prefixes supported such as "ca", "signingAuthority"
@@ -31,7 +32,9 @@ type VerificationResult struct {
 // and results for each verification type that was performed
 type SignatureVerificationOutcome struct {
 	// SignerInfo contains the details of the digital signature and associated metadata
-	SignerInfo *nsigner.SignerInfo
+	SignerInfo *signature.SignerInfo
+	// Signature payload contains the payload of an envelope
+	SignaturePayload *signature.Payload
 	// VerificationLevel describes what verification level was used for performing signature verification
 	VerificationLevel *VerificationLevel
 	// VerificationResults contains the verifications performed on the signature and their results


### PR DESCRIPTION
1. Move key and cert to the member fields of external provider.
2. Add `GuessSignatureEnvelopeFormat` to insepct signature format in a brute force manner.
3. Add validate to signer to ensure the envelope format is supported.
4. Bug fix and doc.

Signed-off-by: zaihaoyin <zaihaoyin@microsoft.com>