### PR TITLE
test:add signer,verifer,provider,algorithm unit tests

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,11 +4,11 @@ go 1.17
 
 require (
 	github.com/go-ldap/ldap/v3 v3.4.4
-	github.com/notaryproject/notation-core-go v0.0.0-20220822041019-9757c1e36233
+	github.com/notaryproject/notation-core-go v0.0.0-20220826063805-89bf7623e96a
 	github.com/opencontainers/go-digest v1.0.0
 	github.com/opencontainers/image-spec v1.0.2
 	github.com/oras-project/artifacts-spec v1.0.0-rc.2
-	github.com/veraison/go-cose v1.0.0-rc.1
+	github.com/veraison/go-cose v1.0.0-rc.1.0.20220824135457-9d2fab636b83
 	oras.land/oras-go/v2 v2.0.0-rc.2
 )
 

--- a/go.sum
+++ b/go.sum
@@ -11,8 +11,8 @@ github.com/go-ldap/ldap/v3 v3.4.4/go.mod h1:fe1MsuN5eJJ1FeLT/LEBVdWfNWKh459R7aXg
 github.com/golang-jwt/jwt/v4 v4.4.1/go.mod h1:m21LjoU+eqJr34lmDMbreY2eSTRJ1cv77w39/MY0Ch0=
 github.com/golang-jwt/jwt/v4 v4.4.2 h1:rcc4lwaZgFMCZ5jxF9ABolDcIHdBytAFgqFPbSJQAYs=
 github.com/golang-jwt/jwt/v4 v4.4.2/go.mod h1:m21LjoU+eqJr34lmDMbreY2eSTRJ1cv77w39/MY0Ch0=
-github.com/notaryproject/notation-core-go v0.0.0-20220822041019-9757c1e36233 h1:YCaXP/7YtyxgyiTVk8/o8yk4bqH3pRHBM/pHjanb9o4=
-github.com/notaryproject/notation-core-go v0.0.0-20220822041019-9757c1e36233/go.mod h1:KcUBZtOH3r3moiIbQ2h2ZJZ9QCOZ+W0rxHP8KBVnCbY=
+github.com/notaryproject/notation-core-go v0.0.0-20220826063805-89bf7623e96a h1:v0/8mzj8J7is8lF5tS8DYmw7pATcDL1PJQfCWjZQ+kM=
+github.com/notaryproject/notation-core-go v0.0.0-20220826063805-89bf7623e96a/go.mod h1:vRFI64uedpKUChiadJ/2q8jJNdKtxHa7Er1JbSnm8AY=
 github.com/opencontainers/distribution-spec/specs-go v0.0.0-20220620172159-4ab4752c3b86 h1:Oumw+lPnO8qNLTY2mrqPJZMoGExLi/0h/DdikoLTXVU=
 github.com/opencontainers/distribution-spec/specs-go v0.0.0-20220620172159-4ab4752c3b86/go.mod h1:aA4vdXRS8E1TG7pLZOz85InHi3BiPdErh8IpJN6E0x4=
 github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8Oi/yOhh5U=
@@ -26,8 +26,8 @@ github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZN
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.7.2 h1:4jaiDzPyXQvSd7D0EjG45355tLlV3VOECpq10pLC+8s=
 github.com/stretchr/testify v1.7.2/go.mod h1:R6va5+xMeoiuVRoj+gSkQ7d3FALtqAAGI1FQKckRals=
-github.com/veraison/go-cose v1.0.0-rc.1 h1:4qA7dbFJGvt7gcqv5MCIyCQvN+NpHFPkW7do3EeDLb8=
-github.com/veraison/go-cose v1.0.0-rc.1/go.mod h1:7ziE85vSq4ScFTg6wyoMXjucIGOf4JkFEZi/an96Ct4=
+github.com/veraison/go-cose v1.0.0-rc.1.0.20220824135457-9d2fab636b83 h1:g8vDfnNOPcGzg6mnlBGc0J5t5lAJkaepXqbc9qFRnFs=
+github.com/veraison/go-cose v1.0.0-rc.1.0.20220824135457-9d2fab636b83/go.mod h1:7ziE85vSq4ScFTg6wyoMXjucIGOf4JkFEZi/an96Ct4=
 github.com/x448/float16 v0.8.4 h1:qLwI1I70+NjRFUR3zs1JPUCgaCXSh3SW62uAKT1mSBM=
 github.com/x448/float16 v0.8.4/go.mod h1:14CWIYCyZA/cWjXOioeEpHeN/83MdbZDRQHoFcYsOfg=
 golang.org/x/crypto v0.0.0-20220622213112-05595931fe9d h1:sK3txAijHtOK88l68nt020reeT1ZdKLIYetKl95FzVY=

--- a/plugin/plugin.go
+++ b/plugin/plugin.go
@@ -127,14 +127,11 @@ type DescribeKeyResponse struct {
 	// https://github.com/notaryproject/notaryproject/blob/main/signature-specification.md#algorithm-selection
 	KeySpec string `json:"keySpec"`
 
-	// TODO: need to check new spec, now add a new field(CertificateChain) to response
 	// Ordered list of certificates starting with leaf certificate
 	// and ending with root certificate.
-	CertificateChain [][]byte `json:"certificateChain"`
 }
 
 // GenerateSignatureRequest contains the parameters passed in a generate-signature request.
