### PR TITLE
update: bump up notation-core-go

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.18
 
 require (
 	github.com/go-ldap/ldap/v3 v3.4.4
-	github.com/notaryproject/notation-core-go v0.1.0-alpha.4.0.20221017041709-56bd40a80d26
+	github.com/notaryproject/notation-core-go v0.1.0-alpha.4.0.20221028010439-0e98fb144120
 	github.com/opencontainers/go-digest v1.0.0
 	github.com/opencontainers/image-spec v1.0.2
 	github.com/oras-project/artifacts-spec v1.0.0-rc.2

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.18
 
 require (
 	github.com/go-ldap/ldap/v3 v3.4.4
-	github.com/notaryproject/notation-core-go v0.1.0-alpha.4.0.20221028010439-0e98fb144120
+	github.com/notaryproject/notation-core-go v0.1.0-alpha.4.0.20221031114150-3033a42e145c
 	github.com/opencontainers/go-digest v1.0.0
 	github.com/opencontainers/image-spec v1.0.2
 	github.com/oras-project/artifacts-spec v1.0.0-rc.2

--- a/go.sum
+++ b/go.sum
@@ -10,8 +10,6 @@ github.com/go-ldap/ldap/v3 v3.4.4 h1:qPjipEpt+qDa6SI/h1fzuGWoRUY+qqQ9sOZq67/PYUs
 github.com/go-ldap/ldap/v3 v3.4.4/go.mod h1:fe1MsuN5eJJ1FeLT/LEBVdWfNWKh459R7aXgXtJC+aI=
 github.com/golang-jwt/jwt/v4 v4.4.2 h1:rcc4lwaZgFMCZ5jxF9ABolDcIHdBytAFgqFPbSJQAYs=
 github.com/golang-jwt/jwt/v4 v4.4.2/go.mod h1:m21LjoU+eqJr34lmDMbreY2eSTRJ1cv77w39/MY0Ch0=
-github.com/notaryproject/notation-core-go v0.1.0-alpha.4.0.20221028010439-0e98fb144120 h1:MVUq+8mSWbQECQowzwER5/YuqORHQXGCjX1bzKyorBI=
-github.com/notaryproject/notation-core-go v0.1.0-alpha.4.0.20221028010439-0e98fb144120/go.mod h1:s8DZptmN1rZS0tBLTPt/w+d4o6eAcGWTYYJlXaJhQ4U=
 github.com/notaryproject/notation-core-go v0.1.0-alpha.4.0.20221031114150-3033a42e145c h1:PEZKUf1Ud5PzWo9Vab46YQ5ls7VoCMYcjscxgdLUWIE=
 github.com/notaryproject/notation-core-go v0.1.0-alpha.4.0.20221031114150-3033a42e145c/go.mod h1:s8DZptmN1rZS0tBLTPt/w+d4o6eAcGWTYYJlXaJhQ4U=
 github.com/opencontainers/distribution-spec/specs-go v0.0.0-20220620172159-4ab4752c3b86 h1:Oumw+lPnO8qNLTY2mrqPJZMoGExLi/0h/DdikoLTXVU=

--- a/go.sum
+++ b/go.sum
@@ -10,8 +10,8 @@ github.com/go-ldap/ldap/v3 v3.4.4 h1:qPjipEpt+qDa6SI/h1fzuGWoRUY+qqQ9sOZq67/PYUs
 github.com/go-ldap/ldap/v3 v3.4.4/go.mod h1:fe1MsuN5eJJ1FeLT/LEBVdWfNWKh459R7aXgXtJC+aI=
 github.com/golang-jwt/jwt/v4 v4.4.2 h1:rcc4lwaZgFMCZ5jxF9ABolDcIHdBytAFgqFPbSJQAYs=
 github.com/golang-jwt/jwt/v4 v4.4.2/go.mod h1:m21LjoU+eqJr34lmDMbreY2eSTRJ1cv77w39/MY0Ch0=
-github.com/notaryproject/notation-core-go v0.1.0-alpha.4.0.20221017041709-56bd40a80d26 h1:tAM+m4MocXBXdRBr8GDWABWHw3XiO3PE9+L38aEECLc=
-github.com/notaryproject/notation-core-go v0.1.0-alpha.4.0.20221017041709-56bd40a80d26/go.mod h1:s8DZptmN1rZS0tBLTPt/w+d4o6eAcGWTYYJlXaJhQ4U=
+github.com/notaryproject/notation-core-go v0.1.0-alpha.4.0.20221028010439-0e98fb144120 h1:MVUq+8mSWbQECQowzwER5/YuqORHQXGCjX1bzKyorBI=
+github.com/notaryproject/notation-core-go v0.1.0-alpha.4.0.20221028010439-0e98fb144120/go.mod h1:s8DZptmN1rZS0tBLTPt/w+d4o6eAcGWTYYJlXaJhQ4U=
 github.com/opencontainers/distribution-spec/specs-go v0.0.0-20220620172159-4ab4752c3b86 h1:Oumw+lPnO8qNLTY2mrqPJZMoGExLi/0h/DdikoLTXVU=
 github.com/opencontainers/distribution-spec/specs-go v0.0.0-20220620172159-4ab4752c3b86/go.mod h1:aA4vdXRS8E1TG7pLZOz85InHi3BiPdErh8IpJN6E0x4=
 github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8Oi/yOhh5U=

--- a/go.sum
+++ b/go.sum
@@ -12,6 +12,8 @@ github.com/golang-jwt/jwt/v4 v4.4.2 h1:rcc4lwaZgFMCZ5jxF9ABolDcIHdBytAFgqFPbSJQA
 github.com/golang-jwt/jwt/v4 v4.4.2/go.mod h1:m21LjoU+eqJr34lmDMbreY2eSTRJ1cv77w39/MY0Ch0=
 github.com/notaryproject/notation-core-go v0.1.0-alpha.4.0.20221028010439-0e98fb144120 h1:MVUq+8mSWbQECQowzwER5/YuqORHQXGCjX1bzKyorBI=
 github.com/notaryproject/notation-core-go v0.1.0-alpha.4.0.20221028010439-0e98fb144120/go.mod h1:s8DZptmN1rZS0tBLTPt/w+d4o6eAcGWTYYJlXaJhQ4U=
+github.com/notaryproject/notation-core-go v0.1.0-alpha.4.0.20221031114150-3033a42e145c h1:PEZKUf1Ud5PzWo9Vab46YQ5ls7VoCMYcjscxgdLUWIE=
+github.com/notaryproject/notation-core-go v0.1.0-alpha.4.0.20221031114150-3033a42e145c/go.mod h1:s8DZptmN1rZS0tBLTPt/w+d4o6eAcGWTYYJlXaJhQ4U=
 github.com/opencontainers/distribution-spec/specs-go v0.0.0-20220620172159-4ab4752c3b86 h1:Oumw+lPnO8qNLTY2mrqPJZMoGExLi/0h/DdikoLTXVU=
 github.com/opencontainers/distribution-spec/specs-go v0.0.0-20220620172159-4ab4752c3b86/go.mod h1:aA4vdXRS8E1TG7pLZOz85InHi3BiPdErh8IpJN6E0x4=
 github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8Oi/yOhh5U=

--- a/plugin/plugin.go
+++ b/plugin/plugin.go
@@ -185,18 +185,18 @@ type VerifySignatureRequest struct {
 // Signature represents a signature pulled from the envelope
 type Signature struct {
 	CriticalAttributes    CriticalAttributes `json:"criticalAttributes"`
-	UnprocessedAttributes []string           `json:"unprocessedAttributes"`
+	UnprocessedAttributes []interface{}      `json:"unprocessedAttributes"`
 	CertificateChain      [][]byte           `json:"certificateChain"`
 }
 
 // CriticalAttributes contains all Notary V2 defined critical
 // attributes and their values in the signature envelope
 type CriticalAttributes struct {
-	ContentType          string                 `json:"contentType"`
-	SigningScheme        string                 `json:"signingScheme"`
-	Expiry               *time.Time             `json:"expiry,omitempty"`
-	AuthenticSigningTime *time.Time             `json:"authenticSigningTime,omitempty"`
-	ExtendedAttributes   map[string]interface{} `json:"extendedAttributes,omitempty"`
+	ContentType          string                      `json:"contentType"`
+	SigningScheme        string                      `json:"signingScheme"`
+	Expiry               *time.Time                  `json:"expiry,omitempty"`
+	AuthenticSigningTime *time.Time                  `json:"authenticSigningTime,omitempty"`
+	ExtendedAttributes   map[interface{}]interface{} `json:"extendedAttributes,omitempty"`
 }
 
 // TrustPolicy represents trusted identities that sign the artifacts
@@ -212,7 +212,7 @@ func (VerifySignatureRequest) Command() Command {
 // VerifySignatureResponse is the response of a verify-signature request.
 type VerifySignatureResponse struct {
 	VerificationResults map[VerificationCapability]*VerificationResult `json:"verificationResults"`
-	ProcessedAttributes []string                                       `json:"processedAttributes"`
+	ProcessedAttributes []interface{}                                  `json:"processedAttributes"`
 }
 
 // VerificationResult is the result of a verification performed by the plugin

--- a/verification/helpers.go
+++ b/verification/helpers.go
@@ -69,6 +69,15 @@ func isPresent(val string, values []string) bool {
 	return false
 }
 
+func isPresentAny(val interface{}, values []interface{}) bool {
+	for _, v := range values {
+		if v == val {
+			return true
+		}
+	}
+	return false
+}
+
 func getArtifactPathFromUri(artifactUri string) (string, error) {
 	// TODO support more types of URI like "domain.com/repository", "domain.com/repository:tag"
 	i := strings.LastIndex(artifactUri, "@")

--- a/verification/verifier.go
+++ b/verification/verifier.go
@@ -247,7 +247,7 @@ func (v *Verifier) processPluginResponse(capabilitiesToVerify []plugin.Verificat
 	// verify all extended critical attributes are processed by the plugin
 	for _, attr := range outcome.EnvelopeContent.SignerInfo.SignedAttributes.ExtendedAttributes {
 		if attr.Critical {
-			if !isPresent(attr.Key, response.ProcessedAttributes) {
+			if !isPresentAny(attr.Key, response.ProcessedAttributes) {
 				return fmt.Errorf("extended critical attribute %q was not processed by the verification plugin %q (all extended critical attributes must be processed by the verification plugin)", attr.Key, verificationPluginName)
 			}
 		}

--- a/verification/verifier_helpers.go
+++ b/verification/verifier_helpers.go
@@ -253,8 +253,8 @@ func (v *Verifier) executePlugin(ctx context.Context, trustPolicy *TrustPolicy, 
 	if err != nil {
 		return nil, err
 	}
-	var attributesToProcess []string
-	extendedAttributes := make(map[string]interface{})
+	var attributesToProcess []interface{}
+	extendedAttributes := make(map[interface{}]interface{})
 
 	// pass extended critical attributes to the plugin's verify-signature command
 	for _, attr := range signerInfo.SignedAttributes.ExtendedAttributes {

--- a/verification/verifier_test.go
+++ b/verification/verifier_test.go
@@ -446,7 +446,7 @@ func assertPluginVerification(scheme signature.SigningScheme, t *testing.T) {
 				Success: true,
 			},
 		},
-		ProcessedAttributes: []string{mock.PluginExtendedCriticalAttribute.Key, VerificationPlugin},
+		ProcessedAttributes: []interface{}{mock.PluginExtendedCriticalAttribute.Key, VerificationPlugin},
 	}
 
 	verifier = Verifier{
@@ -470,7 +470,7 @@ func assertPluginVerification(scheme signature.SigningScheme, t *testing.T) {
 				Reason:  "i feel like failing today",
 			},
 		},
-		ProcessedAttributes: []string{mock.PluginExtendedCriticalAttribute.Key, VerificationPlugin},
+		ProcessedAttributes: []interface{}{mock.PluginExtendedCriticalAttribute.Key, VerificationPlugin},
 	}
 
 	verifier = Verifier{
@@ -493,7 +493,7 @@ func assertPluginVerification(scheme signature.SigningScheme, t *testing.T) {
 				Success: true,
 			},
 		},
-		ProcessedAttributes: []string{mock.PluginExtendedCriticalAttribute.Key, VerificationPlugin},
+		ProcessedAttributes: []interface{}{mock.PluginExtendedCriticalAttribute.Key, VerificationPlugin},
 	}
 
 	verifier = Verifier{
@@ -517,7 +517,7 @@ func assertPluginVerification(scheme signature.SigningScheme, t *testing.T) {
 				Reason:  "i feel like failing today",
 			},
 		},
-		ProcessedAttributes: []string{mock.PluginExtendedCriticalAttribute.Key, VerificationPlugin},
+		ProcessedAttributes: []interface{}{mock.PluginExtendedCriticalAttribute.Key, VerificationPlugin},
 	}
 
 	verifier = Verifier{
@@ -543,7 +543,7 @@ func assertPluginVerification(scheme signature.SigningScheme, t *testing.T) {
 				Success: true,
 			},
 		},
-		ProcessedAttributes: []string{mock.PluginExtendedCriticalAttribute.Key, VerificationPlugin},
+		ProcessedAttributes: []interface{}{mock.PluginExtendedCriticalAttribute.Key, VerificationPlugin},
 	}
 
 	verifier = Verifier{
@@ -599,7 +599,7 @@ func assertPluginVerification(scheme signature.SigningScheme, t *testing.T) {
 				Success: true,
 			},
 		},
-		ProcessedAttributes: []string{VerificationPlugin}, // exclude the critical attribute
+		ProcessedAttributes: []interface{}{VerificationPlugin}, // exclude the critical attribute
 	}
 
 	verifier = Verifier{
@@ -618,7 +618,7 @@ func assertPluginVerification(scheme signature.SigningScheme, t *testing.T) {
 	pluginManager.PluginCapabilities = []plugin.Capability{plugin.CapabilityTrustedIdentityVerifier}
 	pluginManager.PluginRunnerExecuteResponse = &plugin.VerifySignatureResponse{
 		VerificationResults: map[plugin.VerificationCapability]*plugin.VerificationResult{},
-		ProcessedAttributes: []string{mock.PluginExtendedCriticalAttribute.Key, VerificationPlugin},
+		ProcessedAttributes: []interface{}{mock.PluginExtendedCriticalAttribute.Key, VerificationPlugin},
 	}
 
 	verifier = Verifier{


### PR DESCRIPTION
This PR bumps up notation-core-go. Since extended attribute key type is changed to interface{}, notation-go code needs to be updated accordingly.

Signed-off-by: Patrick Zheng <patrickzheng@microsoft.com>