### PR TITLE
fix:fix broken verification unit tests

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.17
 
 require (
 	github.com/go-ldap/ldap/v3 v3.4.4
-	github.com/notaryproject/notation-core-go v0.0.0-20220826063805-89bf7623e96a
+	github.com/notaryproject/notation-core-go v0.0.0-20220831054755-60059d52bd31
 	github.com/opencontainers/go-digest v1.0.0
 	github.com/opencontainers/image-spec v1.0.2
 	github.com/oras-project/artifacts-spec v1.0.0-rc.2

--- a/go.sum
+++ b/go.sum
@@ -11,8 +11,8 @@ github.com/go-ldap/ldap/v3 v3.4.4/go.mod h1:fe1MsuN5eJJ1FeLT/LEBVdWfNWKh459R7aXg
 github.com/golang-jwt/jwt/v4 v4.4.1/go.mod h1:m21LjoU+eqJr34lmDMbreY2eSTRJ1cv77w39/MY0Ch0=
 github.com/golang-jwt/jwt/v4 v4.4.2 h1:rcc4lwaZgFMCZ5jxF9ABolDcIHdBytAFgqFPbSJQAYs=
 github.com/golang-jwt/jwt/v4 v4.4.2/go.mod h1:m21LjoU+eqJr34lmDMbreY2eSTRJ1cv77w39/MY0Ch0=
-github.com/notaryproject/notation-core-go v0.0.0-20220826063805-89bf7623e96a h1:v0/8mzj8J7is8lF5tS8DYmw7pATcDL1PJQfCWjZQ+kM=
-github.com/notaryproject/notation-core-go v0.0.0-20220826063805-89bf7623e96a/go.mod h1:vRFI64uedpKUChiadJ/2q8jJNdKtxHa7Er1JbSnm8AY=
+github.com/notaryproject/notation-core-go v0.0.0-20220831054755-60059d52bd31 h1:4Bo6TEDpc+vtF7Z/tFld2l8mLnLHaUK0BjwKyNzUMvA=
+github.com/notaryproject/notation-core-go v0.0.0-20220831054755-60059d52bd31/go.mod h1:vRFI64uedpKUChiadJ/2q8jJNdKtxHa7Er1JbSnm8AY=
 github.com/opencontainers/distribution-spec/specs-go v0.0.0-20220620172159-4ab4752c3b86 h1:Oumw+lPnO8qNLTY2mrqPJZMoGExLi/0h/DdikoLTXVU=
 github.com/opencontainers/distribution-spec/specs-go v0.0.0-20220620172159-4ab4752c3b86/go.mod h1:aA4vdXRS8E1TG7pLZOz85InHi3BiPdErh8IpJN6E0x4=
 github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8Oi/yOhh5U=

--- a/plugin/plugin.go
+++ b/plugin/plugin.go
@@ -196,13 +196,11 @@ type Signature struct {
 // CriticalAttributes contains all Notary V2 defined critical
 // attributes and their values in the signature envelope
 type CriticalAttributes struct {
-	ContentType                  string                 `json:"contentType"`
-	SigningScheme                string                 `json:"signingScheme"`
-	Expiry                       *time.Time             `json:"expiry,omitempty"`
-	AuthenticSigningTime         *time.Time             `json:"authenticSigningTime,omitempty"`
-	VerificationPlugin           string                 `json:"verificationPlugin,omitempty"`
-	VerificationPluginMinVersion string                 `json:"verificationPluginMinVersion,omitempty"`
-	ExtendedAttributes           map[string]interface{} `json:"extendedAttributes,omitempty"`
+	ContentType          string                 `json:"contentType"`
+	SigningScheme        string                 `json:"signingScheme"`
+	Expiry               *time.Time             `json:"expiry,omitempty"`
+	AuthenticSigningTime *time.Time             `json:"authenticSigningTime,omitempty"`
+	ExtendedAttributes   map[string]interface{} `json:"extendedAttributes,omitempty"`
 }
 
 // TrustPolicy represents trusted identities that sign the artifacts

--- a/signature/plugin_test.go
+++ b/signature/plugin_test.go
@@ -41,9 +41,6 @@ var (
 )
 
 var (
-	validMetaDataWithSigningCapabilityFunc = func(ctx context.Context, req plugin.Request) (interface{}, error) {
-		return &validMetadata, nil
-	}
 	validMetaDataWithEnvelopeGeneratorCapabilityFunc = func(ctx context.Context, req plugin.Request) (interface{}, error) {
 		metaData := validMetadata
 		metaData.Capabilities = []plugin.Capability{plugin.CapabilityEnvelopeGenerator}

--- a/signature/provider_test.go
+++ b/signature/provider_test.go
@@ -14,7 +14,7 @@ func TestProvider_Builtin_NewProvider(t *testing.T) {
 		*keyCertPair
 		expectedErr bool
 	}
-	tests := make([]builtinArgs, 0)
+	var tests []builtinArgs
 	for _, keyCert := range keyCertPairCollections {
 		tests = append(tests, builtinArgs{
 			keyCert,
@@ -56,8 +56,7 @@ func TestProvider_Builtin_NewProvider(t *testing.T) {
 	}
 }
 
-type customerCommand struct {
-}
+type customerCommand struct{}
 
 func (customerCommand) Command() plugin.Command {
 	return "customer"

--- a/verification/helpers_test.go
+++ b/verification/helpers_test.go
@@ -48,6 +48,9 @@ func TestLoadPolicyDocument(t *testing.T) {
 	// existing invalid json file
 	path := filepath.Join(t.TempDir(), "invalid.json")
 	err = ioutil.WriteFile(path, []byte(`{"invalid`), 0644)
+	if err != nil {
+		t.Fatalf("TestLoadPolicyDocument create invalid policy file failed. Error: %v", err)
+	}
 	_, err = loadPolicyDocument(path)
 	if err == nil {
 		t.Fatalf("TestLoadPolicyDocument should throw error for invalid policy file. Error: %v", err)
@@ -58,6 +61,9 @@ func TestLoadPolicyDocument(t *testing.T) {
 	policyDoc1 := dummyPolicyDocument()
 	policyJson, _ := json.Marshal(policyDoc1)
 	err = ioutil.WriteFile(path, policyJson, 0644)
+	if err != nil {
+		t.Fatalf("TestLoadPolicyDocument create valid policy file failed. Error: %v", err)
+	}
 	_, err = loadPolicyDocument(path)
 	if err != nil {
 		t.Fatalf("TestLoadPolicyDocument should not throw error for an existing policy file. Error: %v", err)
@@ -76,6 +82,9 @@ func TestLoadX509TrustStore(t *testing.T) {
 		),
 	}
 	caTrustStores, err := loadX509TrustStores(signature.SigningSchemeX509, &dummyPolicy, path)
+	if err != nil {
+		t.Fatalf("TestLoadX509TrustStore should not throw error for a valid trust store. Error: %v", err)
+	}
 	saTrustStores, err := loadX509TrustStores(signature.SigningSchemeX509SigningAuthority, &dummyPolicy, path)
 	if err != nil {
 		t.Fatalf("TestLoadX509TrustStore should not throw error for a valid trust store. Error: %v", err)

--- a/verification/types.go
+++ b/verification/types.go
@@ -224,7 +224,7 @@ func WithPluginConfig(ctx context.Context, config map[string]string) context.Con
 }
 
 // getPluginConfig used to retrieve the config from the context.
-func getPluginConfig(ctx context.Context, config map[string]string) map[string]string {
+func getPluginConfig(ctx context.Context) map[string]string {
 	config, ok := ctx.Value(pluginConfigCtxKey{}).(map[string]string)
 	if !ok {
 		return nil

--- a/verification/verifier_test.go
+++ b/verification/verifier_test.go
@@ -14,6 +14,9 @@ import (
 	"github.com/notaryproject/notation-go/plugin"
 	"github.com/notaryproject/notation-go/plugin/manager"
 	"github.com/notaryproject/notation-go/registry"
+
+	_ "github.com/notaryproject/notation-core-go/signature/cose"
+	_ "github.com/notaryproject/notation-core-go/signature/jws"
 )
 
 func verifyResult(outcome *SignatureVerificationOutcome, expectedResult VerificationResult, expectedErr error, t *testing.T) {
@@ -255,7 +258,7 @@ func assertNotationVerification(t *testing.T, scheme signature.SigningScheme) {
 		policyDocument := dummyPolicyDocument()
 		repo := mock.NewRepository()
 		repo.GetResponse = invalidSigEnv
-		expectedErr := fmt.Errorf("signature is invalid. Error: illegal base64 data at input byte 242")
+		expectedErr := fmt.Errorf("payload error: illegal base64 data at input byte 242")
 		testCases = append(testCases, testCase{
 			verificationType:  Integrity,
 			verificationLevel: level,
@@ -443,7 +446,7 @@ func assertPluginVerification(scheme signature.SigningScheme, t *testing.T) {
 				Success: true,
 			},
 		},
-		ProcessedAttributes: []string{mock.PluginExtendedCriticalAttribute.Key},
+		ProcessedAttributes: []string{mock.PluginExtendedCriticalAttribute.Key, VerificationPlugin},
 	}
 
 	verifier = Verifier{
@@ -467,7 +470,7 @@ func assertPluginVerification(scheme signature.SigningScheme, t *testing.T) {
 				Reason:  "i feel like failing today",
 			},
 		},
-		ProcessedAttributes: []string{mock.PluginExtendedCriticalAttribute.Key},
+		ProcessedAttributes: []string{mock.PluginExtendedCriticalAttribute.Key, VerificationPlugin},
 	}
 
 	verifier = Verifier{
@@ -490,7 +493,7 @@ func assertPluginVerification(scheme signature.SigningScheme, t *testing.T) {
 				Success: true,
 			},
 		},
-		ProcessedAttributes: []string{mock.PluginExtendedCriticalAttribute.Key},
+		ProcessedAttributes: []string{mock.PluginExtendedCriticalAttribute.Key, VerificationPlugin},
 	}
 
 	verifier = Verifier{
@@ -514,7 +517,7 @@ func assertPluginVerification(scheme signature.SigningScheme, t *testing.T) {
 				Reason:  "i feel like failing today",
 			},
 		},
-		ProcessedAttributes: []string{mock.PluginExtendedCriticalAttribute.Key},
+		ProcessedAttributes: []string{mock.PluginExtendedCriticalAttribute.Key, VerificationPlugin},
 	}
 
 	verifier = Verifier{
@@ -540,7 +543,7 @@ func assertPluginVerification(scheme signature.SigningScheme, t *testing.T) {
 				Success: true,
 			},
 		},
-		ProcessedAttributes: []string{mock.PluginExtendedCriticalAttribute.Key},
+		ProcessedAttributes: []string{mock.PluginExtendedCriticalAttribute.Key, VerificationPlugin},
 	}
 
 	verifier = Verifier{
@@ -583,7 +586,6 @@ func assertPluginVerification(scheme signature.SigningScheme, t *testing.T) {
 		PathManager:    path,
 	}
 	outcomes, err = verifier.Verify(context.Background(), mock.SampleArtifactUri)
-	outcomes, err = verifier.Verify(context.Background(), mock.SampleArtifactUri)
 	if err == nil || outcomes[0].Error == nil || outcomes[0].Error.Error() != "verification plugin \"plugin-name\" returned unexpected response : \"invalid plugin response\"" {
 		t.Fatalf("verification should fail when the verification plugin returns unexpected response. error : %v", outcomes[0].Error)
 	}
@@ -597,7 +599,7 @@ func assertPluginVerification(scheme signature.SigningScheme, t *testing.T) {
 				Success: true,
 			},
 		},
-		ProcessedAttributes: []string{}, // exclude the critical attribute
+		ProcessedAttributes: []string{VerificationPlugin}, // exclude the critical attribute
 	}
 
 	verifier = Verifier{
@@ -616,7 +618,7 @@ func assertPluginVerification(scheme signature.SigningScheme, t *testing.T) {
 	pluginManager.PluginCapabilities = []plugin.Capability{plugin.CapabilityTrustedIdentityVerifier}
 	pluginManager.PluginRunnerExecuteResponse = &plugin.VerifySignatureResponse{
 		VerificationResults: map[plugin.VerificationCapability]*plugin.VerificationResult{},
-		ProcessedAttributes: []string{mock.PluginExtendedCriticalAttribute.Key},
+		ProcessedAttributes: []string{mock.PluginExtendedCriticalAttribute.Key, VerificationPlugin},
 	}
 
 	verifier = Verifier{


### PR DESCRIPTION
1. Remove `VerificationPlugin` and `VerificationPluginMinVersion` from plugin's critical attribute
2. Fix broken tests (mostly error msg changes)

Signed-off-by: zaihaoyin <zaihaoyin@microsoft.com>