### PR TITLE
Remove plugin name and version from ProcessedAttributes response from…

### DIFF
--- a/verification/types.go
+++ b/verification/types.go
@@ -63,6 +63,12 @@ const (
 
 	TrustStorePrefixCA               TrustStorePrefix = "ca"
 	TrustStorePrefixSigningAuthority TrustStorePrefix = "signingAuthority"
+
+	// HeaderVerificationPlugin specifies the name of the verification plugin that should be used to verify the signature.
+	HeaderVerificationPlugin = "io.cncf.notary.verificationPlugin"
+
+	// HeaderVerificationPluginMinVersion specifies the minimum version of the verification plugin that should be used to verify the signature.
+	HeaderVerificationPluginMinVersion = "io.cncf.notary.verificationPluginMinVersion"
 )
 
 var (
@@ -134,6 +140,11 @@ var (
 	TrustStorePrefixes = []TrustStorePrefix{
 		TrustStorePrefixCA,
 		TrustStorePrefixSigningAuthority,
+	}
+
+	VerificationPluginHeaders = []string{
+		HeaderVerificationPlugin,
+		HeaderVerificationPluginMinVersion,
 	}
 )
 
@@ -229,11 +240,3 @@ func getPluginConfig(ctx context.Context) map[string]string {
 	}
 	return config
 }
-
-const (
-	// VerificationPlugin specifies the name of the verification plugin that should be used to verify the signature.
-	VerificationPlugin = "io.cncf.notary.verificationPlugin"
-
-	// VerificationPluginMinVersion specifies the minimum version of the verification plugin that should be used to verify the signature.
-	VerificationPluginMinVersion = "io.cncf.notary.verificationPluginMinVersion"
-)

--- a/verification/verifier.go
+++ b/verification/verifier.go
@@ -162,7 +162,7 @@ func (v *Verifier) processSignature(ctx context.Context, sigBlob []byte, sigMani
 		if _, err := getVerificationPluginMinVersion(&outcome.EnvelopeContent.SignerInfo); err != nil && err != errExtendedAttributeNotExist {
 			return ErrorVerificationInconclusive{msg: fmt.Sprintf("error while getting plugin minimum version, error: %s", err)}
 		}
-		// TODO verify the plugin's version is equal to or greater than `outcome.SignerInfo.SignedAttributes.VerificationPluginMinVersion`
+		// TODO verify the plugin's version is equal to or greater than `outcome.SignerInfo.SignedAttributes.HeaderVerificationPluginMinVersion`
 		// https://github.com/notaryproject/notation-go/issues/102
 
 		// filter the "verification" capabilities supported by the installed plugin
@@ -242,12 +242,11 @@ func (v *Verifier) processPluginResponse(capabilitiesToVerify []plugin.Verificat
 	if err != nil {
 		return err
 	}
+
 	// verify all extended critical attributes are processed by the plugin
-	for _, attr := range outcome.EnvelopeContent.SignerInfo.SignedAttributes.ExtendedAttributes {
-		if attr.Critical {
-			if !isPresentAny(attr.Key, response.ProcessedAttributes) {
-				return fmt.Errorf("extended critical attribute %q was not processed by the verification plugin %q (all extended critical attributes must be processed by the verification plugin)", attr.Key, verificationPluginName)
-			}
+	for _, attr := range getNonPluginExtendedCriticalAttributes(&outcome.EnvelopeContent.SignerInfo) {
+		if !isPresentAny(attr.Key, response.ProcessedAttributes) {
+			return fmt.Errorf("extended critical attribute %q was not processed by the verification plugin %q (all extended critical attributes must be processed by the verification plugin)", attr.Key, verificationPluginName)
 		}
 	}
 

--- a/verification/verifier_test.go
+++ b/verification/verifier_test.go
@@ -436,7 +436,7 @@ func assertPluginVerification(scheme signature.SigningScheme, t *testing.T) {
 				Success: true,
 			},
 		},
-		ProcessedAttributes: []interface{}{mock.PluginExtendedCriticalAttribute.Key, VerificationPlugin},
+		ProcessedAttributes: []interface{}{mock.PluginExtendedCriticalAttribute.Key},
 	}
 
 	verifier = Verifier{
@@ -459,7 +459,7 @@ func assertPluginVerification(scheme signature.SigningScheme, t *testing.T) {
 				Reason:  "i feel like failing today",
 			},
 		},
-		ProcessedAttributes: []interface{}{mock.PluginExtendedCriticalAttribute.Key, VerificationPlugin},
+		ProcessedAttributes: []interface{}{mock.PluginExtendedCriticalAttribute.Key},
 	}
 
 	verifier = Verifier{
@@ -481,7 +481,7 @@ func assertPluginVerification(scheme signature.SigningScheme, t *testing.T) {
 				Success: true,
 			},
 		},
-		ProcessedAttributes: []interface{}{mock.PluginExtendedCriticalAttribute.Key, VerificationPlugin},
+		ProcessedAttributes: []interface{}{mock.PluginExtendedCriticalAttribute.Key},
 	}
 
 	verifier = Verifier{
@@ -504,7 +504,7 @@ func assertPluginVerification(scheme signature.SigningScheme, t *testing.T) {
 				Reason:  "i feel like failing today",
 			},
 		},
-		ProcessedAttributes: []interface{}{mock.PluginExtendedCriticalAttribute.Key, VerificationPlugin},
+		ProcessedAttributes: []interface{}{mock.PluginExtendedCriticalAttribute.Key},
 	}
 
 	verifier = Verifier{
@@ -529,7 +529,7 @@ func assertPluginVerification(scheme signature.SigningScheme, t *testing.T) {
 				Success: true,
 			},
 		},
-		ProcessedAttributes: []interface{}{mock.PluginExtendedCriticalAttribute.Key, VerificationPlugin},
+		ProcessedAttributes: []interface{}{mock.PluginExtendedCriticalAttribute.Key},
 	}
 
 	verifier = Verifier{
@@ -582,7 +582,7 @@ func assertPluginVerification(scheme signature.SigningScheme, t *testing.T) {
 				Success: true,
 			},
 		},
-		ProcessedAttributes: []interface{}{VerificationPlugin}, // exclude the critical attribute
+		ProcessedAttributes: []interface{}{}, // exclude the critical attribute
 	}
 
 	verifier = Verifier{
@@ -600,7 +600,7 @@ func assertPluginVerification(scheme signature.SigningScheme, t *testing.T) {
 	pluginManager.PluginCapabilities = []plugin.Capability{plugin.CapabilityTrustedIdentityVerifier}
 	pluginManager.PluginRunnerExecuteResponse = &plugin.VerifySignatureResponse{
 		VerificationResults: map[plugin.VerificationCapability]*plugin.VerificationResult{},
-		ProcessedAttributes: []interface{}{mock.PluginExtendedCriticalAttribute.Key, VerificationPlugin},
+		ProcessedAttributes: []interface{}{mock.PluginExtendedCriticalAttribute.Key},
 	}
 
 	verifier = Verifier{


### PR DESCRIPTION
Currently, the Verifier is expecting VerificationPlugin and VerificationPluginMinVersion extended attributes to be processed by a verification plugin, which just doesn't make sense. This PR will stop sending those two attributes to a plugin.

Signed-off-by: rgnote <5878554+rgnote@users.noreply.github.com>