-// TODO: need to check new spec
 // do we still need keyspec and hash?
 type GenerateSignatureRequest struct {
 	ContractVersion string            `json:"contractVersion"`
@@ -150,7 +147,6 @@ func (GenerateSignatureRequest) Command() Command {
 }
 
 // GenerateSignatureResponse is the response of a generate-signature request.
-// TODO: need to check new spec
 type GenerateSignatureResponse struct {
 	KeyID            string `json:"keyId"`
 	Signature        []byte `json:"signature"`

--- a/signature/algorithm.go
+++ b/signature/algorithm.go
@@ -5,20 +5,31 @@ import "github.com/notaryproject/notation-core-go/signature"
 // one of the following key spec name
 // https://github.com/notaryproject/notaryproject/blob/main/signature-specification.md#algorithm-selection
 const (
-	RSA_2048 = "RSA_2048"
-	RSA_3072 = "RSA_3072"
-	RSA_4096 = "RSA_4096"
-	EC_256   = "EC_256"
-	EC_384   = "EC_384"
-	EC_521   = "EC_521"
+	RSA_2048 = "RSA-2048"
+	RSA_3072 = "RSA-3072"
+	RSA_4096 = "RSA-4096"
+	EC_256   = "EC-256"
+	EC_384   = "EC-384"
+	EC_521   = "EC-521"
 )
 
 // one of the following hash name
 // https://github.com/notaryproject/notaryproject/blob/main/signature-specification.md#algorithm-selection
 const (
-	SHA_256 = "SHA_256"
-	SHA_384 = "SHA_384"
-	SHA_512 = "SHA_512"
+	SHA_256 = "SHA-256"
+	SHA_384 = "SHA-384"
+	SHA_512 = "SHA-512"
+)
+
+// one of the following signing algorithm name
+// https://github.com/notaryproject/notaryproject/blob/main/signature-specification.md#algorithm-selection
+const (
+	ECDSA_SHA_256      = "ECDSA-SHA-256"
+	ECDSA_SHA_384      = "ECDSA-SHA-384"
+	ECDSA_SHA_512      = "ECDSA-SHA-512"
+	RSASSA_PSS_SHA_256 = "RSASSA-PSS-SHA-256"
+	RSASSA_PSS_SHA_384 = "RSASSA-PSS-SHA-384"
+	RSASSA_PSS_SHA_512 = "RSASSA-PSS-SHA-512"
 )
 
 // KeySpecName returns the name of a keySpec according to the spec
@@ -71,7 +82,7 @@ func KeySpecHashName(k signature.KeySpec) string {
 	return ""
 }
 
-// ParseKeySpecFromName parses keyspec name to a signature.keySpec type
+// ParseKeySpecFromName parses keySpec name to a signature.keySpec type
 func ParseKeySpecFromName(raw string) (keySpec signature.KeySpec) {
 	switch raw {
 	case RSA_2048:
@@ -94,4 +105,42 @@ func ParseKeySpecFromName(raw string) (keySpec signature.KeySpec) {
 		keySpec.Type = signature.KeyTypeEC
 	}
 	return
+}
+
+// SigningAlgorithmName returns signing algorithm name of an algorithm according to the spec
+func SigningAlgorithmName(alg signature.Algorithm) string {
+	switch alg {
+	case signature.AlgorithmES256:
+		return ECDSA_SHA_256
+	case signature.AlgorithmES384:
+		return ECDSA_SHA_384
+	case signature.AlgorithmES512:
+		return ECDSA_SHA_512
+	case signature.AlgorithmPS256:
+		return RSASSA_PSS_SHA_256
+	case signature.AlgorithmPS384:
+		return RSASSA_PSS_SHA_384
+	case signature.AlgorithmPS512:
+		return RSASSA_PSS_SHA_512
+	}
+	return ""
+}
+
+// ParseSigningAlgorithFromName parses signing algorithm name from a given string
+func ParseSigningAlgorithFromName(raw string) signature.Algorithm {
+	switch raw {
+	case ECDSA_SHA_256:
+		return signature.AlgorithmES256
+	case ECDSA_SHA_384:
+		return signature.AlgorithmES384
+	case ECDSA_SHA_512:
+		return signature.AlgorithmES512
+	case RSASSA_PSS_SHA_256:
+		return signature.AlgorithmPS256
+	case RSASSA_PSS_SHA_384:
+		return signature.AlgorithmPS384
+	case RSASSA_PSS_SHA_512:
+		return signature.AlgorithmPS512
+	}
+	return 0
 }

--- a/signature/algorithm_test.go
+++ b/signature/algorithm_test.go
@@ -74,7 +74,7 @@ func TestKeySpecName(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			if name := KeySpecName(tt.keySpec); name != tt.expected {
-				t.Errorf("unexpected keySpec name, expect: %v, got: %v", tt.expected, name)
+				t.Fatalf("unexpected keySpec name, expect: %v, got: %v", tt.expected, name)
 			}
 		})
 	}
@@ -148,7 +148,7 @@ func TestKeySpecHashName(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			if name := KeySpecHashName(tt.keySpec); name != tt.expected {
-				t.Errorf("unexpected keySpec hash function name, expect: %v, got: %v", tt.expected, name)
+				t.Fatalf("unexpected keySpec hash function name, expect: %v, got: %v", tt.expected, name)
 			}
 		})
 	}
