### PR TITLE
Add additional header validation for payload

### DIFF
--- a/notation.go
+++ b/notation.go
@@ -26,7 +26,7 @@ var errDoneVerification = errors.New("done verification")
 
 // SignOptions contains parameters for Signer.Sign.
 type SignOptions struct {
-	// Reference of the artifact that needs to be signed.
+	// ArtifactReference sets the reference of the artifact that needs to be signed.
 	ArtifactReference string
 
 	// SignatureMediaType is the envelope type of the signature.
@@ -38,8 +38,11 @@ type SignOptions struct {
 	// represents no expiry duration.
 	ExpiryDuration time.Duration
 
-	// Sets or overrides the plugin configuration.
+	// PluginConfig sets or overrides the plugin configuration.
 	PluginConfig map[string]string
+
+	// SigningAgent sets the signing agent name
+	SigningAgent string
 }
 
 // Signer is a generic interface for signing an artifact.

--- a/signer/signer.go
+++ b/signer/signer.go
@@ -82,6 +82,12 @@ func (s *genericSigner) Sign(ctx context.Context, desc ocispec.Descriptor, opts 
 		return nil, nil, fmt.Errorf("envelope payload can't be marshalled: %w", err)
 	}
 
+	var signingAgentId string
+	if opts.SigningAgent != "" {
+		signingAgentId = opts.SigningAgent
+	} else {
+		signingAgentId = signingAgent
+	}
 	signReq := &signature.SignRequest{
 		Payload: signature.Payload{
 			ContentType: envelope.MediaTypePayloadV1,
@@ -90,7 +96,7 @@ func (s *genericSigner) Sign(ctx context.Context, desc ocispec.Descriptor, opts 
 		Signer:        s.Signer,
 		SigningTime:   time.Now(),
 		SigningScheme: signature.SigningSchemeX509,
-		SigningAgent:  signingAgent, // TODO: include external signing plugin's name and version. https://github.com/notaryproject/notation-go/issues/80
+		SigningAgent:  signingAgentId,
 	}
 
 	// Add expiry only if ExpiryDuration is not zero


### PR DESCRIPTION
Addresses TODO's tracked in [Issue 80](https://github.com/notaryproject/notation-go/issues/80)

- Note that new tests for NewSignerFromFiles were already added back [in September](https://github.com/notaryproject/notation-go/commit/2bcfd343f974938e8eeb76e233bc2526e0c36061)

- Validations around no top-level attributes being added are from [5.c.c](https://github.com/notaryproject/notaryproject/blob/main/specs/plugin-extensibility.md#signing-workflow-using-plugin-1) in the spec

Signed-off-by: Jonathan Donas <jddonas@amazon.com>