### PR TITLE
fix: dir package isolates system/user directory

### DIFF
--- a/config/base.go
+++ b/config/base.go
@@ -4,21 +4,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
-
-	"github.com/notaryproject/notation-go/dir"
 )
-
-var (
-	// ConfigPath is the path for config.json
-	ConfigPath string
-	// SigningKeysPath is the path for signingkeys.json
-	SigningKeysPath string
-)
-
-func init() {
-	ConfigPath = dir.Path.Config()
-	SigningKeysPath = dir.Path.SigningKeyConfig()
-}
 
 // save stores the cfg struct to file
 func save(filePath string, cfg interface{}) error {

--- a/config/config.go
+++ b/config/config.go
@@ -45,7 +45,7 @@ func NewConfig() *Config {
 func (c *Config) Save(path string) error {
 	// set default path
 	if path == "" {
-		path = dir.Path.ConfigForWrite(dir.UserLevel)
+		path = dir.Path.Config(dir.UserLevel)
 	}
 	return save(path, c)
 }
@@ -57,7 +57,7 @@ func (c *Config) Save(path string) error {
 func LoadConfig(path string) (*Config, error) {
 	// set default path
 	if path == "" {
-		path = dir.Path.Config()
+		path = dir.Path.Config(dir.UnionLevel)
 	}
 
 	// load config

--- a/config/config.go
+++ b/config/config.go
@@ -41,10 +41,6 @@ func NewConfig() *Config {
 //
 // if the `path` is an empty string, it uses built-in user level config directory.
 func (c *Config) Save(path string) error {
-	// set default path
-	if path == "" {
-		path = dir.Path.Config(dir.UserLevel)
-	}
 	return save(path, c)
 }
 

--- a/config/config.go
+++ b/config/config.go
@@ -25,6 +25,8 @@ type Config struct {
 	InsecureRegistries       []string                 `json:"insecureRegistries"`
 	CredentialsStore         string                   `json:"credsStore,omitempty"`
 	CredentialHelpers        map[string]string        `json:"credHelpers,omitempty"`
+	// EnvelopeType defines the envelope type for signing
+	EnvelopeType string `json:"envelopeType,omitempty"`
 }
 
 // VerificationCertificates is a collection of public certs used for verification.

--- a/config/config.go
+++ b/config/config.go
@@ -43,7 +43,7 @@ func NewConfig() *Config {
 
 // Save stores the config to file.
 //
-// if the `path` is an empty string, it uses build-in user level config directory.
+// if the `path` is an empty string, it uses built-in user level config directory.
 func (c *Config) Save(path string) error {
 	// set default path
 	if path == "" {
@@ -54,7 +54,7 @@ func (c *Config) Save(path string) error {
 
 // LoadConfig reads the config from file or return a default config if not found.
 //
-// if `path` is an empty string, it uses build-in config.json directory, including
+// if `path` is an empty string, it uses built-in config.json directory, including
 // user level and system level.
 func LoadConfig(path string) (*Config, error) {
 	// set default path

--- a/config/config.go
+++ b/config/config.go
@@ -43,28 +43,28 @@ func NewConfig() *Config {
 
 // Save stores the config to file.
 //
-// if the `path` is not set, it uses build-in user level config directory.
-func (c *Config) Save(path ...string) error {
-	if len(path) > 0 {
-		return save(path[0], c)
+// if the `path` is an empty string, it uses build-in user level config directory.
+func (c *Config) Save(path string) error {
+	// set default path
+	if path == "" {
+		path = dir.Path.ConfigForWrite(dir.UserLevel)
 	}
-	return save(dir.Path.ConfigForWrite(dir.UserLevel), c)
+	return save(path, c)
 }
 
 // LoadConfig reads the config from file or return a default config if not found.
 //
-// if `path` is not set, it uses build-in config.json directory, including
+// if `path` is an empty string, it uses build-in config.json directory, including
 // user level and system level.
-func LoadConfig(path ...string) (*Config, error) {
-	var (
-		err    error
-		config Config
-	)
-	if len(path) > 0 {
-		err = load(path[0], &config)
-	} else {
-		err = load(dir.Path.Config(), &config)
+func LoadConfig(path string) (*Config, error) {
+	// set default path
+	if path == "" {
+		path = dir.Path.Config()
 	}
+
+	// load config
+	var config Config
+	err := load(path, &config)
 	if err != nil {
 		if errors.Is(err, fs.ErrNotExist) {
 			return NewConfig(), nil

--- a/config/config.go
+++ b/config/config.go
@@ -3,6 +3,8 @@ package config
 import (
 	"errors"
 	"io/fs"
+
+	"github.com/notaryproject/notation-go/dir"
 )
 
 // CertificateReference is a named file path.
@@ -37,15 +39,30 @@ func NewConfig() *Config {
 	}
 }
 
-// Save stores the config to file
-func (c *Config) Save() error {
-	return save(ConfigPath, c)
+// Save stores the config to file.
+//
+// if the `path` is not set, it uses build-in user level config directory.
+func (c *Config) Save(path ...string) error {
+	if len(path) > 0 {
+		return save(path[0], c)
+	}
+	return save(dir.Path.ConfigForWrite(dir.UserLevel), c)
 }
 
 // LoadConfig reads the config from file or return a default config if not found.
-func LoadConfig() (*Config, error) {
-	var config Config
-	err := load(ConfigPath, &config)
+//
+// if `path` is not set, it uses build-in config.json directory, including
+// user level and system level.
+func LoadConfig(path ...string) (*Config, error) {
+	var (
+		err    error
+		config Config
+	)
+	if len(path) > 0 {
+		err = load(path[0], &config)
+	} else {
+		err = load(dir.Path.Config(), &config)
+	}
 	if err != nil {
 		if errors.Is(err, fs.ErrNotExist) {
 			return NewConfig(), nil

--- a/config/config.go
+++ b/config/config.go
@@ -34,9 +34,7 @@ type VerificationCertificates struct {
 
 // NewConfig creates a new config file
 func NewConfig() *Config {
-	return &Config{
-		InsecureRegistries: []string{},
-	}
+	return &Config{}
 }
 
 // Save stores the config to file.

--- a/config/config.go
+++ b/config/config.go
@@ -25,8 +25,6 @@ type Config struct {
 	InsecureRegistries       []string                 `json:"insecureRegistries"`
 	CredentialsStore         string                   `json:"credsStore,omitempty"`
 	CredentialHelpers        map[string]string        `json:"credHelpers,omitempty"`
-	// EnvelopeType defines the envelope type for signing
-	EnvelopeType string `json:"envelopeType,omitempty"`
 }
 
 // VerificationCertificates is a collection of public certs used for verification.

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -4,8 +4,6 @@ import (
 	"path/filepath"
 	"reflect"
 	"testing"
-
-	"github.com/notaryproject/notation-go/dir"
 )
 
 const (
@@ -32,10 +30,6 @@ var sampleConfig = &Config{
 }
 
 func TestLoadFile(t *testing.T) {
-	t.Cleanup(func() {
-		// restore path
-		ConfigPath = dir.Path.Config()
-	})
 	type args struct {
 		filePath string
 	}
@@ -60,8 +54,7 @@ func TestLoadFile(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			ConfigPath = tt.args.filePath
-			got, err := LoadConfig()
+			got, err := LoadConfig(tt.args.filePath)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("loadFile() error = %v, wantErr %v", err, tt.wantErr)
 				return
@@ -74,13 +67,9 @@ func TestLoadFile(t *testing.T) {
 }
 
 func TestSaveFile(t *testing.T) {
-	t.Cleanup(func() {
-		// restore path
-		ConfigPath = dir.Path.Config()
-	})
 	root := t.TempDir()
-	ConfigPath = filepath.Join(root, "config.json")
-	sampleConfig.Save()
+	configPath := filepath.Join(root, "config.json")
+	sampleConfig.Save(configPath)
 	config, err := LoadConfig()
 	if err != nil {
 		t.Fatal("Load config file from temp dir failed")

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -27,6 +27,7 @@ var sampleConfig = &Config{
 	InsecureRegistries: []string{
 		"registry.wabbit-networks.io",
 	},
+	EnvelopeType: "jws",
 }
 
 func TestLoadFile(t *testing.T) {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -71,7 +71,7 @@ func TestSaveFile(t *testing.T) {
 	root := t.TempDir()
 	configPath := filepath.Join(root, "config.json")
 	sampleConfig.Save(configPath)
-	config, err := LoadConfig()
+	config, err := LoadConfig(configPath)
 	if err != nil {
 		t.Fatal("Load config file from temp dir failed")
 	}

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -27,7 +27,6 @@ var sampleConfig = &Config{
 	InsecureRegistries: []string{
 		"registry.wabbit-networks.io",
 	},
-	EnvelopeType: "jws",
 }
 
 func TestLoadFile(t *testing.T) {

--- a/config/keys.go
+++ b/config/keys.go
@@ -42,7 +42,7 @@ type SigningKeys struct {
 
 // Save config to file.
 //
-// if `path` is an empty string, it uses build-in user level signingkey.json directory.
+// if `path` is an empty string, it uses built-in user level signingkey.json directory.
 func (s *SigningKeys) Save(path string) error {
 	// set default path
 	if path == "" {
@@ -59,7 +59,7 @@ func NewSigningKeys() *SigningKeys {
 // LoadSigningKeys reads the config from file
 // or return a default config if not found.
 //
-// if `path` is an empty string, it uses build-in user level signingkey.json directory.
+// if `path` is an empty string, it uses built-in user level signingkey.json directory.
 func LoadSigningKeys(path string) (*SigningKeys, error) {
 	// set default path
 	if path == "" {

--- a/config/keys.go
+++ b/config/keys.go
@@ -61,11 +61,6 @@ func NewSigningKeys() *SigningKeys {
 //
 // if `path` is an empty string, it uses built-in user level signingkey.json directory.
 func LoadSigningKeys(path string) (*SigningKeys, error) {
-	// set default path
-	if path == "" {
-		path = dir.Path.SigningKeyConfig()
-	}
-
 	// load signingkeys config
 	var config SigningKeys
 	err := load(path, &config)

--- a/config/keys.go
+++ b/config/keys.go
@@ -42,12 +42,13 @@ type SigningKeys struct {
 
 // Save config to file.
 //
-// if `path` is not set, it uses build-in user level signingkey.json directory.
-func (s *SigningKeys) Save(path ...string) error {
-	if len(path) > 0 {
-		return save(path[0], s)
+// if `path` is an empty string, it uses build-in user level signingkey.json directory.
+func (s *SigningKeys) Save(path string) error {
+	// set default path
+	if path == "" {
+		path = dir.Path.SigningKeyConfig()
 	}
-	return save(dir.Path.SigningKeyConfig(), s)
+	return save(path, s)
 }
 
 // NewSigningKeys creates a new signingkeys config file.
@@ -58,18 +59,16 @@ func NewSigningKeys() *SigningKeys {
 // LoadSigningKeys reads the config from file
 // or return a default config if not found.
 //
-// if `path` is not set, it uses build-in user level signingkey.json directory.
-func LoadSigningKeys(path ...string) (*SigningKeys, error) {
-	var (
-		err    error
-		config SigningKeys
-	)
-	if len(path) > 0 {
-		err = load(path[0], &config)
-	} else {
-		err = load(dir.Path.SigningKeyConfig(), &config)
+// if `path` is an empty string, it uses build-in user level signingkey.json directory.
+func LoadSigningKeys(path string) (*SigningKeys, error) {
+	// set default path
+	if path == "" {
+		path = dir.Path.SigningKeyConfig()
 	}
 
+	// load signingkeys config
+	var config SigningKeys
+	err := load(path, &config)
 	if err != nil {
 		if errors.Is(err, fs.ErrNotExist) {
 			return NewSigningKeys(), nil

--- a/config/keys_test.go
+++ b/config/keys_test.go
@@ -4,8 +4,6 @@ import (
 	"path/filepath"
 	"reflect"
 	"testing"
-
-	"github.com/notaryproject/notation-go/dir"
 )
 
 const (
@@ -44,10 +42,6 @@ var sampleSigningKeysInfo = &SigningKeys{
 }
 
 func TestLoadSigningKeysInfo(t *testing.T) {
-	t.Cleanup(func() {
-		// restore path
-		SigningKeysPath = dir.Path.SigningKeyConfig()
-	})
 	type args struct {
 		filePath string
 	}
@@ -69,8 +63,7 @@ func TestLoadSigningKeysInfo(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			SigningKeysPath = tt.args.filePath
-			got, err := LoadSigningKeys()
+			got, err := LoadSigningKeys(tt.args.filePath)
 			if err != nil {
 				t.Errorf("LoadSigningKeysInfo() error = %v", err)
 				return
@@ -83,13 +76,9 @@ func TestLoadSigningKeysInfo(t *testing.T) {
 }
 
 func TestSaveSigningKeys(t *testing.T) {
-	t.Cleanup(func() {
-		// restore path
-		SigningKeysPath = dir.Path.SigningKeyConfig()
-	})
 	root := t.TempDir()
-	SigningKeysPath = filepath.Join(root, "signingkeys.json")
-	sampleSigningKeysInfo.Save()
+	signingKeysPath := filepath.Join(root, "signingkeys.json")
+	sampleSigningKeysInfo.Save(signingKeysPath)
 	info, err := LoadSigningKeys()
 	if err != nil {
 		t.Fatal("Load signingkeys.json from temp dir failed.")

--- a/config/keys_test.go
+++ b/config/keys_test.go
@@ -79,7 +79,7 @@ func TestSaveSigningKeys(t *testing.T) {
 	root := t.TempDir()
 	signingKeysPath := filepath.Join(root, "signingkeys.json")
 	sampleSigningKeysInfo.Save(signingKeysPath)
-	info, err := LoadSigningKeys()
+	info, err := LoadSigningKeys(signingKeysPath)
 	if err != nil {
 		t.Fatal("Load signingkeys.json from temp dir failed.")
 	}

--- a/config/testdata/config.json
+++ b/config/testdata/config.json
@@ -13,5 +13,6 @@
     },
     "insecureRegistries": [
         "registry.wabbit-networks.io"
-    ]
+    ],
+    "envelopeType": "jws"
 }

--- a/config/testdata/config.json
+++ b/config/testdata/config.json
@@ -13,6 +13,5 @@
     },
     "insecureRegistries": [
         "registry.wabbit-networks.io"
-    ],
-    "envelopeType": "jws"
+    ]
 }

--- a/dir/base.go
+++ b/dir/base.go
@@ -93,11 +93,20 @@ func loadPath() {
 		UserConfigFS: NewUnionDirFS(
 			NewRootedFS(userConfig, nil),
 		),
+		SystemConfigFS: NewUnionDirFS(
+			NewRootedFS(userConfig, nil),
+		),
 		CacheFS: NewUnionDirFS(
 			NewRootedFS(userCache, nil),
 		),
 		LibexecFS: NewUnionDirFS(
 			NewRootedFS(userLibexec, nil),
+			NewRootedFS(systemLibexec, nil),
+		),
+		UserLibexecFS: NewUnionDirFS(
+			NewRootedFS(userLibexec, nil),
+		),
+		SystemLibexecFS: NewUnionDirFS(
 			NewRootedFS(systemLibexec, nil),
 		),
 	}

--- a/dir/base.go
+++ b/dir/base.go
@@ -90,23 +90,11 @@ func loadPath() {
 			NewRootedFS(userConfig, nil),
 			NewRootedFS(systemConfig, nil),
 		),
-		UserConfigFS: NewUnionDirFS(
-			NewRootedFS(userConfig, nil),
-		),
-		SystemConfigFS: NewUnionDirFS(
-			NewRootedFS(userConfig, nil),
-		),
 		CacheFS: NewUnionDirFS(
 			NewRootedFS(userCache, nil),
 		),
 		LibexecFS: NewUnionDirFS(
 			NewRootedFS(userLibexec, nil),
-			NewRootedFS(systemLibexec, nil),
-		),
-		UserLibexecFS: NewUnionDirFS(
-			NewRootedFS(userLibexec, nil),
-		),
-		SystemLibexecFS: NewUnionDirFS(
 			NewRootedFS(systemLibexec, nil),
 		),
 	}

--- a/dir/base.go
+++ b/dir/base.go
@@ -39,7 +39,7 @@ func init() {
 }
 
 // loadPath function defines the directory for
-// NotationLibexec, NotationConfig, NotationCache
+// NotationLibexec, NotationConfig, NotationCache.
 func loadPath() {
 	var err error
 	// set system config and libexec

--- a/dir/base.go
+++ b/dir/base.go
@@ -17,18 +17,18 @@ var (
 	userCacheDir  = os.UserCacheDir
 	getenv        = os.Getenv
 
-	// systemLibexec directory for binaries not meant to be executed directly
+	// SystemLibexec directory for binaries not meant to be executed directly
 	// by users' shell or scripts
-	systemLibexec string
-	// systemConfig directory for configurations
-	systemConfig string
+	SystemLibexec string
+	// SystemConfig directory for configurations
+	SystemConfig string
 
-	// userLibexec is user level libexec directory
-	userLibexec string
-	// userConfig is user level config directory
-	userConfig string
-	// userCache for user-specific cache
-	userCache string
+	// UserLibexec is user level libexec directory
+	UserLibexec string
+	// UserConfig is user level config directory
+	UserConfig string
+	// UserCache for user-specific cache
+	UserCache string
 
 	// Path is a PathManager pointer
 	Path *PathManager
@@ -45,57 +45,57 @@ func loadPath() {
 	// set system config and libexec
 	switch goos {
 	case "darwin":
-		systemConfig = "/Library/Application Support/notation"
-		systemLibexec = "/usr/local/lib/notation"
+		SystemConfig = "/Library/Application Support/notation"
+		SystemLibexec = "/usr/local/lib/notation"
 	case "windows":
-		systemConfig = getenv("ProgramData")
-		if systemConfig == "" {
+		SystemConfig = getenv("ProgramData")
+		if SystemConfig == "" {
 			// unsupported OS
 			panic("environment variable `ProgramData` is not set.")
 		}
-		systemConfig = filepath.Join(systemConfig, notation)
+		SystemConfig = filepath.Join(SystemConfig, notation)
 
-		systemLibexec = getenv("ProgramFiles")
-		if systemLibexec == "" {
+		SystemLibexec = getenv("ProgramFiles")
+		if SystemLibexec == "" {
 			// unsupported OS
 			panic("environment variable `ProgramFiles` is not set.")
 		}
-		systemLibexec = filepath.Join(systemLibexec, notation)
+		SystemLibexec = filepath.Join(SystemLibexec, notation)
 
 	default:
-		systemConfig = "/etc/notation"
-		systemLibexec = "/usr/libexec/notation"
+		SystemConfig = "/etc/notation"
+		SystemLibexec = "/usr/libexec/notation"
 	}
 
 	// set user config
-	userConfig, err = userConfigDir()
+	UserConfig, err = userConfigDir()
 	if err != nil {
 		panic(err)
 	}
-	userConfig = filepath.Join(userConfig, notation)
+	UserConfig = filepath.Join(UserConfig, notation)
 	// set user libexec
-	userLibexec = userConfig
+	UserLibexec = UserConfig
 	// set user cache
-	userCache, err = userCacheDir()
+	UserCache, err = userCacheDir()
 	if err != nil {
 		panic(err)
 	}
-	userCache = filepath.Join(userCache, notation)
+	UserCache = filepath.Join(UserCache, notation)
 
 	// set PathManager
 	// TODO(JeyJeyGao): The user/system directory priority may change later
 	// (https://github.com/notaryproject/notation/issues/203)
 	Path = &PathManager{
 		ConfigFS: NewUnionDirFS(
-			NewRootedFS(userConfig, nil),
-			NewRootedFS(systemConfig, nil),
+			NewRootedFS(UserConfig, nil),
+			NewRootedFS(SystemConfig, nil),
 		),
 		CacheFS: NewUnionDirFS(
-			NewRootedFS(userCache, nil),
+			NewRootedFS(UserCache, nil),
 		),
 		LibexecFS: NewUnionDirFS(
-			NewRootedFS(userLibexec, nil),
-			NewRootedFS(systemLibexec, nil),
+			NewRootedFS(UserLibexec, nil),
+			NewRootedFS(SystemLibexec, nil),
 		),
 	}
 }

--- a/dir/base_test.go
+++ b/dir/base_test.go
@@ -84,11 +84,11 @@ func TestLoadPath(t *testing.T) {
 			userCacheDir = tt.userCacheDir
 			getenv = tt.getenv
 			loadPath()
-			assertPathEqual(t, tt.wantSystemConfig, systemConfig, "systemConfig error.")
-			assertPathEqual(t, tt.wantSystemLibexec, systemLibexec, "systemLibexec error.")
-			assertPathEqual(t, tt.wantUserConfig, userConfig, "userConfig error.")
-			assertPathEqual(t, tt.wantUserLibexec, userLibexec, "userLibexec")
-			assertPathEqual(t, tt.wantUserCache, userCache, "userCache error.")
+			assertPathEqual(t, tt.wantSystemConfig, SystemConfig, "systemConfig error.")
+			assertPathEqual(t, tt.wantSystemLibexec, SystemLibexec, "systemLibexec error.")
+			assertPathEqual(t, tt.wantUserConfig, UserConfig, "userConfig error.")
+			assertPathEqual(t, tt.wantUserLibexec, UserLibexec, "userLibexec")
+			assertPathEqual(t, tt.wantUserCache, UserCache, "userCache error.")
 		})
 	}
 }

--- a/dir/fs.go
+++ b/dir/fs.go
@@ -146,8 +146,8 @@ func (u unionDirFS) ReadDir(name string) ([]fs.DirEntry, error) {
 func PluginFS(dirs ...string) UnionDirFS {
 	var rootedFsys []RootedFS
 	if len(dirs) == 0 {
-		dirs = append(dirs, filepath.Join(userLibexec, "plugins"))
-		dirs = append(dirs, filepath.Join(systemLibexec, "plugins"))
+		dirs = append(dirs, filepath.Join(UserLibexec, "plugins"))
+		dirs = append(dirs, filepath.Join(SystemLibexec, "plugins"))
 	}
 	for _, dir := range dirs {
 		rootedFsys = append(rootedFsys, NewRootedFS(dir, nil))

--- a/dir/fs.go
+++ b/dir/fs.go
@@ -142,7 +142,7 @@ func (u unionDirFS) ReadDir(name string) ([]fs.DirEntry, error) {
 
 // PluginFS returns the UnionDirFS for notation plugins
 // if dirs is set, use dirs as the directories for plugins
-// if dirs is not set, use build-in directory structure for plugins
+// if dirs is not set, use built-in directory structure for plugins
 func PluginFS(dirs ...string) UnionDirFS {
 	var rootedFsys []RootedFS
 	if len(dirs) == 0 {

--- a/dir/fs.go
+++ b/dir/fs.go
@@ -11,7 +11,7 @@ import (
 // RootedFS is a file system interface supporting for getting root path.
 type RootedFS interface {
 	fs.FS
-	// Root returns the root path of the RootedFS
+	// Root returns the root path of the RootedFS.
 	Root() string
 }
 
@@ -20,14 +20,14 @@ type rootedFS struct {
 	root string
 }
 
-// Root returns the root path of the rootedFS
+// Root returns the root path of the rootedFS.
 func (r *rootedFS) Root() string {
 	return r.root
 }
 
-// NewRootedFS create a rootedFS
+// NewRootedFS create a rootedFS.
 //
-// if fsys is nil, uses os.DirFS
+// If fsys is nil, uses os.DirFS.
 func NewRootedFS(root string, fsys fs.FS) RootedFS {
 	if fsys == nil {
 		return &rootedFS{FS: os.DirFS(root), root: root}
@@ -35,29 +35,29 @@ func NewRootedFS(root string, fsys fs.FS) RootedFS {
 	return &rootedFS{FS: fsys, root: root}
 }
 
-// UnionDirFS is a simple union directory file system interface
+// UnionDirFS is a simple union directory file system interface.
 type UnionDirFS interface {
 	fs.ReadDirFS
-	// GetPath returns the path of the named file or directory under the FS
+	// GetPath returns the path of the named file or directory under the FS.
 	GetPath(elem ...string) (string, error)
 }
 
-// NewUnionDirFS create an unionDirFS by rootedFS
+// NewUnionDirFS create an unionDirFS by rootedFS.
 func NewUnionDirFS(rootedFsys ...RootedFS) UnionDirFS {
 	return unionDirFS{Dirs: rootedFsys}
 }
 
-// unionDirFS is a simple union directory file system
+// unionDirFS is a simple union directory file system.
 //
-// it unions multiple directory to be one directory with priority based on the
-// order of Dirs
+// It unions multiple directory to be one directory with priority based on the
+// order of Dirs.
 type unionDirFS struct {
 	Dirs []RootedFS
 }
 
-// Open implements fs.FS interface
+// Open implements fs.FS interface.
 //
-// traverse all union directories and return the first existing file
+// Traverse all union directories and return the first existing file.
 func (u unionDirFS) Open(name string) (fs.File, error) {
 	for _, dir := range u.Dirs {
 		f, err := dir.Open(name)
@@ -73,11 +73,12 @@ func (u unionDirFS) Open(name string) (fs.File, error) {
 	return nil, &fs.PathError{Op: "open", Err: fs.ErrNotExist, Path: name}
 }
 
-// GetPath returns the path of the named file or directory under the FS
+// GetPath returns the path of the named file or directory under the FS.
 //
-// if path exists, it returns the first existing path in union directories(dirs)
+// If path exists, it returns the first existing path in union
+// directories (dirs).
 //
-// if path doesn't exist, it returns the first possible path in the union
+// If path doesn't exist, it returns the first possible path in the union
 // directories for creating new file and a fs.ErrNotExist error.
 func (u unionDirFS) GetPath(elem ...string) (string, error) {
 	pathSuffix := path.Join(elem...)
@@ -111,9 +112,9 @@ func (u unionDirFS) GetPath(elem ...string) (string, error) {
 	}
 }
 
-// ReadDir implements the ReadDirFS interface
+// ReadDir implements the ReadDirFS interface.
 //
-// traverse all union directories and return all existing DirEntries
+// Traverse all union directories and return all existing DirEntries.
 func (u unionDirFS) ReadDir(name string) ([]fs.DirEntry, error) {
 	isVisited := make(map[string]struct{})
 	var newEntries []fs.DirEntry
@@ -140,9 +141,10 @@ func (u unionDirFS) ReadDir(name string) ([]fs.DirEntry, error) {
 	return newEntries, nil
 }
 
-// PluginFS returns the UnionDirFS for notation plugins
-// if dirs is set, use dirs as the directories for plugins
-// if dirs is not set, use built-in directory structure for plugins
+// PluginFS returns the UnionDirFS for notation plugins.
+//
+// If dirs is set, use dirs as the directories for plugins.
+// If dirs is not set, use built-in directory structure for plugins.
 func PluginFS(dirs ...string) UnionDirFS {
 	var rootedFsys []RootedFS
 	if len(dirs) == 0 {

--- a/dir/fs.go
+++ b/dir/fs.go
@@ -75,10 +75,10 @@ func (u unionDirFS) Open(name string) (fs.File, error) {
 
 // GetPath returns the path of the named file or directory under the FS
 //
-// if path exists, it returns the first existing path in union directories (dirs)
+// if path exists, it returns the first existing path in union directories(dirs)
 //
-// if path doesn't exist, it returns the first possible path in the union directories
-// for creating new file and a fs.ErrNotExist error.
+// if path doesn't exist, it returns the first possible path in the union
+// directories for creating new file and a fs.ErrNotExist error.
 func (u unionDirFS) GetPath(elem ...string) (string, error) {
 	pathSuffix := path.Join(elem...)
 	for _, dir := range u.Dirs {

--- a/dir/fs_test.go
+++ b/dir/fs_test.go
@@ -254,8 +254,8 @@ func TestPluginFS(t *testing.T) {
 			name: "default PluginFS",
 			args: args{dirs: []string{}},
 			want: NewUnionDirFS(
-				NewRootedFS(filepath.Join(userLibexec, "plugins"), nil),
-				NewRootedFS(filepath.Join(systemLibexec, "plugins"), nil),
+				NewRootedFS(filepath.Join(UserLibexec, "plugins"), nil),
+				NewRootedFS(filepath.Join(SystemLibexec, "plugins"), nil),
 			),
 		},
 		{

--- a/dir/path.go
+++ b/dir/path.go
@@ -80,9 +80,9 @@ func (p *PathManager) Config(dirLevel DirLevel) string {
 		path, err = p.ConfigFS.GetPath(ConfigFile)
 		checkError(err)
 	case SystemLevel:
-		path = filepath.Join(systemConfig, ConfigFile)
+		path = filepath.Join(SystemConfig, ConfigFile)
 	case UserLevel:
-		path = filepath.Join(userConfig, ConfigFile)
+		path = filepath.Join(UserConfig, ConfigFile)
 	}
 
 	return path
@@ -91,14 +91,14 @@ func (p *PathManager) Config(dirLevel DirLevel) string {
 // LocalKey returns the user level path of the local private key and it's certificate
 // in the localkeys directory
 func (p *PathManager) Localkey(name string) (keyPath, certPath string) {
-	keyPath = filepath.Join(userConfig, LocalKeysDir, name+LocalKeyExtension)
-	certPath = filepath.Join(userConfig, LocalKeysDir, name+LocalCertificateExtension)
+	keyPath = filepath.Join(UserConfig, LocalKeysDir, name+LocalKeyExtension)
+	certPath = filepath.Join(UserConfig, LocalKeysDir, name+LocalCertificateExtension)
 	return
 }
 
 // SigningKeyConfig returns the writable user level path of signingkeys.json files
 func (p *PathManager) SigningKeyConfig() string {
-	return filepath.Join(userConfig, SigningKeysFile)
+	return filepath.Join(UserConfig, SigningKeysFile)
 }
 
 // TrustPolicy returns the path of trustpolicy.json file based on named directory level.
@@ -113,9 +113,9 @@ func (p *PathManager) TrustPolicy(dirLevel DirLevel) string {
 		path, err = p.ConfigFS.GetPath(TrustPolicyFile)
 		checkError(err)
 	case SystemLevel:
-		path = filepath.Join(systemConfig, TrustPolicyFile)
+		path = filepath.Join(SystemConfig, TrustPolicyFile)
 	case UserLevel:
-		path = filepath.Join(userConfig, TrustPolicyFile)
+		path = filepath.Join(UserConfig, TrustPolicyFile)
 	}
 
 	return path
@@ -134,9 +134,9 @@ func (p *PathManager) X509TrustStore(dirLevel DirLevel, prefix, namedStore strin
 		path, err = p.ConfigFS.GetPath(TrustStoreDir, "x509", prefix, namedStore)
 		checkError(err)
 	case SystemLevel:
-		path = filepath.Join(systemConfig, TrustStoreDir, "x509", prefix, namedStore)
+		path = filepath.Join(SystemConfig, TrustStoreDir, "x509", prefix, namedStore)
 	case UserLevel:
-		path = filepath.Join(userConfig, TrustStoreDir, "x509", prefix, namedStore)
+		path = filepath.Join(UserConfig, TrustStoreDir, "x509", prefix, namedStore)
 	}
 
 	return path

--- a/dir/path.go
+++ b/dir/path.go
@@ -36,13 +36,28 @@ const (
 	TrustStoreDir = "truststore"
 )
 
+// WriteLevel defines the write directory level supporting UserLevel or SystemLevel.
+type WriteLevel int
+
+const (
+	// SystemLevel is the label to specify write directory to system level
+	SystemLevel WriteLevel = 0
+	// UserLevel is the label to specify write directory to user level
+	UserLevel WriteLevel = 1
+)
+
 // PathManager contains the union directory file system and methods
 // to access paths of notation
 type PathManager struct {
-	ConfigFS     UnionDirFS
-	CacheFS      UnionDirFS
-	LibexecFS    UnionDirFS
-	UserConfigFS UnionDirFS
+	ConfigFS  UnionDirFS
+	CacheFS   UnionDirFS
+	LibexecFS UnionDirFS
+
+	UserConfigFS   UnionDirFS
+	SystemConfigFS UnionDirFS
+
+	UserLibexecFS   UnionDirFS
+	SystemLibexecFS UnionDirFS
 }
 
 func checkError(err error) {
@@ -52,14 +67,19 @@ func checkError(err error) {
 	}
 }
 
-// Config returns the path of config.json
+// Config returns the ready-only path of config.json
 func (p *PathManager) Config() string {
 	path, err := p.ConfigFS.GetPath(ConfigFile)
 	checkError(err)
 	return path
 }
 
-// LocalKey returns path of the local private key and it's certificate
+// ConfigForWrite returns the writable path of config.json
+func (p *PathManager) ConfigForWrite(writeLevel WriteLevel) string {
+	return getPathForWrite(writeLevel, p.UserConfigFS, p.SystemConfigFS, ConfigFile)
+}
+
+// LocalKey returns the user level path of the local private key and it's certificate
 // in the localkeys directory
 func (p *PathManager) Localkey(name string) (keyPath, certPath string) {
 	keyPath, err := p.UserConfigFS.GetPath(LocalKeysDir, name+LocalKeyExtension)
@@ -69,25 +89,36 @@ func (p *PathManager) Localkey(name string) (keyPath, certPath string) {
 	return keyPath, certPath
 }
 
-// SigningKeyConfig return the path of signingkeys.json files
+// SigningKeyConfig returns the writable user level path of signingkeys.json files
 func (p *PathManager) SigningKeyConfig() string {
 	path, err := p.UserConfigFS.GetPath(SigningKeysFile)
 	checkError(err)
 	return path
 }
 
-// TrustPolicy returns the path of trustpolicy.json file
+// TrustPolicy returns the ready-only path of trustpolicy.json file
 func (p *PathManager) TrustPolicy() string {
 	path, err := p.ConfigFS.GetPath(TrustPolicyFile)
 	checkError(err)
 	return path
 }
 
-// X509TrustStore returns the path of x509 trust store certificate
+// TrustPolicyForWrite returns the writable path of trustpolicy.json file
+func (p *PathManager) TrustPolicyForWrite(writeLevel WriteLevel) string {
+	return getPathForWrite(writeLevel, p.UserConfigFS, p.SystemConfigFS, TrustPolicyFile)
+}
+
+// X509TrustStore returns the read-only path of x509 trust store certificate
 func (p *PathManager) X509TrustStore(prefix, namedStore string) string {
 	path, err := p.ConfigFS.GetPath(TrustStoreDir, "x509", prefix, namedStore)
 	checkError(err)
 	return path
+}
+
+// X509TrustStoreForWrite returns the writable path of x509 trust store certificate
+func (p *PathManager) X509TrustStoreForWrite(writeLevel WriteLevel, prefix, namedStore string) string {
+	return getPathForWrite(writeLevel, p.UserConfigFS, p.SystemConfigFS,
+		TrustStoreDir, "x509", prefix, namedStore)
 }
 
 // CachedSignature returns the cached signature file path
@@ -117,6 +148,21 @@ func (p *PathManager) CachedSignatureRoot(manifestDigest digest.Digest) string {
 // CachedSignatureStoreDirPath returns the cached signing keys directory
 func (p *PathManager) CachedSignatureStoreDirPath() string {
 	path, err := p.CacheFS.GetPath(SignatureStoreDirName)
+	checkError(err)
+	return path
+}
+
+func getPathForWrite(writeLevel WriteLevel, user UnionDirFS, system UnionDirFS, items ...string) string {
+	var (
+		path string
+		err  error
+	)
+	if writeLevel == SystemLevel {
+		path, err = system.GetPath(items...)
+	} else {
+		path, err = user.GetPath(items...)
+	}
+
 	checkError(err)
 	return path
 }

--- a/dir/path.go
+++ b/dir/path.go
@@ -3,6 +3,7 @@ package dir
 import (
 	"errors"
 	"io/fs"
+	"path/filepath"
 
 	"github.com/opencontainers/go-digest"
 )
@@ -36,14 +37,20 @@ const (
 	TrustStoreDir = "truststore"
 )
 
-// WriteLevel defines the write directory level supporting UserLevel or SystemLevel.
-type WriteLevel int
+// DirLevel defines the directory level.
+type DirLevel int
 
 const (
+	// UnionLevel is the label to specify the directory to union user and system level,
+	// and user level has higher priority than system level.
+	// [directory spec]: https://github.com/notaryproject/notation/blob/main/specs/directory.md#category
+	UnionLevel DirLevel = iota
+
 	// SystemLevel is the label to specify write directory to system level
-	SystemLevel WriteLevel = 0
+	SystemLevel
+
 	// UserLevel is the label to specify write directory to user level
-	UserLevel WriteLevel = 1
+	UserLevel
 )
 
 // PathManager contains the union directory file system and methods
@@ -52,12 +59,6 @@ type PathManager struct {
 	ConfigFS  UnionDirFS
 	CacheFS   UnionDirFS
 	LibexecFS UnionDirFS
-
-	UserConfigFS   UnionDirFS
-	SystemConfigFS UnionDirFS
-
-	UserLibexecFS   UnionDirFS
-	SystemLibexecFS UnionDirFS
 }
 
 func checkError(err error) {
@@ -67,58 +68,78 @@ func checkError(err error) {
 	}
 }
 
-// Config returns the ready-only path of config.json
-func (p *PathManager) Config() string {
-	path, err := p.ConfigFS.GetPath(ConfigFile)
-	checkError(err)
-	return path
-}
+// Config returns the path of config.json based on named directory level.
+func (p *PathManager) Config(dirLevel DirLevel) string {
+	var (
+		path string
+		err  error
+	)
 
-// ConfigForWrite returns the writable path of config.json
-func (p *PathManager) ConfigForWrite(writeLevel WriteLevel) string {
-	return getPathForWrite(writeLevel, p.UserConfigFS, p.SystemConfigFS, ConfigFile)
+	switch dirLevel {
+	case UnionLevel:
+		path, err = p.ConfigFS.GetPath(ConfigFile)
+		checkError(err)
+	case SystemLevel:
+		path = filepath.Join(systemConfig, ConfigFile)
+	case UserLevel:
+		path = filepath.Join(userConfig, ConfigFile)
+	}
+
+	return path
 }
 
 // LocalKey returns the user level path of the local private key and it's certificate
 // in the localkeys directory
 func (p *PathManager) Localkey(name string) (keyPath, certPath string) {
-	keyPath, err := p.UserConfigFS.GetPath(LocalKeysDir, name+LocalKeyExtension)
-	checkError(err)
-	certPath, err = p.UserConfigFS.GetPath(LocalKeysDir, name+LocalCertificateExtension)
-	checkError(err)
-	return keyPath, certPath
+	keyPath = filepath.Join(userConfig, LocalKeysDir, name+LocalKeyExtension)
+	certPath = filepath.Join(userConfig, LocalKeysDir, name+LocalCertificateExtension)
+	return
 }
 
 // SigningKeyConfig returns the writable user level path of signingkeys.json files
 func (p *PathManager) SigningKeyConfig() string {
-	path, err := p.UserConfigFS.GetPath(SigningKeysFile)
-	checkError(err)
+	return filepath.Join(userConfig, SigningKeysFile)
+}
+
+// TrustPolicy returns the path of trustpolicy.json file based on named directory level.
+func (p *PathManager) TrustPolicy(dirLevel DirLevel) string {
+	var (
+		path string
+		err  error
+	)
+
+	switch dirLevel {
+	case UnionLevel:
+		path, err = p.ConfigFS.GetPath(TrustPolicyFile)
+		checkError(err)
+	case SystemLevel:
+		path = filepath.Join(systemConfig, TrustPolicyFile)
+	case UserLevel:
+		path = filepath.Join(userConfig, TrustPolicyFile)
+	}
+
 	return path
 }
 
-// TrustPolicy returns the ready-only path of trustpolicy.json file
-func (p *PathManager) TrustPolicy() string {
-	path, err := p.ConfigFS.GetPath(TrustPolicyFile)
-	checkError(err)
+// X509TrustStore returns the path of x509 trust store certificate
+// based on named directory level.
+func (p *PathManager) X509TrustStore(dirLevel DirLevel, prefix, namedStore string) string {
+	var (
+		path string
+		err  error
+	)
+
+	switch dirLevel {
+	case UnionLevel:
+		path, err = p.ConfigFS.GetPath(TrustStoreDir, "x509", prefix, namedStore)
+		checkError(err)
+	case SystemLevel:
+		path = filepath.Join(systemConfig, TrustStoreDir, "x509", prefix, namedStore)
+	case UserLevel:
+		path = filepath.Join(userConfig, TrustStoreDir, "x509", prefix, namedStore)
+	}
+
 	return path
-}
-
-// TrustPolicyForWrite returns the writable path of trustpolicy.json file
-func (p *PathManager) TrustPolicyForWrite(writeLevel WriteLevel) string {
-	return getPathForWrite(writeLevel, p.UserConfigFS, p.SystemConfigFS, TrustPolicyFile)
-}
-
-// X509TrustStore returns the read-only path of x509 trust store certificate
-func (p *PathManager) X509TrustStore(prefix, namedStore string) string {
-	path, err := p.ConfigFS.GetPath(TrustStoreDir, "x509", prefix, namedStore)
-	checkError(err)
-	return path
-}
-
-// X509TrustStoreForWrite returns the writable path of x509 trust store certificate
-func (p *PathManager) X509TrustStoreForWrite(writeLevel WriteLevel, prefix, namedStore string) string {
-	return getPathForWrite(writeLevel, p.UserConfigFS, p.SystemConfigFS,
-		TrustStoreDir, "x509", prefix, namedStore)
 }
 
 // CachedSignature returns the cached signature file path
@@ -148,21 +169,6 @@ func (p *PathManager) CachedSignatureRoot(manifestDigest digest.Digest) string {
 // CachedSignatureStoreDirPath returns the cached signing keys directory
 func (p *PathManager) CachedSignatureStoreDirPath() string {
 	path, err := p.CacheFS.GetPath(SignatureStoreDirName)
-	checkError(err)
-	return path
-}
-
-func getPathForWrite(writeLevel WriteLevel, user UnionDirFS, system UnionDirFS, items ...string) string {
-	var (
-		path string
-		err  error
-	)
-	if writeLevel == SystemLevel {
-		path, err = system.GetPath(items...)
-	} else {
-		path, err = user.GetPath(items...)
-	}
-
 	checkError(err)
 	return path
 }

--- a/dir/path.go
+++ b/dir/path.go
@@ -41,8 +41,8 @@ const (
 type DirLevel int
 
 const (
-	// UnionLevel is the label to specify the directory to union user and system level,
-	// and user level has higher priority than system level.
+	// UnionLevel is the label to specify the directory to union user and
+	// system level, and user level has higher priority than system level.
 	// [directory spec]: https://github.com/notaryproject/notation/blob/main/specs/directory.md#category
 	UnionLevel DirLevel = iota
 
@@ -88,20 +88,22 @@ func (p *PathManager) Config(dirLevel DirLevel) string {
 	return path
 }
 
-// LocalKey returns the user level path of the local private key and it's certificate
-// in the localkeys directory
+// LocalKey returns the user level path of the local private key and
+// it's certificate in the localkeys directory.
 func (p *PathManager) Localkey(name string) (keyPath, certPath string) {
 	keyPath = filepath.Join(UserConfig, LocalKeysDir, name+LocalKeyExtension)
 	certPath = filepath.Join(UserConfig, LocalKeysDir, name+LocalCertificateExtension)
 	return
 }
 
-// SigningKeyConfig returns the writable user level path of signingkeys.json files
+// SigningKeyConfig returns the writable user level path of signingkeys.json
+// files.
 func (p *PathManager) SigningKeyConfig() string {
 	return filepath.Join(UserConfig, SigningKeysFile)
 }
 
-// TrustPolicy returns the path of trustpolicy.json file based on named directory level.
+// TrustPolicy returns the path of trustpolicy.json file based on named
+// directory level.
 func (p *PathManager) TrustPolicy(dirLevel DirLevel) string {
 	var (
 		path string
@@ -142,7 +144,7 @@ func (p *PathManager) X509TrustStore(dirLevel DirLevel, prefix, namedStore strin
 	return path
 }
 
-// CachedSignature returns the cached signature file path
+// CachedSignature returns the cached signature file path.
 func (p *PathManager) CachedSignature(manifestDigest, signatureDigest digest.Digest) string {
 	path, err := p.CacheFS.GetPath(
 		SignatureStoreDirName,
@@ -155,7 +157,7 @@ func (p *PathManager) CachedSignature(manifestDigest, signatureDigest digest.Dig
 	return path
 }
 
-// CachedSignatureRoot returns the cached signature root path
+// CachedSignatureRoot returns the cached signature root path.
 func (p *PathManager) CachedSignatureRoot(manifestDigest digest.Digest) string {
 	path, err := p.CacheFS.GetPath(
 		SignatureStoreDirName,
@@ -166,7 +168,7 @@ func (p *PathManager) CachedSignatureRoot(manifestDigest digest.Digest) string {
 	return path
 }
 
-// CachedSignatureStoreDirPath returns the cached signing keys directory
+// CachedSignatureStoreDirPath returns the cached signing keys directory.
 func (p *PathManager) CachedSignatureStoreDirPath() string {
 	path, err := p.CacheFS.GetPath(SignatureStoreDirName)
 	checkError(err)

--- a/dir/path.go
+++ b/dir/path.go
@@ -9,31 +9,31 @@ import (
 )
 
 const (
-	// ConfigFile is the name of config file
+	// ConfigFile is the name of config file.
 	ConfigFile = "config.json"
 
-	// LocalCertificateExtension defines the extension of the certificate files
+	// LocalCertificateExtension defines the extension of the certificate files.
 	LocalCertificateExtension = ".crt"
 
-	// LocalKeyExtension defines the extension of the key files
+	// LocalKeyExtension defines the extension of the key files.
 	LocalKeyExtension = ".key"
 
-	// LocalKeysDir is the directory name for local key store
+	// LocalKeysDir is the directory name for local key store.
 	LocalKeysDir = "localkeys"
 
-	// SignatureExtension defines the extension of the signature files
+	// SignatureExtension defines the extension of the signature files.
 	SignatureExtension = ".sig"
 
-	// SignatureStoreDirName is the name of the signature store directory
+	// SignatureStoreDirName is the name of the signature store directory.
 	SignatureStoreDirName = "signatures"
 
-	// SigningKeysFile is the file name of signing key info
+	// SigningKeysFile is the file name of signing key info.
 	SigningKeysFile = "signingkeys.json"
 
-	// TrustPolicyFile is the file name of trust policy info
+	// TrustPolicyFile is the file name of trust policy info.
 	TrustPolicyFile = "trustpolicy.json"
 
-	// TrustStoreDir is the directory name of trust store
+	// TrustStoreDir is the directory name of trust store.
 	TrustStoreDir = "truststore"
 )
 
@@ -46,15 +46,15 @@ const (
 	// [directory spec]: https://github.com/notaryproject/notation/blob/main/specs/directory.md#category
 	UnionLevel DirLevel = iota
 
-	// SystemLevel is the label to specify write directory to system level
+	// SystemLevel is the label to specify write directory to system level.
 	SystemLevel
 
-	// UserLevel is the label to specify write directory to user level
+	// UserLevel is the label to specify write directory to user level.
 	UserLevel
 )
 
 // PathManager contains the union directory file system and methods
-// to access paths of notation
+// to access paths of notation.
 type PathManager struct {
 	ConfigFS  UnionDirFS
 	CacheFS   UnionDirFS
@@ -62,7 +62,7 @@ type PathManager struct {
 }
 
 func checkError(err error) {
-	// if path does not exist, the path can be used to create file
+	// if path does not exist, the path can be used to create file.
 	if err != nil && !errors.Is(err, fs.ErrNotExist) {
 		panic(err)
 	}
@@ -123,9 +123,9 @@ func (p *PathManager) TrustPolicy(dirLevel DirLevel) string {
 	return path
 }
 
-// X509TrustStore returns the path of x509 trust store certificate
+// TrustStore returns the path of x509 trust store certificate
 // based on named directory level.
-func (p *PathManager) X509TrustStore(dirLevel DirLevel, prefix, namedStore string) string {
+func (p *PathManager) TrustStore(dirLevel DirLevel, prefix, namedStore string) string {
 	var (
 		path string
 		err  error

--- a/dir/path_test.go
+++ b/dir/path_test.go
@@ -113,7 +113,7 @@ func TestX509TrustStoreCerts(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := config.X509TrustStore(UnionLevel, tt.args.prefix, tt.args.namedStore)
+			got := config.TrustStore(UnionLevel, tt.args.prefix, tt.args.namedStore)
 			assertPathEqual(t, tt.want, got, "X509TrustStoreCerts path error.")
 		})
 	}
@@ -182,7 +182,7 @@ func TestTrustStoreForWrite(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := config.X509TrustStore(tt.args.WriteLevel, "ca", "jj")
+			got := config.TrustStore(tt.args.WriteLevel, "ca", "jj")
 			assertPathEqual(t, tt.want, got, "config path for write error.")
 		})
 	}
@@ -273,7 +273,7 @@ func TestPathManager_X509TrustStore(t *testing.T) {
 			NewRootedFS("/home/exampleuser/.config/notation/", nil),
 		),
 	}
-	storePath := path.X509TrustStore(UnionLevel, "ca", "store")
+	storePath := path.TrustStore(UnionLevel, "ca", "store")
 	if storePath != "/home/exampleuser/.config/notation/truststore/x509/ca/store" {
 		t.Fatal("get X509TrustStore() failed.")
 	}

--- a/dir/path_test.go
+++ b/dir/path_test.go
@@ -119,6 +119,153 @@ func TestX509TrustStoreCerts(t *testing.T) {
 	}
 }
 
+func TestConfigForWrite(t *testing.T) {
+	config := PathManager{
+		UserConfigFS: unionDirFS{
+			Dirs: []RootedFS{
+				NewRootedFS(
+					"/user/exampleuser/.config/notation",
+					fstest.MapFS{},
+				),
+			},
+		},
+		SystemConfigFS: unionDirFS{
+			Dirs: []RootedFS{
+				NewRootedFS(
+					"/etc/notation",
+					fstest.MapFS{},
+				),
+			},
+		},
+	}
+	type args struct {
+		WriteLevel WriteLevel
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    string
+		wantErr bool
+	}{
+		{
+			name:    "config path for write in user level",
+			args:    args{UserLevel},
+			want:    "/user/exampleuser/.config/notation/config.json",
+			wantErr: false,
+		},
+		{
+			name:    "config path for write in system level",
+			args:    args{SystemLevel},
+			want:    "/etc/notation/config.json",
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := config.ConfigForWrite(tt.args.WriteLevel)
+			assertPathEqual(t, tt.want, got, "config path for write error.")
+		})
+	}
+}
+
+func TestTrustStoreForWrite(t *testing.T) {
+	config := PathManager{
+		UserConfigFS: unionDirFS{
+			Dirs: []RootedFS{
+				NewRootedFS(
+					"/user/exampleuser/.config/notation",
+					fstest.MapFS{},
+				),
+			},
+		},
+		SystemConfigFS: unionDirFS{
+			Dirs: []RootedFS{
+				NewRootedFS(
+					"/etc/notation",
+					fstest.MapFS{},
+				),
+			},
+		},
+	}
+	type args struct {
+		WriteLevel WriteLevel
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    string
+		wantErr bool
+	}{
+		{
+			name:    "trust store path for write in user level",
+			args:    args{UserLevel},
+			want:    "/user/exampleuser/.config/notation/truststore/x509/ca/jj",
+			wantErr: false,
+		},
+		{
+			name:    "trust store path for write in system level",
+			args:    args{SystemLevel},
+			want:    "/etc/notation/truststore/x509/ca/jj",
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := config.X509TrustStoreForWrite(tt.args.WriteLevel, "ca", "jj")
+			assertPathEqual(t, tt.want, got, "config path for write error.")
+		})
+	}
+}
+
+func TestTrustPolicyForWrite(t *testing.T) {
+	config := PathManager{
+		UserConfigFS: unionDirFS{
+			Dirs: []RootedFS{
+				NewRootedFS(
+					"/user/exampleuser/.config/notation",
+					fstest.MapFS{},
+				),
+			},
+		},
+		SystemConfigFS: unionDirFS{
+			Dirs: []RootedFS{
+				NewRootedFS(
+					"/etc/notation",
+					fstest.MapFS{},
+				),
+			},
+		},
+	}
+	type args struct {
+		WriteLevel WriteLevel
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    string
+		wantErr bool
+	}{
+		{
+			name:    "trust policy path for write in user level",
+			args:    args{UserLevel},
+			want:    "/user/exampleuser/.config/notation/trustpolicy.json",
+			wantErr: false,
+		},
+		{
+			name:    "trust policy path for write in system level",
+			args:    args{SystemLevel},
+			want:    "/etc/notation/trustpolicy.json",
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := config.TrustPolicyForWrite(tt.args.WriteLevel)
+			assertPathEqual(t, tt.want, got, "config path for write error.")
+		})
+	}
+}
+
 func TestPathManager_Config(t *testing.T) {
 	path := &PathManager{
 		ConfigFS: NewUnionDirFS(

--- a/dir/path_test.go
+++ b/dir/path_test.go
@@ -121,8 +121,8 @@ func TestX509TrustStoreCerts(t *testing.T) {
 
 func TestConfigForWrite(t *testing.T) {
 	config := PathManager{}
-	userConfig = "/user/exampleuser/.config/notation/"
-	systemConfig = "/etc/notation/"
+	UserConfig = "/user/exampleuser/.config/notation/"
+	SystemConfig = "/etc/notation/"
 
 	type args struct {
 		WriteLevel DirLevel
@@ -156,8 +156,8 @@ func TestConfigForWrite(t *testing.T) {
 
 func TestTrustStoreForWrite(t *testing.T) {
 	config := PathManager{}
-	userConfig = "/user/exampleuser/.config/notation/"
-	systemConfig = "/etc/notation/"
+	UserConfig = "/user/exampleuser/.config/notation/"
+	SystemConfig = "/etc/notation/"
 	type args struct {
 		WriteLevel DirLevel
 	}
@@ -190,8 +190,8 @@ func TestTrustStoreForWrite(t *testing.T) {
 
 func TestTrustPolicyForWrite(t *testing.T) {
 	config := PathManager{}
-	userConfig = "/user/exampleuser/.config/notation/"
-	systemConfig = "/etc/notation/"
+	UserConfig = "/user/exampleuser/.config/notation/"
+	SystemConfig = "/etc/notation/"
 	type args struct {
 		WriteLevel DirLevel
 	}
@@ -236,7 +236,7 @@ func TestPathManager_Config(t *testing.T) {
 
 func TestPathManager_LocalKey(t *testing.T) {
 	path := &PathManager{}
-	userConfig = "/home/exampleuser/.config/notation/"
+	UserConfig = "/home/exampleuser/.config/notation/"
 	keyPath, certPath := path.Localkey("key1")
 	if keyPath != "/home/exampleuser/.config/notation/localkeys/key1"+LocalKeyExtension {
 		t.Fatal("get Localkey() failed.")
@@ -248,7 +248,7 @@ func TestPathManager_LocalKey(t *testing.T) {
 
 func TestPathManager_SigningKeyConfig(t *testing.T) {
 	path := &PathManager{}
-	userConfig = "/home/exampleuser/.config/notation/"
+	UserConfig = "/home/exampleuser/.config/notation/"
 	signingKeyPath := path.SigningKeyConfig()
 	if signingKeyPath != "/home/exampleuser/.config/notation/"+SigningKeysFile {
 		t.Fatal("get SigningKeyConfig() failed.")

--- a/dir/path_test.go
+++ b/dir/path_test.go
@@ -113,33 +113,19 @@ func TestX509TrustStoreCerts(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := config.X509TrustStore(tt.args.prefix, tt.args.namedStore)
+			got := config.X509TrustStore(UnionLevel, tt.args.prefix, tt.args.namedStore)
 			assertPathEqual(t, tt.want, got, "X509TrustStoreCerts path error.")
 		})
 	}
 }
 
 func TestConfigForWrite(t *testing.T) {
-	config := PathManager{
-		UserConfigFS: unionDirFS{
-			Dirs: []RootedFS{
-				NewRootedFS(
-					"/user/exampleuser/.config/notation",
-					fstest.MapFS{},
-				),
-			},
-		},
-		SystemConfigFS: unionDirFS{
-			Dirs: []RootedFS{
-				NewRootedFS(
-					"/etc/notation",
-					fstest.MapFS{},
-				),
-			},
-		},
-	}
+	config := PathManager{}
+	userConfig = "/user/exampleuser/.config/notation/"
+	systemConfig = "/etc/notation/"
+
 	type args struct {
-		WriteLevel WriteLevel
+		WriteLevel DirLevel
 	}
 	tests := []struct {
 		name    string
@@ -162,33 +148,18 @@ func TestConfigForWrite(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := config.ConfigForWrite(tt.args.WriteLevel)
+			got := config.Config(tt.args.WriteLevel)
 			assertPathEqual(t, tt.want, got, "config path for write error.")
 		})
 	}
 }
 
 func TestTrustStoreForWrite(t *testing.T) {
-	config := PathManager{
-		UserConfigFS: unionDirFS{
-			Dirs: []RootedFS{
-				NewRootedFS(
-					"/user/exampleuser/.config/notation",
-					fstest.MapFS{},
-				),
-			},
-		},
-		SystemConfigFS: unionDirFS{
-			Dirs: []RootedFS{
-				NewRootedFS(
-					"/etc/notation",
-					fstest.MapFS{},
-				),
-			},
-		},
-	}
+	config := PathManager{}
+	userConfig = "/user/exampleuser/.config/notation/"
+	systemConfig = "/etc/notation/"
 	type args struct {
-		WriteLevel WriteLevel
+		WriteLevel DirLevel
 	}
 	tests := []struct {
 		name    string
@@ -211,33 +182,18 @@ func TestTrustStoreForWrite(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := config.X509TrustStoreForWrite(tt.args.WriteLevel, "ca", "jj")
+			got := config.X509TrustStore(tt.args.WriteLevel, "ca", "jj")
 			assertPathEqual(t, tt.want, got, "config path for write error.")
 		})
 	}
 }
 
 func TestTrustPolicyForWrite(t *testing.T) {
-	config := PathManager{
-		UserConfigFS: unionDirFS{
-			Dirs: []RootedFS{
-				NewRootedFS(
-					"/user/exampleuser/.config/notation",
-					fstest.MapFS{},
-				),
-			},
-		},
-		SystemConfigFS: unionDirFS{
-			Dirs: []RootedFS{
-				NewRootedFS(
-					"/etc/notation",
-					fstest.MapFS{},
-				),
-			},
-		},
-	}
+	config := PathManager{}
+	userConfig = "/user/exampleuser/.config/notation/"
+	systemConfig = "/etc/notation/"
 	type args struct {
-		WriteLevel WriteLevel
+		WriteLevel DirLevel
 	}
 	tests := []struct {
 		name    string
@@ -260,7 +216,7 @@ func TestTrustPolicyForWrite(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := config.TrustPolicyForWrite(tt.args.WriteLevel)
+			got := config.TrustPolicy(tt.args.WriteLevel)
 			assertPathEqual(t, tt.want, got, "config path for write error.")
 		})
 	}
@@ -272,18 +228,15 @@ func TestPathManager_Config(t *testing.T) {
 			NewRootedFS("/home/exampleuser/.config/notation/", nil),
 		),
 	}
-	configPath := path.Config()
+	configPath := path.Config(UnionLevel)
 	if configPath != "/home/exampleuser/.config/notation/"+ConfigFile {
 		t.Fatal("get Config() failed.")
 	}
 }
 
 func TestPathManager_LocalKey(t *testing.T) {
-	path := &PathManager{
-		UserConfigFS: NewUnionDirFS(
-			NewRootedFS("/home/exampleuser/.config/notation/", nil),
-		),
-	}
+	path := &PathManager{}
+	userConfig = "/home/exampleuser/.config/notation/"
 	keyPath, certPath := path.Localkey("key1")
 	if keyPath != "/home/exampleuser/.config/notation/localkeys/key1"+LocalKeyExtension {
 		t.Fatal("get Localkey() failed.")
@@ -294,11 +247,8 @@ func TestPathManager_LocalKey(t *testing.T) {
 }
 
 func TestPathManager_SigningKeyConfig(t *testing.T) {
-	path := &PathManager{
-		UserConfigFS: NewUnionDirFS(
-			NewRootedFS("/home/exampleuser/.config/notation/", nil),
-		),
-	}
+	path := &PathManager{}
+	userConfig = "/home/exampleuser/.config/notation/"
 	signingKeyPath := path.SigningKeyConfig()
 	if signingKeyPath != "/home/exampleuser/.config/notation/"+SigningKeysFile {
 		t.Fatal("get SigningKeyConfig() failed.")
@@ -311,7 +261,7 @@ func TestPathManager_TrustPolicy(t *testing.T) {
 			NewRootedFS("/home/exampleuser/.config/notation/", nil),
 		),
 	}
-	policyPath := path.TrustPolicy()
+	policyPath := path.TrustPolicy(UnionLevel)
 	if policyPath != "/home/exampleuser/.config/notation/"+TrustPolicyFile {
 		t.Fatal("get TrustPolicy() failed.")
 	}
@@ -323,7 +273,7 @@ func TestPathManager_X509TrustStore(t *testing.T) {
 			NewRootedFS("/home/exampleuser/.config/notation/", nil),
 		),
 	}
-	storePath := path.X509TrustStore("ca", "store")
+	storePath := path.X509TrustStore(UnionLevel, "ca", "store")
 	if storePath != "/home/exampleuser/.config/notation/truststore/x509/ca/store" {
 		t.Fatal("get X509TrustStore() failed.")
 	}

--- a/verification/helpers.go
+++ b/verification/helpers.go
@@ -50,7 +50,7 @@ func loadX509TrustStores(scheme signature.SigningScheme, policy *TrustPolicy, pa
 		}
 
 		name := trustStore[i+1:]
-		x509TrustStore, err := LoadX509TrustStore(pathManager.X509TrustStore(dir.UnionLevel, prefix, name))
+		x509TrustStore, err := LoadX509TrustStore(pathManager.TrustStore(dir.UnionLevel, prefix, name))
 		if err != nil {
 			return nil, err
 		}

--- a/verification/helpers.go
+++ b/verification/helpers.go
@@ -50,7 +50,7 @@ func loadX509TrustStores(scheme signature.SigningScheme, policy *TrustPolicy, pa
 		}
 
 		name := trustStore[i+1:]
-		x509TrustStore, err := LoadX509TrustStore(pathManager.X509TrustStore(prefix, name))
+		x509TrustStore, err := LoadX509TrustStore(pathManager.X509TrustStore(dir.UnionLevel, prefix, name))
 		if err != nil {
 			return nil, err
 		}

--- a/verification/verifier.go
+++ b/verification/verifier.go
@@ -27,7 +27,7 @@ type pluginManager interface {
 
 func NewVerifier(repository registry.Repository) (*Verifier, error) {
 	// load trust policy
-	policyDocument, err := loadPolicyDocument(dir.Path.TrustPolicy())
+	policyDocument, err := loadPolicyDocument(dir.Path.TrustPolicy(dir.UnionLevel))
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
1. config add EnvelopeType argument.
2. dir package optimize: allow user define DirLevel = UserLevel | SystemLevel | UnionLevel.
4. refector config pacakge: receive a path argument when load and save file to allow user to overwrite the default directory structure.

Test: added unit test.

Resolves #144 
Signed-off-by: Junjie Gao <junjiegao@microsoft.com>