### PR TITLE
fix: optimize config package

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -43,28 +43,28 @@ func NewConfig() *Config {
 
 // Save stores the config to file.
 //
-// if the `path` is not set, it uses build-in user level config directory.
-func (c *Config) Save(path ...string) error {
-	if len(path) > 0 {
-		return save(path[0], c)
+// if the `path` is an empty string, it uses build-in user level config directory.
+func (c *Config) Save(path string) error {
+	// set default path
+	if path == "" {
+		path = dir.Path.ConfigForWrite(dir.UserLevel)
 	}
-	return save(dir.Path.ConfigForWrite(dir.UserLevel), c)
+	return save(path, c)
 }
 
 // LoadConfig reads the config from file or return a default config if not found.
 //
-// if `path` is not set, it uses build-in config.json directory, including
+// if `path` is an empty string, it uses build-in config.json directory, including
 // user level and system level.
-func LoadConfig(path ...string) (*Config, error) {
-	var (
-		err    error
-		config Config
-	)
-	if len(path) > 0 {
-		err = load(path[0], &config)
-	} else {
-		err = load(dir.Path.Config(), &config)
+func LoadConfig(path string) (*Config, error) {
+	// set default path
+	if path == "" {
+		path = dir.Path.Config()
 	}
+
+	// load config
+	var config Config
+	err := load(path, &config)
 	if err != nil {
 		if errors.Is(err, fs.ErrNotExist) {
 			return NewConfig(), nil

--- a/config/keys.go
+++ b/config/keys.go
@@ -42,12 +42,13 @@ type SigningKeys struct {
 
 // Save config to file.
 //
-// if `path` is not set, it uses build-in user level signingkey.json directory.
-func (s *SigningKeys) Save(path ...string) error {
-	if len(path) > 0 {
-		return save(path[0], s)
+// if `path` is an empty string, it uses build-in user level signingkey.json directory.
+func (s *SigningKeys) Save(path string) error {
+	// set default path
+	if path == "" {
+		path = dir.Path.SigningKeyConfig()
 	}
-	return save(dir.Path.SigningKeyConfig(), s)
+	return save(path, s)
 }
 
 // NewSigningKeys creates a new signingkeys config file.
@@ -58,18 +59,16 @@ func NewSigningKeys() *SigningKeys {
 // LoadSigningKeys reads the config from file
 // or return a default config if not found.
 //
-// if `path` is not set, it uses build-in user level signingkey.json directory.
-func LoadSigningKeys(path ...string) (*SigningKeys, error) {
-	var (
-		err    error
-		config SigningKeys
-	)
-	if len(path) > 0 {
-		err = load(path[0], &config)
-	} else {
-		err = load(dir.Path.SigningKeyConfig(), &config)
+// if `path` is an empty string, it uses build-in user level signingkey.json directory.
+func LoadSigningKeys(path string) (*SigningKeys, error) {
+	// set default path
+	if path == "" {
+		path = dir.Path.SigningKeyConfig()
 	}
 
+	// load signingkeys config
+	var config SigningKeys
+	err := load(path, &config)
 	if err != nil {
 		if errors.Is(err, fs.ErrNotExist) {
 			return NewSigningKeys(), nil


### PR DESCRIPTION
change the config load & save function's `path` parameter to be a single string value instead of an array of string.

Signed-off-by: Junjie Gao <junjiegao@microsoft.com>