### PR TITLE
feat: dir package allows user to define user/system write level

### DIFF
--- a/config/base.go
+++ b/config/base.go
@@ -4,21 +4,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
-
-	"github.com/notaryproject/notation-go/dir"
 )
-
-var (
-	// ConfigPath is the path for config.json
-	ConfigPath string
-	// SigningKeysPath is the path for signingkeys.json
-	SigningKeysPath string
-)
-
-func init() {
-	ConfigPath = dir.Path.Config()
-	SigningKeysPath = dir.Path.SigningKeyConfig()
-}
 
 // save stores the cfg struct to file
 func save(filePath string, cfg interface{}) error {

--- a/config/config.go
+++ b/config/config.go
@@ -23,6 +23,8 @@ type Config struct {
 	InsecureRegistries       []string                 `json:"insecureRegistries"`
 	CredentialsStore         string                   `json:"credsStore,omitempty"`
 	CredentialHelpers        map[string]string        `json:"credHelpers,omitempty"`
+	// EnvelopeType defines the envelope type for signing
+	EnvelopeType string `json:"envelopeType,omitempty"`
 }
 
 // VerificationCertificates is a collection of public certs used for verification.

--- a/config/config.go
+++ b/config/config.go
@@ -3,6 +3,8 @@ package config
 import (
 	"errors"
 	"io/fs"
+
+	"github.com/notaryproject/notation-go/dir"
 )
 
 // CertificateReference is a named file path.
@@ -39,15 +41,30 @@ func NewConfig() *Config {
 	}
 }
 
