### PR TITLE
fix: trustpolicy identity malformed check

### DIFF
--- a/verification/verifier_helpers.go
+++ b/verification/verifier_helpers.go
@@ -216,7 +216,7 @@ func verifyX509TrustedIdentities(certs []*x509.Certificate, trustPolicy *TrustPo
 	for _, identity := range trustPolicy.TrustedIdentities {
 		parts := strings.Split(identity, ":")
 		if len(parts) != 2 {
-			return fmt.Errorf("trustpolicy identity `%s` malformed.", identity)
+			return fmt.Errorf("trustpolicy identity %q is malformed.", identity)
 		}
 
 		identityPrefix := parts[0]

--- a/verification/verifier_helpers.go
+++ b/verification/verifier_helpers.go
@@ -214,10 +214,13 @@ func verifyX509TrustedIdentities(certs []*x509.Certificate, trustPolicy *TrustPo
 
 	var trustedX509Identities []map[string]string
 	for _, identity := range trustPolicy.TrustedIdentities {
-		i := strings.Index(identity, ":")
+		parts := strings.Split(identity, ":")
+		if len(parts) != 2 {
+			return fmt.Errorf("trustpolicy identity `%s` malformed.", identity)
+		}
 
-		identityPrefix := identity[:i]
-		identityValue := identity[i+1:]
+		identityPrefix := parts[0]
+		identityValue := parts[1]
 
 		if identityPrefix == x509Subject {
 			parsedSubject, err := parseDistinguishedName(identityValue)

--- a/verification/verifier_helpers_test.go
+++ b/verification/verifier_helpers_test.go
@@ -44,6 +44,7 @@ func TestVerifyX509TrustedIdentities(t *testing.T) {
 		{[]string{"x509.subject:C=IND,O=SomeOrg,ST=TS"}, true},
 		{[]string{"x509.subject:C=IND,O=SomeOrg,ST=TS", "nonX509Prefix:my-custom-identity"}, true},
 		{[]string{"x509.subject:C=IND,O=SomeOrg,ST=TS", "x509.subject:C=LOL,O=LOL,ST=LOL"}, true},
+		{[]string{"C=IND,O=SomeOrg,ST=TS"}, true},
 	}
 	for i, tt := range tests {
 		t.Run(strconv.Itoa(i), func(t *testing.T) {


### PR DESCRIPTION
Fix the issue:
previously the identity parameter format was not checked. The following identity config causes a runtime error.
```
trustpolicy.json
{...
 "trustedIdentities": [
              "CN=wabbit-networks.io,O=Notary,L=Seattle,ST=WA,C=US"
            ]
...
}
```

Test:
add unit test

Signed-off-by: Junjie Gao <junjiegao@microsoft.com>