@@ -221,7 +221,109 @@ func TestParseKeySpecFromName(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			if keySpec := ParseKeySpecFromName(tt.raw); keySpec != tt.expected {
-				t.Errorf("unexpected pared keySpec name, expect: %v, got: %v", tt.expected, keySpec)
+				t.Fatalf("unexpected pared keySpec name, expect: %v, got: %v", tt.expected, keySpec)
+			}
+		})
+	}
+}
+
+func TestSigningAlgorithmName(t *testing.T) {
+	tests := []struct {
+		name     string
+		alg      signature.Algorithm
+		expected string
+	}{
+		{
+			name:     "RSASSA-PSS with SHA-256",
+			alg:      signature.AlgorithmPS256,
+			expected: RSASSA_PSS_SHA_256,
+		},
+		{
+			name:     "RSASSA-PSS with SHA-384",
+			alg:      signature.AlgorithmPS384,
+			expected: RSASSA_PSS_SHA_384,
+		},
+		{
+			name:     "RSASSA-PSS with SHA-512",
+			alg:      signature.AlgorithmPS512,
+			expected: RSASSA_PSS_SHA_512,
+		},
+		{
+			name:     "ECDSA on secp256r1 with SHA-256",
+			alg:      signature.AlgorithmES256,
+			expected: ECDSA_SHA_256,
+		},
+		{
+			name:     "ECDSA on secp384r1 with SHA-384",
+			alg:      signature.AlgorithmES384,
+			expected: ECDSA_SHA_384,
+		},
+		{
+			name:     "ECDSA on secp521r1 with SHA-512",
+			alg:      signature.AlgorithmES512,
+			expected: ECDSA_SHA_512,
+		},
+		{
+			name:     "unsupported algorithm",
+			alg:      0,
+			expected: "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if name := SigningAlgorithmName(tt.alg); name != tt.expected {
+				t.Fatalf("unexpected signing algorithm name, expect: %v, got: %v", tt.expected, name)
+			}
+		})
+	}
+}
+
+func TestParseSigningAlgorithFromName(t *testing.T) {
+	tests := []struct {
+		name     string
+		raw      string
+		expected signature.Algorithm
+	}{
+		{
+			name:     "RSASSA-PSS with SHA-256",
+			raw:      RSASSA_PSS_SHA_256,
+			expected: signature.AlgorithmPS256,
+		},
+		{
+			name:     "RSASSA-PSS with SHA-384",
+			raw:      RSASSA_PSS_SHA_384,
+			expected: signature.AlgorithmPS384,
+		},
+		{
+			name:     "RSASSA-PSS with SHA-512",
+			raw:      RSASSA_PSS_SHA_512,
+			expected: signature.AlgorithmPS512,
+		},
+		{
+			name:     "ECDSA on secp256r1 with SHA-256",
+			raw:      ECDSA_SHA_256,
+			expected: signature.AlgorithmES256,
+		},
+		{
+			name:     "ECDSA on secp384r1 with SHA-384",
+			raw:      ECDSA_SHA_384,
+			expected: signature.AlgorithmES384,
+		},
+		{
+			name:     "ECDSA on secp521r1 with SHA-512",
+			raw:      ECDSA_SHA_512,
+			expected: signature.AlgorithmES512,
+		},
+		{
+			name:     "unsupported algorithm",
+			raw:      "",
+			expected: 0,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if alg := ParseSigningAlgorithFromName(tt.raw); alg != tt.expected {
+				t.Fatalf("unexpected signing algorithm, expect: %v, got: %v", tt.expected, alg)
 			}
 		})
 	}

--- a/signature/algorithm_test.go
+++ b/signature/algorithm_test.go
@@ -6,7 +6,6 @@ import (
 	"github.com/notaryproject/notation-core-go/signature"
 )
 