-// Save stores the config to file
-func (c *Config) Save() error {
-	return save(ConfigPath, c)
+// Save stores the config to file.
+//
+// if the `path` is not set, it uses build-in user level config directory.
+func (c *Config) Save(path ...string) error {
+	if len(path) > 0 {
+		return save(path[0], c)
+	}
+	return save(dir.Path.ConfigForWrite(dir.UserLevel), c)
 }
 
 // LoadConfig reads the config from file or return a default config if not found.
-func LoadConfig() (*Config, error) {
-	var config Config
-	err := load(ConfigPath, &config)
+//
+// if `path` is not set, it uses build-in config.json directory, including
+// user level and system level.
+func LoadConfig(path ...string) (*Config, error) {
+	var (
+		err    error
+		config Config
+	)
+	if len(path) > 0 {
+		err = load(path[0], &config)
+	} else {
+		err = load(dir.Path.Config(), &config)
+	}
 	if err != nil {
 		if errors.Is(err, fs.ErrNotExist) {
 			return NewConfig(), nil

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -29,6 +29,7 @@ var sampleConfig = &Config{
 	InsecureRegistries: []string{
 		"registry.wabbit-networks.io",
 	},
+	EnvelopeType: "jws",
 }
 
 func TestLoadFile(t *testing.T) {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -4,8 +4,6 @@ import (
 	"path/filepath"
 	"reflect"
 	"testing"
-
-	"github.com/notaryproject/notation-go/dir"
 )
 
 const (
@@ -33,10 +31,6 @@ var sampleConfig = &Config{
 }
 
 func TestLoadFile(t *testing.T) {
-	t.Cleanup(func() {
-		// restore path
-		ConfigPath = dir.Path.Config()
-	})
 	type args struct {
 		filePath string
 	}
@@ -61,8 +55,7 @@ func TestLoadFile(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			ConfigPath = tt.args.filePath
-			got, err := LoadConfig()
+			got, err := LoadConfig(tt.args.filePath)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("loadFile() error = %v, wantErr %v", err, tt.wantErr)
 				return
@@ -75,13 +68,9 @@ func TestLoadFile(t *testing.T) {
 }
 
 func TestSaveFile(t *testing.T) {
-	t.Cleanup(func() {
-		// restore path
-		ConfigPath = dir.Path.Config()
-	})
 	root := t.TempDir()
-	ConfigPath = filepath.Join(root, "config.json")
-	sampleConfig.Save()
+	configPath := filepath.Join(root, "config.json")
+	sampleConfig.Save(configPath)
 	config, err := LoadConfig()
 	if err != nil {
 		t.Fatal("Load config file from temp dir failed")

--- a/config/keys_test.go
+++ b/config/keys_test.go
@@ -4,8 +4,6 @@ import (
 	"path/filepath"
 	"reflect"
 	"testing"
-
-	"github.com/notaryproject/notation-go/dir"
 )
 
 const (
@@ -44,10 +42,6 @@ var sampleSigningKeysInfo = &SigningKeys{
 }
 
 func TestLoadSigningKeysInfo(t *testing.T) {
-	t.Cleanup(func() {
-		// restore path
-		SigningKeysPath = dir.Path.SigningKeyConfig()
-	})
 	type args struct {
 		filePath string
 	}
@@ -69,8 +63,7 @@ func TestLoadSigningKeysInfo(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			SigningKeysPath = tt.args.filePath
-			got, err := LoadSigningKeys()
+			got, err := LoadSigningKeys(tt.args.filePath)
 			if err != nil {
 				t.Errorf("LoadSigningKeysInfo() error = %v", err)
 				return
@@ -83,13 +76,9 @@ func TestLoadSigningKeysInfo(t *testing.T) {
 }
 
 func TestSaveSigningKeys(t *testing.T) {
-	t.Cleanup(func() {
-		// restore path
-		SigningKeysPath = dir.Path.SigningKeyConfig()
-	})
 	root := t.TempDir()
-	SigningKeysPath = filepath.Join(root, "signingkeys.json")
-	sampleSigningKeysInfo.Save()
+	signingKeysPath := filepath.Join(root, "signingkeys.json")
+	sampleSigningKeysInfo.Save(signingKeysPath)
 	info, err := LoadSigningKeys()
 	if err != nil {
 		t.Fatal("Load signingkeys.json from temp dir failed.")

--- a/config/testdata/config.json
+++ b/config/testdata/config.json
@@ -13,5 +13,6 @@
     },
     "insecureRegistries": [
         "registry.wabbit-networks.io"
-    ]
+    ],
+    "envelopeType": "jws"
 }

--- a/dir/base.go
+++ b/dir/base.go
@@ -93,11 +93,20 @@ func loadPath() {
 		UserConfigFS: NewUnionDirFS(
 			NewRootedFS(userConfig, nil),
 		),
+		SystemConfigFS: NewUnionDirFS(
+			NewRootedFS(userConfig, nil),
+		),
 		CacheFS: NewUnionDirFS(
 			NewRootedFS(userCache, nil),
 		),
 		LibexecFS: NewUnionDirFS(
 			NewRootedFS(userLibexec, nil),
+			NewRootedFS(systemLibexec, nil),
+		),
+		UserLibexecFS: NewUnionDirFS(
+			NewRootedFS(userLibexec, nil),
+		),
+		SystemLibexecFS: NewUnionDirFS(
 			NewRootedFS(systemLibexec, nil),
 		),
 	}

--- a/dir/path.go
+++ b/dir/path.go
@@ -36,13 +36,28 @@ const (
 	TrustStoreDir = "truststore"
 )
 
+// WriteLevel defines the write directory level supporting UserLevel or SystemLevel.
+type WriteLevel int
+
+const (
+	// SystemLevel is the label to specify write directory to system level
+	SystemLevel WriteLevel = 0
+	// UserLevel is the label to specify write directory to user level
+	UserLevel WriteLevel = 1
+)
+
 // PathManager contains the union directory file system and methods
 // to access paths of notation
 type PathManager struct {
-	ConfigFS     UnionDirFS
-	CacheFS      UnionDirFS
-	LibexecFS    UnionDirFS
-	UserConfigFS UnionDirFS
+	ConfigFS  UnionDirFS
+	CacheFS   UnionDirFS
+	LibexecFS UnionDirFS
+
+	UserConfigFS   UnionDirFS
+	SystemConfigFS UnionDirFS
+
+	UserLibexecFS   UnionDirFS
+	SystemLibexecFS UnionDirFS
 }
 
 func checkError(err error) {
@@ -52,14 +67,19 @@ func checkError(err error) {
 	}
 }
 
-// Config returns the path of config.json
+// Config returns the ready-only path of config.json
 func (p *PathManager) Config() string {
 	path, err := p.ConfigFS.GetPath(ConfigFile)
 	checkError(err)
 	return path
 }
 
-// LocalKey returns path of the local private key and it's certificate
+// ConfigForWrite returns the writable path of config.json
+func (p *PathManager) ConfigForWrite(writeLevel WriteLevel) string {
+	return getPathForWrite(writeLevel, p.UserConfigFS, p.SystemConfigFS, ConfigFile)
+}
+
+// LocalKey returns the user level path of the local private key and it's certificate
 // in the localkeys directory
 func (p *PathManager) Localkey(name string) (keyPath, certPath string) {
 	keyPath, err := p.UserConfigFS.GetPath(LocalKeysDir, name+LocalKeyExtension)
@@ -69,25 +89,36 @@ func (p *PathManager) Localkey(name string) (keyPath, certPath string) {
 	return keyPath, certPath
 }
 
-// SigningKeyConfig return the path of signingkeys.json files
+// SigningKeyConfig returns the writable user level path of signingkeys.json files
 func (p *PathManager) SigningKeyConfig() string {
 	path, err := p.UserConfigFS.GetPath(SigningKeysFile)
 	checkError(err)
 	return path
 }
 
-// TrustPolicy returns the path of trustpolicy.json file
+// TrustPolicy returns the ready-only path of trustpolicy.json file
 func (p *PathManager) TrustPolicy() string {
 	path, err := p.ConfigFS.GetPath(TrustPolicyFile)
 	checkError(err)
 	return path
 }
 
-// X509TrustStore returns the path of x509 trust store certificate
+// TrustPolicyForWrite returns the writable path of trustpolicy.json file
+func (p *PathManager) TrustPolicyForWrite(writeLevel WriteLevel) string {
+	return getPathForWrite(writeLevel, p.UserConfigFS, p.SystemConfigFS, TrustPolicyFile)
+}
+
+// X509TrustStore returns the read-only path of x509 trust store certificate
 func (p *PathManager) X509TrustStore(prefix, namedStore string) string {
 	path, err := p.ConfigFS.GetPath(TrustStoreDir, "x509", prefix, namedStore)
 	checkError(err)
 	return path
+}
+
+// X509TrustStoreForWrite returns the writable path of x509 trust store certificate
+func (p *PathManager) X509TrustStoreForWrite(writeLevel WriteLevel, prefix, namedStore string) string {
+	return getPathForWrite(writeLevel, p.UserConfigFS, p.SystemConfigFS,
+		TrustStoreDir, "x509", prefix, namedStore)
 }
 
 // CachedSignature returns the cached signature file path
@@ -117,6 +148,21 @@ func (p *PathManager) CachedSignatureRoot(manifestDigest digest.Digest) string {
 // CachedSignatureStoreDirPath returns the cached signing keys directory
 func (p *PathManager) CachedSignatureStoreDirPath() string {
 	path, err := p.CacheFS.GetPath(SignatureStoreDirName)
+	checkError(err)
+	return path
+}
+
+func getPathForWrite(writeLevel WriteLevel, user UnionDirFS, system UnionDirFS, items ...string) string {
+	var (
+		path string
+		err  error
+	)
+	if writeLevel == SystemLevel {
+		path, err = system.GetPath(items...)
+	} else {
+		path, err = user.GetPath(items...)
+	}
+
 	checkError(err)
 	return path
 }

--- a/dir/path_test.go
+++ b/dir/path_test.go
@@ -119,6 +119,153 @@ func TestX509TrustStoreCerts(t *testing.T) {
 	}
 }
 
+func TestConfigForWrite(t *testing.T) {
+	config := PathManager{
+		UserConfigFS: unionDirFS{
+			Dirs: []RootedFS{
+				NewRootedFS(
+					"/user/exampleuser/.config/notation",
+					fstest.MapFS{},
+				),
+			},
+		},
+		SystemConfigFS: unionDirFS{
+			Dirs: []RootedFS{
+				NewRootedFS(
+					"/etc/notation",
+					fstest.MapFS{},
+				),
+			},
+		},
+	}
+	type args struct {
+		WriteLevel WriteLevel
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    string
+		wantErr bool
+	}{
+		{
+			name:    "config path for write in user level",
+			args:    args{UserLevel},
+			want:    "/user/exampleuser/.config/notation/config.json",
+			wantErr: false,
+		},
+		{
+			name:    "config path for write in system level",
+			args:    args{SystemLevel},
+			want:    "/etc/notation/config.json",
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := config.ConfigForWrite(tt.args.WriteLevel)
+			assertPathEqual(t, tt.want, got, "config path for write error.")
+		})
+	}
+}
+
+func TestTrustStoreForWrite(t *testing.T) {
+	config := PathManager{
+		UserConfigFS: unionDirFS{
+			Dirs: []RootedFS{
+				NewRootedFS(
+					"/user/exampleuser/.config/notation",
+					fstest.MapFS{},
+				),
+			},
+		},
+		SystemConfigFS: unionDirFS{
+			Dirs: []RootedFS{
+				NewRootedFS(
+					"/etc/notation",
+					fstest.MapFS{},
+				),
+			},
+		},
+	}
+	type args struct {
+		WriteLevel WriteLevel
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    string
+		wantErr bool
+	}{
+		{
+			name:    "trust store path for write in user level",
+			args:    args{UserLevel},
+			want:    "/user/exampleuser/.config/notation/truststore/x509/ca/jj",
+			wantErr: false,
+		},
+		{
+			name:    "trust store path for write in system level",
+			args:    args{SystemLevel},
+			want:    "/etc/notation/truststore/x509/ca/jj",
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := config.X509TrustStoreForWrite(tt.args.WriteLevel, "ca", "jj")
+			assertPathEqual(t, tt.want, got, "config path for write error.")
+		})
+	}
+}
+
+func TestTrustPolicyForWrite(t *testing.T) {
+	config := PathManager{
+		UserConfigFS: unionDirFS{
+			Dirs: []RootedFS{
+				NewRootedFS(
+					"/user/exampleuser/.config/notation",
+					fstest.MapFS{},
+				),
+			},
+		},
+		SystemConfigFS: unionDirFS{
+			Dirs: []RootedFS{
+				NewRootedFS(
+					"/etc/notation",
+					fstest.MapFS{},
+				),
+			},
+		},
+	}
+	type args struct {
+		WriteLevel WriteLevel
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    string
+		wantErr bool
+	}{
+		{
+			name:    "trust policy path for write in user level",
+			args:    args{UserLevel},
+			want:    "/user/exampleuser/.config/notation/trustpolicy.json",
+			wantErr: false,
+		},
+		{
+			name:    "trust policy path for write in system level",
+			args:    args{SystemLevel},
+			want:    "/etc/notation/trustpolicy.json",
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := config.TrustPolicyForWrite(tt.args.WriteLevel)
+			assertPathEqual(t, tt.want, got, "config path for write error.")
+		})
+	}
+}
+
 func TestPathManager_Config(t *testing.T) {
 	path := &PathManager{
 		ConfigFS: NewUnionDirFS(


### PR DESCRIPTION
1. config add `EnvelopeType` argument
2. dir package optimize: allow user define `WriteLevel` = UserLevel | SystemLevel
3. add ConfigForWrite(), TrustStoreForWrite(), TrustPolicyForWrite() func to get writable path
4. refector `config` pacakge: receive a `path` argument when load and save file to allow user to overwrite the default directory structure