### PR TITLE
build: update notation-core-go to use main branch

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.18
 
 require (
 	github.com/go-ldap/ldap/v3 v3.4.4
-	github.com/notaryproject/notation-core-go v0.0.0-20220926064152-c65f5c6b3537
+	github.com/notaryproject/notation-core-go v0.1.0-alpha.3.0.20220929020818-b5df54c7465b
 	github.com/opencontainers/go-digest v1.0.0
 	github.com/opencontainers/image-spec v1.0.2
 	github.com/oras-project/artifacts-spec v1.0.0-rc.2

--- a/go.sum
+++ b/go.sum
@@ -10,8 +10,8 @@ github.com/go-ldap/ldap/v3 v3.4.4 h1:qPjipEpt+qDa6SI/h1fzuGWoRUY+qqQ9sOZq67/PYUs
 github.com/go-ldap/ldap/v3 v3.4.4/go.mod h1:fe1MsuN5eJJ1FeLT/LEBVdWfNWKh459R7aXgXtJC+aI=
 github.com/golang-jwt/jwt/v4 v4.4.2 h1:rcc4lwaZgFMCZ5jxF9ABolDcIHdBytAFgqFPbSJQAYs=
 github.com/golang-jwt/jwt/v4 v4.4.2/go.mod h1:m21LjoU+eqJr34lmDMbreY2eSTRJ1cv77w39/MY0Ch0=
-github.com/notaryproject/notation-core-go v0.0.0-20220926064152-c65f5c6b3537 h1:z2GiPNoJtMQdI2hqDO4a7XpCPf7+1J7/MJYpF8C8AAM=
-github.com/notaryproject/notation-core-go v0.0.0-20220926064152-c65f5c6b3537/go.mod h1:s8DZptmN1rZS0tBLTPt/w+d4o6eAcGWTYYJlXaJhQ4U=
+github.com/notaryproject/notation-core-go v0.1.0-alpha.3.0.20220929020818-b5df54c7465b h1:acKGhDN17oQn+JhsrkUklFpfhn7CS1ceQl3XqJm/9CI=
+github.com/notaryproject/notation-core-go v0.1.0-alpha.3.0.20220929020818-b5df54c7465b/go.mod h1:s8DZptmN1rZS0tBLTPt/w+d4o6eAcGWTYYJlXaJhQ4U=
 github.com/opencontainers/distribution-spec/specs-go v0.0.0-20220620172159-4ab4752c3b86 h1:Oumw+lPnO8qNLTY2mrqPJZMoGExLi/0h/DdikoLTXVU=
 github.com/opencontainers/distribution-spec/specs-go v0.0.0-20220620172159-4ab4752c3b86/go.mod h1:aA4vdXRS8E1TG7pLZOz85InHi3BiPdErh8IpJN6E0x4=
 github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8Oi/yOhh5U=


### PR DESCRIPTION
### What?
Switch to notation-core-go main branch.

Signed-off-by: Binbin Li <libinbin@microsoft.com>