### PR TITLE
fix: only check root cert is CA cert

### DIFF
--- a/verification/store.go
+++ b/verification/store.go
@@ -56,10 +56,9 @@ func LoadX509TrustStore(path string) (*X509TrustStore, error) {
 		if len(certs) < 1 {
 			return nil, fmt.Errorf("could not parse a certificate from %q, every file in a trust store must have a PEM or DER certificate in it", joinedPath)
 		}
-		for _, cert := range certs {
-			if !cert.IsCA {
-				return nil, fmt.Errorf("certificate with subject %q from file %q is not a CA certificate, only CA certificates (BasicConstraint CA=True) are allowed", cert.Subject, joinedPath)
-			}
+		rootCert := certs[len(certs) - 1]
+		if !rootCert.IsCA {
+			return nil, fmt.Errorf("root certificate with subject %q from file %q is not a CA certificate, only CA certificates (BasicConstraint CA=True) are allowed", rootCert.Subject, joinedPath)
 		}
 
 		trustStore.Certificates = append(trustStore.Certificates, certs...)

--- a/verification/store_test.go
+++ b/verification/store_test.go
@@ -68,7 +68,7 @@ func TestLoadTrustStoreWithLeafCerts(t *testing.T) {
 	path := filepath.FromSlash("testdata/truststore/x509/trust-store-with-leaf-certs")
 	failurePath := filepath.FromSlash("testdata/truststore/x509/trust-store-with-leaf-certs/non-ca.crt")
 	_, err := LoadX509TrustStore(path)
-	if err == nil || err.Error() != fmt.Sprintf("certificate with subject \"CN=lol,OU=lol,O=lol,L=lol,ST=Some-State,C=AU,1.2.840.113549.1.9.1=#13036c6f6c\" from file %q is not a CA certificate, only CA certificates (BasicConstraint CA=True) are allowed", failurePath) {
+	if err == nil || err.Error() != fmt.Sprintf("root certificate with subject \"CN=lol,OU=lol,O=lol,L=lol,ST=Some-State,C=AU,1.2.840.113549.1.9.1=#13036c6f6c\" from file %q is not a CA certificate, only CA certificates (BasicConstraint CA=True) are allowed", failurePath) {
 		t.Fatalf("leaf cert in a trust store should return error : %q", err)
 	}
 }


### PR DESCRIPTION
### What?

For a valid cert chain, we require that the root cert should be a CA cert. But the current implementation require all certs should satisfy with it. Update it to validate the root cert only.

### Test
Updated unit tests.

Signed-off-by: Binbin Li <libinbin@microsoft.com>