-// TODO: keySpec may change, need to check new spec
 func TestKeySpecName(t *testing.T) {
 	tests := []struct {
 		name     string
@@ -80,7 +79,6 @@ func TestKeySpecName(t *testing.T) {
 	}
 }
 
-// TODO: hash name may change, need to check new spec
 func TestKeySpecHashName(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/signature/envelope.go
+++ b/signature/envelope.go
@@ -9,6 +9,7 @@ import (
 	gcose "github.com/veraison/go-cose"
 )
 
+// GuessSignatureEnvelopeFormat guesses envelope format by looping all builtin envelope format
 // TODO: need inspect
 // don't know how to get envelope format if passed a local signature file
 // or verify with local signature

--- a/signature/plugin.go
+++ b/signature/plugin.go
@@ -32,21 +32,15 @@ func NewSignerPlugin(runner plugin.Runner, keyID string, pluginConfig map[string
 	if keyID == "" {
 		return nil, errors.New("nil signing keyID")
 	}
-
-	extProvider, err := newExternalProvider(runner, keyID)
-	if err != nil {
-		return nil, err
-	}
 	if err := ValidateEnvelopeMediaType(envelopeMediaType); err != nil {
 		return nil, err
 	}
-	signer := &pluginSigner{
-		sigProvider:       extProvider,
+	return &pluginSigner{
+		sigProvider:       newExternalProvider(runner, keyID),
 		envelopeMediaType: envelopeMediaType,
 		keyID:             keyID,
 		pluginConfig:      pluginConfig,
-	}
-	return signer, nil
+	}, nil
 }
 
 // Sign signs the artifact described by its descriptor and returns the marshalled envelope
@@ -98,7 +92,6 @@ func (s *pluginSigner) describeKey(ctx context.Context, config map[string]string
 	if !ok {
 		return nil, fmt.Errorf("plugin runner returned incorrect describe-key response type '%T'", out)
 	}
-	// TODO: validate cert chain here?
 	return resp, nil
 }
 

--- a/signature/provider.go
+++ b/signature/provider.go
@@ -58,7 +58,6 @@ func (*builtinProvider) SetConfig(map[string]string) {
 
 // Run implement the plugin workflow.
 // only support metadata and describe key
-// TODO: how to return key spec
 func (p *builtinProvider) Run(_ context.Context, req plugin.Request) (interface{}, error) {
 	switch req.Command() {
 	case plugin.CommandGetMetadata:
@@ -83,24 +82,16 @@ type externalProvider struct {
 	plugin.Runner
 	keyID   string
 	config  map[string]string
-	keySpec signature.KeySpec
-	certs   []*x509.Certificate
+	keySpec *signature.KeySpec
 }
 
 // newExternalProvider create a external provider
 // It will call describe key command and save keySpec and certs to the provider
-func newExternalProvider(runner plugin.Runner, keyID string) (provider, error) {
-	p := &externalProvider{
+func newExternalProvider(runner plugin.Runner, keyID string) provider {
+	return &externalProvider{
 		Runner: runner,
 		keyID:  keyID,
 	}
-	keySpec, certs, err := p.keyInfo()
-	if err != nil {
-		return nil, err
-	}
-	p.keySpec = keySpec
-	p.certs = certs
-	return p, nil
 }
 
 // SetConfig setup config used by signing
@@ -126,69 +117,58 @@ func (p *externalProvider) describeKey(ctx context.Context) (*plugin.DescribeKey
 }
 
 // Sign sign the digest by calling the real plugin
-// TODO: new sign spec accept payload, not hashed digest, need changed after notation-core-go and spec updated
-func (p *externalProvider) Sign(digest []byte) ([]byte, error) {
+func (p *externalProvider) Sign(payload []byte) ([]byte, []*x509.Certificate, error) {
 	// Execute plugin sign command.
-	// TODO: do we still need keyspec and hash in request?
 	keySpec, err := p.KeySpec()
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	req := &plugin.GenerateSignatureRequest{
 		ContractVersion: plugin.ContractVersion,
 		KeyID:           p.keyID,
 		KeySpec:         KeySpecName(keySpec),
 		Hash:            KeySpecHashName(keySpec),
-		Payload:         digest,
+		Payload:         payload,
 		PluginConfig:    p.config,
 	}
 
 	out, err := p.Run(context.Background(), req)
 	if err != nil {
-		return nil, fmt.Errorf("generate-signature command failed: %w", err)
+		return nil, nil, fmt.Errorf("generate-signature command failed: %w", err)
 	}
 
 	resp, ok := out.(*plugin.GenerateSignatureResponse)
 	if !ok {
-		return nil, fmt.Errorf("plugin runner returned incorrect generate-signature response type '%T'", out)
+		return nil, nil, fmt.Errorf("plugin runner returned incorrect generate-signature response type '%T'", out)
 	}
 
 	// Check keyID is honored.
 	if req.KeyID != resp.KeyID {
-		return nil, fmt.Errorf("keyID in generateSignature response %q does not match request %q", resp.KeyID, req.KeyID)
+		return nil, nil, fmt.Errorf("keyID in generateSignature response %q does not match request %q", resp.KeyID, req.KeyID)
 	}
 
-	// TODO: do we still need cert chain in response?
-	if _, err = parseCertChain(resp.CertificateChain); err != nil {
-		return nil, err
+	var certs []*x509.Certificate
+	if certs, err = parseCertChain(resp.CertificateChain); err != nil {
+		return nil, nil, err
 	}
-
-	return resp.Signature, nil
-}
-
-func (p *externalProvider) keyInfo() (signature.KeySpec, []*x509.Certificate, error) {
-	keyResp, err := p.describeKey(context.Background())
-	if err != nil {
-		return signature.KeySpec{}, nil, err
-	}
-
-	// Check keyID is honored.
-	if p.keyID != keyResp.KeyID {
-		return signature.KeySpec{}, nil, fmt.Errorf("keyID in describeKey response %q does not match request %q", keyResp.KeyID, p.keyID)
-	}
-	certs, err := parseCertChain(keyResp.CertificateChain)
-	if err != nil {
-		return signature.KeySpec{}, nil, err
-	}
-	return ParseKeySpecFromName(keyResp.KeySpec), certs, nil
-}
-
-// CertificateChain returns cert chain of a keyID
-func (p *externalProvider) CertificateChain() ([]*x509.Certificate, error) {
-	return p.certs, nil
+	return resp.Signature, certs, nil
 }
 
 // KeySpec return s keyspec of a keyID
 func (p *externalProvider) KeySpec() (signature.KeySpec, error) {
-	return p.keySpec, nil
+	if p.keySpec != nil {
+		return *p.keySpec, nil
+	}
+	keyResp, err := p.describeKey(context.Background())
+	if err != nil {
+		return signature.KeySpec{}, err
+	}
+
+	// Check keyID is honored.
+	if p.keyID != keyResp.KeyID {
+		return signature.KeySpec{}, fmt.Errorf("keyID in describeKey response %q does not match request %q", keyResp.KeyID, p.keyID)
+	}
+	keySpec := ParseKeySpecFromName(keyResp.KeySpec)
+	p.keySpec = &keySpec
+	return keySpec, nil
 }

--- a/signature/provider_test.go
+++ b/signature/provider_test.go
@@ -1,0 +1,162 @@
+package signature
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	"github.com/notaryproject/notation-core-go/signature"
+	"github.com/notaryproject/notation-go/plugin"
+)
+
+func TestProvider_Builtin_NewProvider(t *testing.T) {
+	type builtinArgs struct {
+		*keyCertPair
+		expectedErr bool
+	}
+	tests := make([]builtinArgs, 0)
+	for _, keyCert := range keyCertPairCollections {
+		tests = append(tests, builtinArgs{
+			keyCert,
+			false,
+		})
+	}
+	key1, cert1, _ := generateKeyCertPair()
+	key2, cert2, _ := generateKeyCertPair()
+	tests = append(tests,
+		builtinArgs{
+			keyCertPair: &keyCertPair{
+				keySpecName: "no certs",
+				key:         key1,
+			},
+			expectedErr: true,
+		},
+		builtinArgs{
+			keyCertPair: &keyCertPair{
+				keySpecName: "no key",
+				certs:       cert2,
+			},
+			expectedErr: true,
+		},
+		builtinArgs{
+			keyCertPair: &keyCertPair{
+				keySpecName: "key cert mismatch",
+				key:         key2,
+				certs:       cert1,
+			},
+			expectedErr: true,
+		},
+	)
+	for _, tt := range tests {
+		t.Run(tt.keySpecName, func(t *testing.T) {
+			if _, err := newBuiltinProvider(tt.key, tt.certs); (err != nil) != tt.expectedErr {
+				t.Fatalf("new builtin provider failed, expectedErr: %v, got: %v", tt.expectedErr, err)
+			}
+		})
+	}
+}
+
+type customerCommand struct {
+}
+
+func (customerCommand) Command() plugin.Command {
+	return "customer"
+}
+
+func TestProvider_Builtin_Runner(t *testing.T) {
+	p, err := newBuiltinProvider(keyCertPairCollections[0].key, keyCertPairCollections[0].certs)
+	if err != nil {
+		t.Fatalf("expect newBuiltinProvider ok, got: %v", err)
+	}
+
+	tests := []struct {
+		name         string
+		req          plugin.Request
+		ExpectedResp interface{}
+		expectedErr  bool
+	}{
+		{
+			name:         string(plugin.CommandGetMetadata),
+			req:          &plugin.GetMetadataRequest{},
+			ExpectedResp: &builtInPluginMetaData,
+			expectedErr:  false,
+		},
+		{
+			name: string(plugin.CommandDescribeKey),
+			req: &plugin.DescribeKeyRequest{
+				KeyID: "key",
+			},
+			ExpectedResp: &plugin.DescribeKeyResponse{
+				KeyID: "key",
+			},
+			expectedErr: false,
+		},
+		{
+			name:         string("unsuppored command:" + plugin.CommandGenerateSignature),
+			req:          &plugin.GenerateSignatureRequest{},
+			ExpectedResp: nil,
+			expectedErr:  true,
+		},
+		{
+			name:         string("unsuppored command:" + plugin.CommandGenerateEnvelope),
+			req:          &plugin.GenerateEnvelopeRequest{},
+			ExpectedResp: nil,
+			expectedErr:  true,
+		},
+		{
+			name:         "unsupported customer command:",
+			req:          &customerCommand{},
+			ExpectedResp: nil,
+			expectedErr:  true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resp, err := p.Run(context.Background(), tt.req)
+			if (err != nil) != tt.expectedErr {
+				t.Fatalf("expect builtin runner run with err: %v, got: %v", tt.expectedErr, err)
+			}
+			if !reflect.DeepEqual(resp, tt.ExpectedResp) {
+				t.Fatalf("expect builtin ruuner run result: %v, got: %v", tt.ExpectedResp, resp)
+			}
+		})
+	}
+}
+
+func TestProvider_Builtin_Signer(t *testing.T) {
+	for _, keyCert := range keyCertPairCollections {
+		t.Run(keyCert.keySpecName, func(t *testing.T) {
+			p, err := newBuiltinProvider(keyCert.key, keyCert.certs)
+			if err != nil {
+				t.Fatalf("expect newBuiltInProvider ok, got: %v", err)
+			}
+			gotCert, err := p.CertificateChain()
+			if err != nil {
+				t.Fatalf("expect CertificateChain() ok, got: %v", err)
+			}
+			if !reflect.DeepEqual(gotCert, keyCert.certs) {
+				t.Fatalf("CertificateChain() cert changed")
+			}
+
+			if gotKey := p.(*builtinProvider).PrivateKey(); !reflect.DeepEqual(gotKey, keyCert.key) {
+				t.Fatalf("PrivateKey() key changed")
+			}
+
+			if _, err := p.Sign(nil); err == nil {
+				t.Fatalf("Sign() expect buitin sign method not implemented")
+			}
+
+			expectedKeySpec, err := signature.ExtractKeySpec(keyCert.certs[0])
+			if err != nil {
+				t.Fatalf("extract keySpec failed: %v", err)
+			}
+			gotKeySpec, err := p.KeySpec()
+			if err != nil {
+				t.Fatalf("expect keySpec ok, got: %v", err)
+			}
+			if !reflect.DeepEqual(gotKeySpec, expectedKeySpec) {
+				t.Fatalf("KeySpec() keySpec mismatch")
+			}
+		})
+	}
+}

--- a/signature/provider_test.go
+++ b/signature/provider_test.go
@@ -130,7 +130,7 @@ func TestProvider_Builtin_Signer(t *testing.T) {
 			if err != nil {
 				t.Fatalf("expect newBuiltInProvider ok, got: %v", err)
 			}
-			gotCert, err := p.CertificateChain()
+			gotCert, err := p.(*builtinProvider).CertificateChain()
 			if err != nil {
 				t.Fatalf("expect CertificateChain() ok, got: %v", err)
 			}
@@ -142,7 +142,7 @@ func TestProvider_Builtin_Signer(t *testing.T) {
 				t.Fatalf("PrivateKey() key changed")
 			}
 
-			if _, err := p.Sign(nil); err == nil {
+			if _, _, err = p.Sign(nil); err == nil {
 				t.Fatalf("Sign() expect buitin sign method not implemented")
 			}
 

--- a/signature/signer_test.go
+++ b/signature/signer_test.go
@@ -3,12 +3,16 @@ package signature
 import (
 	"context"
 	"crypto"
+	"crypto/ecdsa"
 	"crypto/elliptic"
 	"crypto/rand"
 	"crypto/rsa"
 	"crypto/x509"
+	"encoding/pem"
+	"errors"
 	"fmt"
-	"strconv"
+	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -16,10 +20,20 @@ import (
 	"github.com/notaryproject/notation-core-go/testhelper"
 	"github.com/notaryproject/notation-go"
 	"github.com/notaryproject/notation-go/crypto/timestamp/timestamptest"
+	"github.com/notaryproject/notation-go/plugin"
 	"github.com/opencontainers/go-digest"
 )
 
+type keyCertPair struct {
+	// keySpec name
+	keySpecName string
+	key         crypto.PrivateKey
+	certs       []*x509.Certificate
+}
+
 var keyCertPairCollections []*keyCertPair
+
+const testKeyID = "testKeyID"
 
 // setUpKeyCertPairCollections setups all combinations of private key and certificates
 func setUpKeyCertPairCollections() {
@@ -27,10 +41,14 @@ func setUpKeyCertPairCollections() {
 	for _, k := range []int{2048, 3072, 4096} {
 		rsaRoot := testhelper.GetRSARootCertificate()
 		certTuple := testhelper.GetRSACertTuple(k)
+		keySpec, err := signature.ExtractKeySpec(certTuple.Cert)
+		if err != nil {
+			panic(fmt.Sprintf("setUpKeyCertPairCollections() failed, invalid keySpec: %v", err))
+		}
 		keyCertPairCollections = append(keyCertPairCollections, &keyCertPair{
-			name:  "RSA_" + strconv.Itoa(k),
-			key:   certTuple.PrivateKey,
-			certs: []*x509.Certificate{certTuple.Cert, rsaRoot.Cert},
+			keySpecName: KeySpecName(keySpec),
+			key:         certTuple.PrivateKey,
+			certs:       []*x509.Certificate{certTuple.Cert, rsaRoot.Cert},
 		})
 	}
 
@@ -38,11 +56,14 @@ func setUpKeyCertPairCollections() {
 	for _, curve := range []elliptic.Curve{elliptic.P256(), elliptic.P384(), elliptic.P521()} {
 		ecdsaRoot := testhelper.GetECRootCertificate()
 		certTuple := testhelper.GetECCertTuple(curve)
-		bitSize := certTuple.PrivateKey.Params().BitSize
+		keySpec, err := signature.ExtractKeySpec(certTuple.Cert)
+		if err != nil {
+			panic(fmt.Sprintf("setUpKeyCertPairCollections() failed, invalid keySpec: %v", err))
+		}
 		keyCertPairCollections = append(keyCertPairCollections, &keyCertPair{
-			name:  "EC_" + strconv.Itoa(bitSize),
-			key:   certTuple.PrivateKey,
-			certs: []*x509.Certificate{certTuple.Cert, ecdsaRoot.Cert},
+			keySpecName: KeySpecName(keySpec),
+			key:         certTuple.PrivateKey,
+			certs:       []*x509.Certificate{certTuple.Cert, ecdsaRoot.Cert},
 		})
 	}
 }
@@ -51,15 +72,81 @@ func init() {
 	setUpKeyCertPairCollections()
 }
 
+func generateCertPem(cert *x509.Certificate) []byte {
+	return pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: cert.Raw})
+}
+
+func generateKeyBytes(key crypto.PrivateKey) (keyBytes []byte, err error) {
+	switch k := key.(type) {
+	case *rsa.PrivateKey:
+		keyBytes, err = x509.MarshalPKCS8PrivateKey(k)
+	case *ecdsa.PrivateKey:
+		keyBytes, err = x509.MarshalECPrivateKey(k)
+	default:
+		return nil, errors.New("private key type not supported")
+	}
+	if err != nil {
+		return nil, err
+	}
+	keyBytes = pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: keyBytes})
+	return keyBytes, nil
+}
+
+func prepareTestKeyCertFile(keyCert *keyCertPair, envelopeType, dir string) (string, string, error) {
+	keyPath, certPath := filepath.Join(dir, keyCert.keySpecName+".key"), filepath.Join(dir, keyCert.keySpecName+".cert")
+	keyBytes, err := generateKeyBytes(keyCert.key)
+	if err != nil {
+		return "", "", err
+	}
+	var certBytes []byte
+	for _, cert := range keyCert.certs {
+		certBytes = append(certBytes, generateCertPem(cert)...)
+	}
+
+	if err := os.WriteFile(keyPath, keyBytes, 0666); err != nil {
+		return "", "", err
+	}
+	if err := os.WriteFile(certPath, certBytes, 0666); err != nil {
+		return "", "", err
+	}
+	return keyPath, certPath, nil
+}
+
+func testSignerFromFile(t *testing.T, keyCert *keyCertPair, envelopeType, dir string) {
+	keyPath, certPath, err := prepareTestKeyCertFile(keyCert, envelopeType, dir)
+	if err != nil {
+		t.Fatalf("prepareTestKeyCertFile() failed: %v", err)
+	}
+	s, err := NewSignerFromFiles(keyPath, certPath, envelopeType)
+	if err != nil {
+		t.Fatalf("NewSignerFromFiles() failed: %v", err)
+	}
+	desc, opts := generateSigningContent(nil)
+	sig, err := s.Sign(context.Background(), desc, opts)
+	if err != nil {
+		t.Fatalf("Sign() failed: %v", err)
+	}
+	// basic verification
+	basicVerification(t, sig, envelopeType, keyCert.certs[len(keyCert.certs)-1])
+}
+
 func TestNewSignerFromFiles(t *testing.T) {
-	t.Skip("Please implement TestNewSignerFromFiles test")
+	// sign with key
+	dir := t.TempDir()
+	for _, envelopeType := range signature.RegisteredEnvelopeTypes() {
+		for _, keyCert := range keyCertPairCollections {
+			t.Run(fmt.Sprintf("envelopeType:%v,keySpec:%v", envelopeType, keyCert.keySpecName), func(t *testing.T) {
+				testSignerFromFile(t, keyCert, envelopeType, dir)
+			})
+		}
+	}
 }
 
 func TestSignWithCertChain(t *testing.T) {
 	// sign with key
 	for _, envelopeType := range signature.RegisteredEnvelopeTypes() {
 		for _, keyCert := range keyCertPairCollections {
-			t.Run(fmt.Sprintf("envelopeType:%v,keySpec:%v", envelopeType, keyCert.name), func(t *testing.T) {
+			t.Run(fmt.Sprintf("envelopeType:%v,keySpec:%v", envelopeType, keyCert.keySpecName), func(t *testing.T) {
 				validateSignWithCerts(t, envelopeType, keyCert.key, keyCert.certs)
 			})
 		}
@@ -72,7 +159,7 @@ func TestSignWithTimestamp(t *testing.T) {
 	// prepare signer
 	for _, envelopeType := range signature.RegisteredEnvelopeTypes() {
 		for _, keyCert := range keyCertPairCollections {
-			t.Run(fmt.Sprintf("envelopeType:%v,keySpec:%v", envelopeType, keyCert.name), func(t *testing.T) {
+			t.Run(fmt.Sprintf("envelopeType:%v,keySpec:%v", envelopeType, keyCert.keySpecName), func(t *testing.T) {
 				s, err := NewSigner(keyCert.key, keyCert.certs, envelopeType)
 				if err != nil {
 					t.Fatalf("NewSigner() error = %v", err)
@@ -103,7 +190,7 @@ func TestSignWithoutExpiry(t *testing.T) {
 	// sign with key
 	for _, envelopeType := range signature.RegisteredEnvelopeTypes() {
 		for _, keyCert := range keyCertPairCollections {
-			t.Run(fmt.Sprintf("envelopeType:%v,keySpec:%v", envelopeType, keyCert.name), func(t *testing.T) {
+			t.Run(fmt.Sprintf("envelopeType:%v,keySpec:%v", envelopeType, keyCert.keySpecName), func(t *testing.T) {
 				s, err := NewSigner(keyCert.key, keyCert.certs, envelopeType)
 				if err != nil {
 					t.Fatalf("NewSigner() error = %v", err)
@@ -117,6 +204,101 @@ func TestSignWithoutExpiry(t *testing.T) {
 					t.Fatalf("Sign() error = %v", err)
 				}
 
+				// basic verification
+				basicVerification(t, sig, envelopeType, keyCert.certs[len(keyCert.certs)-1])
+			})
+		}
+	}
+}
+
+func signRSA(digest []byte, hash crypto.Hash, pk *rsa.PrivateKey) ([]byte, error) {
+	return rsa.SignPSS(rand.Reader, pk, hash, digest, &rsa.PSSOptions{SaltLength: rsa.PSSSaltLengthEqualsHash})
+}
+
+func signECDSA(digest []byte, hash crypto.Hash, pk *ecdsa.PrivateKey) ([]byte, error) {
+	r, s, err := ecdsa.Sign(rand.Reader, pk, digest)
+	if err != nil {
+		return nil, err
+	}
+	n := (pk.Curve.Params().N.BitLen() + 7) / 8
+	sig := make([]byte, 2*n)
+	r.FillBytes(sig[:n])
+	s.FillBytes(sig[n:])
+	return sig, nil
+}
+
+func localSign(digest []byte, hash crypto.Hash, pk crypto.PrivateKey) ([]byte, error) {
+	switch key := pk.(type) {
+	case *rsa.PrivateKey:
+		return signRSA(digest, hash, key)
+	case *ecdsa.PrivateKey:
+		return signECDSA(digest, hash, key)
+	default:
+		return nil, errors.New("signing private key not supported")
+	}
+}
+
+func TestExternalSigner_Sign(t *testing.T) {
+	for _, envelopeType := range signature.RegisteredEnvelopeTypes() {
+		for _, keyCert := range keyCertPairCollections {
+			var rawCerts [][]byte
+			for _, cert := range keyCert.certs {
+				rawCerts = append(rawCerts, cert.Raw)
+			}
+			externalRunner := newMockRunner(
+				mockRunnerWithMetaData(validMetaDataWithSigningCapabilityFunc),
+				mockRunnerWithDescribeKey(func(ctx context.Context, r plugin.Request) (interface{}, error) {
+					return &plugin.DescribeKeyResponse{
+						KeyID:            r.(*plugin.DescribeKeyRequest).KeyID,
+						KeySpec:          keyCert.keySpecName,
+						CertificateChain: rawCerts,
+					}, nil
+				}),
+				mockRunnerWithGenerateSignature(func(ctx context.Context, r plugin.Request) (interface{}, error) {
+					req := r.(*plugin.GenerateSignatureRequest)
+					keySpec := ParseKeySpecFromName(req.KeySpec)
+					sig, err := localSign(req.Payload, keySpec.SignatureAlgorithm().Hash(), keyCert.key)
+					if err != nil {
+						return nil, fmt.Errorf("mock local sign failed: %v", err)
+					}
+					return &plugin.GenerateSignatureResponse{
+						KeyID:            req.KeyID,
+						Signature:        sig,
+						SigningAlgorithm: SigningAlgorithmName(keySpec.SignatureAlgorithm()),
+						CertificateChain: rawCerts,
+					}, nil
+				}),
+			)
+			s, err := NewSignerPlugin(externalRunner, testKeyID, nil, envelopeType)
+			if err != nil {
+				t.Fatalf("NewSigner() error = %v", err)
+			}
+			sig, err := s.Sign(context.Background(), validSignDescriptor, validSignOpts)
+			if err != nil {
+				t.Fatalf("Sign() error = %v", err)
+			}
+			// basic verification
+			basicVerification(t, sig, envelopeType, keyCert.certs[len(keyCert.certs)-1])
+		}
+	}
+}
+
+func TestExternalSigner_SignEnvelope(t *testing.T) {
+	for _, envelopeType := range signature.RegisteredEnvelopeTypes() {
+		for _, keyCert := range keyCertPairCollections {
+			t.Run(fmt.Sprintf("envelopeType:%v,keySpec:%v", envelopeType, keyCert.keySpecName), func(t *testing.T) {
+				p, err := newExternalProvider(newMockEnvelopeProvider(keyCert), testKeyID)
+				if err != nil {
+					t.Fatalf("newExternalProvider() create runner for external signer failed: %v", err)
+				}
+				s, err := NewSignerPlugin(p, testKeyID, nil, envelopeType)
+				if err != nil {
+					t.Fatalf("NewSigner() error = %v", err)
+				}
+				sig, err := s.Sign(context.Background(), validSignDescriptor, validSignOpts)
+				if err != nil {
+					t.Fatalf("Sign() error = %v", err)
+				}
 				// basic verification
 				basicVerification(t, sig, envelopeType, keyCert.certs[len(keyCert.certs)-1])
 			})

--- a/signature/verifier_test.go
+++ b/signature/verifier_test.go
@@ -55,7 +55,7 @@ func TestNewVerifierFromFile(t *testing.T) {
 	dir := t.TempDir()
 	for _, envelopeType := range signature.RegisteredEnvelopeTypes() {
 		for _, keyCert := range keyCertPairCollections {
-			t.Run(fmt.Sprintf("envelopeType:%v,keySpec:%v", envelopeType, keyCert.keySpecName), func(t *testing.T) {
+			t.Run(fmt.Sprintf("envelopeType=%v_keySpec=%v", envelopeType, keyCert.keySpecName), func(t *testing.T) {
 				testVerifierFromFile(t, keyCert, envelopeType, dir)
 			})
 		}
@@ -66,7 +66,7 @@ func TestVerifyWithCertChain(t *testing.T) {
 	// sign with key
 	for _, envelopeType := range signature.RegisteredEnvelopeTypes() {
 		for _, keyCert := range keyCertPairCollections {
-			t.Run(fmt.Sprintf("envelopeType:%v,keySpec:%v", envelopeType, keyCert.keySpecName), func(t *testing.T) {
+			t.Run(fmt.Sprintf("envelopeType=%v_keySpec=%v", envelopeType, keyCert.keySpecName), func(t *testing.T) {
 				s, err := NewSigner(keyCert.key, keyCert.certs, envelopeType)
 				if err != nil {
 					t.Fatalf("NewSigner() error = %v", err)

--- a/signature/verifier_test.go
+++ b/signature/verifier_test.go
@@ -17,11 +17,56 @@ func TestVerifierInterface(t *testing.T) {
 	}
 }
 
+func testVerifierFromFile(t *testing.T, keyCert *keyCertPair, envelopeType, dir string) {
+	keyPath, certPath, err := prepareTestKeyCertFile(keyCert, envelopeType, dir)
+	if err != nil {
+		t.Fatalf("prepare key cert file failed: %v", err)
+	}
+	s, err := NewSignerFromFiles(keyPath, certPath, envelopeType)
+	if err != nil {
+		t.Fatalf("NewSignerFromFiles() failed: %v", err)
+	}
+	desc, opts := generateSigningContent(nil)
+	sig, err := s.Sign(context.Background(), desc, opts)
+	if err != nil {
+		t.Fatalf("Sign() failed: %v", err)
+	}
+	// verify signature
+	v, err := NewVerifierFromFiles([]string{certPath})
+	if err != nil {
+		t.Fatalf("NewVerifierFromFiles() failed: %v", err)
+	}
+	vOpts := notation.VerifyOptions{
+		SignatureMediaType: envelopeType,
+	}
+	got, err := v.Verify(context.Background(), sig, vOpts)
+	if err != nil {
+		t.Fatalf("Verify() error = %v", err)
+	}
+	if !got.Equal(desc) {
+		t.Errorf("Verify() Descriptor = %v, want %v", got, desc)
+	}
+	if !reflect.DeepEqual(got, desc) {
+		t.Errorf("Verify() Descriptor = %v, want %v", got, desc)
+	}
+}
+
+func TestNewVerifierFromFile(t *testing.T) {
+	dir := t.TempDir()
+	for _, envelopeType := range signature.RegisteredEnvelopeTypes() {
+		for _, keyCert := range keyCertPairCollections {
+			t.Run(fmt.Sprintf("envelopeType:%v,keySpec:%v", envelopeType, keyCert.keySpecName), func(t *testing.T) {
+				testVerifierFromFile(t, keyCert, envelopeType, dir)
+			})
+		}
+	}
+}
+
 func TestVerifyWithCertChain(t *testing.T) {
 	// sign with key
 	for _, envelopeType := range signature.RegisteredEnvelopeTypes() {
 		for _, keyCert := range keyCertPairCollections {
-			t.Run(fmt.Sprintf("envelopeType:%v,keySpec:%v", envelopeType, keyCert.name), func(t *testing.T) {
+			t.Run(fmt.Sprintf("envelopeType:%v,keySpec:%v", envelopeType, keyCert.keySpecName), func(t *testing.T) {
 				s, err := NewSigner(keyCert.key, keyCert.certs, envelopeType)
 				if err != nil {
 					t.Fatalf("NewSigner() error = %v", err)


### PR DESCRIPTION
1. Add more signer and verifier tests (test signer/verifier from file)
2. Update algorithm according to new [spec](https://github.com/notaryproject/notaryproject/blob/main/specs/plugin-extensibility.md)
3. Add provider test

```
go test ./signature -cover -count=1   
ok      github.com/notaryproject/notation-go/signature  6.153s  coverage: 87.4% of statements
```
Signed-off-by: zaihaoyin <zaihaoyin@microsoft.com>