### PR TITLE
update: updated verifier design

### DIFF
--- a/verifier/helpers.go
+++ b/verifier/helpers.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/notaryproject/notation-core-go/signature"
 	"github.com/notaryproject/notation-go"
-	"github.com/notaryproject/notation-go/dir"
 	"github.com/notaryproject/notation-go/internal/slices"
 	"github.com/notaryproject/notation-go/plugin"
 	"github.com/notaryproject/notation-go/plugin/proto"
@@ -36,7 +35,7 @@ var errExtendedAttributeNotExist = errors.New("extended attribute not exist")
 
 var semVerRegEx = regexp.MustCompile(`^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)(?:-((?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?$`)
 
-func loadX509TrustStores(ctx context.Context, scheme signature.SigningScheme, policy *trustpolicy.TrustPolicy) ([]*x509.Certificate, error) {
+func loadX509TrustStores(ctx context.Context, scheme signature.SigningScheme, policy *trustpolicy.TrustPolicy, x509TrustStore truststore.X509TrustStore) ([]*x509.Certificate, error) {
 	var typeToLoad truststore.Type
 	switch scheme {
 	case signature.SigningSchemeX509:
@@ -51,7 +50,6 @@ func loadX509TrustStores(ctx context.Context, scheme signature.SigningScheme, po
 	// https://github.com/notaryproject/notation-go/issues/203
 	var processedStoreSet = make(map[string]struct{})
 	var certificates []*x509.Certificate
-	x509TrustStore := truststore.NewX509TrustStore(dir.ConfigFS())
 	for _, trustStore := range policy.TrustStores {
 		if _, ok := processedStoreSet[trustStore]; ok {
 			// we loaded this trust store already

--- a/verifier/helpers_test.go
+++ b/verifier/helpers_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/notaryproject/notation-go"
 	"github.com/notaryproject/notation-go/dir"
 	"github.com/notaryproject/notation-go/verifier/trustpolicy"
+	"github.com/notaryproject/notation-go/verifier/truststore"
 )
 
 func dummyPolicyStatement() (policyStatement trustpolicy.TrustPolicy) {
@@ -68,11 +69,12 @@ func TestLoadX509TrustStore(t *testing.T) {
 	dummyPolicy := dummyPolicyStatement()
 	dummyPolicy.TrustStores = []string{caStore, signingAuthorityStore}
 	dir.UserConfigDir = "testdata"
-	caCerts, err := loadX509TrustStores(context.Background(), signature.SigningSchemeX509, &dummyPolicy)
+	x509truststore := truststore.NewX509TrustStore(dir.ConfigFS())
+	caCerts, err := loadX509TrustStores(context.Background(), signature.SigningSchemeX509, &dummyPolicy, x509truststore)
 	if err != nil {
 		t.Fatalf("TestLoadX509TrustStore should not throw error for a valid trust store. Error: %v", err)
 	}
-	saCerts, err := loadX509TrustStores(context.Background(), signature.SigningSchemeX509SigningAuthority, &dummyPolicy)
+	saCerts, err := loadX509TrustStores(context.Background(), signature.SigningSchemeX509SigningAuthority, &dummyPolicy, x509truststore)
 	if err != nil {
 		t.Fatalf("TestLoadX509TrustStore should not throw error for a valid trust store. Error: %v", err)
 	}

--- a/verifier/verifier_test.go
+++ b/verifier/verifier_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/notaryproject/notation-go/internal/mock"
 	"github.com/notaryproject/notation-go/plugin/proto"
 	"github.com/notaryproject/notation-go/verifier/trustpolicy"
+	"github.com/notaryproject/notation-go/verifier/truststore"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 
 	_ "github.com/notaryproject/notation-core-go/signature/cose"
@@ -41,6 +42,15 @@ func verifyResult(outcome *notation.VerificationOutcome, expectedResult notation
 
 	if expectedResult.Action == trustpolicy.ActionEnforce && expectedErr != nil && outcome.Error.Error() != expectedErr.Error() {
 		t.Fatalf("assertion failed. expected : %v got : %v", expectedErr, outcome.Error)
+	}
+}
+
+func TestNewVerifier_Error(t *testing.T) {
+	policyDocument := dummyPolicyDocument()
+	_, err := New(&policyDocument, nil, nil)
+	expectedErr := errors.New("trustPolicy and trustStore cannot be nil")
+	if err == nil || err.Error() != expectedErr.Error() {
+		t.Fatalf("TestNewVerifier_Error expected error %v, got %v", expectedErr, err)
 	}
 }
 
@@ -245,6 +255,7 @@ func assertNotationVerification(t *testing.T, scheme signature.SigningScheme) {
 
 			verifier := verifier{
 				trustPolicyDoc: &tt.policyDocument,
+				trustStore:     truststore.NewX509TrustStore(dir.ConfigFS()),
 				pluginManager:  pluginManager,
 			}
 			outcome, _ := verifier.Verify(context.Background(), ocispec.Descriptor{}, tt.signatureBlob, tt.opts)
@@ -268,6 +279,7 @@ func assertPluginVerification(scheme signature.SigningScheme, t *testing.T) {
 
 	policyDocument := dummyPolicyDocument()
 	dir.UserConfigDir = "testdata"
+	x509TrustStore := truststore.NewX509TrustStore(dir.ConfigFS())
 
 	// verification plugin is not installed
 	pluginManager := mock.PluginManager{}
@@ -275,6 +287,7 @@ func assertPluginVerification(scheme signature.SigningScheme, t *testing.T) {
 
 	v := verifier{
 		trustPolicyDoc: &policyDocument,
+		trustStore:     x509TrustStore,
 		pluginManager:  pluginManager,
 	}
 	opts := notation.VerifyOptions{ArtifactReference: mock.SampleArtifactUri, SignatureMediaType: "application/jose+json"}
@@ -289,6 +302,7 @@ func assertPluginVerification(scheme signature.SigningScheme, t *testing.T) {
 
 	v = verifier{
 		trustPolicyDoc: &policyDocument,
+		trustStore:     x509TrustStore,
 		pluginManager:  pluginManager,
 	}
 	opts = notation.VerifyOptions{ArtifactReference: mock.SampleArtifactUri, SignatureMediaType: "application/jose+json"}
@@ -311,6 +325,7 @@ func assertPluginVerification(scheme signature.SigningScheme, t *testing.T) {
 
 	v = verifier{
 		trustPolicyDoc: &policyDocument,
+		trustStore:     x509TrustStore,
 		pluginManager:  pluginManager,
 	}
 	opts = notation.VerifyOptions{ArtifactReference: mock.SampleArtifactUri, SignatureMediaType: "application/jose+json"}
@@ -334,6 +349,7 @@ func assertPluginVerification(scheme signature.SigningScheme, t *testing.T) {
 
 	v = verifier{
 		trustPolicyDoc: &policyDocument,
+		trustStore:     x509TrustStore,
 		pluginManager:  pluginManager,
 	}
 	opts = notation.VerifyOptions{ArtifactReference: mock.SampleArtifactUri, SignatureMediaType: "application/jose+json"}
@@ -356,6 +372,7 @@ func assertPluginVerification(scheme signature.SigningScheme, t *testing.T) {
 
 	v = verifier{
 		trustPolicyDoc: &policyDocument,
+		trustStore:     x509TrustStore,
 		pluginManager:  pluginManager,
 	}
 	opts = notation.VerifyOptions{ArtifactReference: mock.SampleArtifactUri, SignatureMediaType: "application/jose+json"}
@@ -379,6 +396,7 @@ func assertPluginVerification(scheme signature.SigningScheme, t *testing.T) {
 
 	v = verifier{
 		trustPolicyDoc: &policyDocument,
+		trustStore:     x509TrustStore,
 		pluginManager:  pluginManager,
 	}
 	opts = notation.VerifyOptions{ArtifactReference: mock.SampleArtifactUri, SignatureMediaType: "application/jose+json"}
@@ -404,6 +422,7 @@ func assertPluginVerification(scheme signature.SigningScheme, t *testing.T) {
 
 	v = verifier{
 		trustPolicyDoc: &policyDocument,
+		trustStore:     x509TrustStore,
 		pluginManager:  pluginManager,
 	}
 	opts = notation.VerifyOptions{ArtifactReference: mock.SampleArtifactUri, SignatureMediaType: "application/jose+json"}
@@ -420,6 +439,7 @@ func assertPluginVerification(scheme signature.SigningScheme, t *testing.T) {
 
 	v = verifier{
 		trustPolicyDoc: &policyDocument,
+		trustStore:     x509TrustStore,
 		pluginManager:  pluginManager,
 	}
 	opts = notation.VerifyOptions{ArtifactReference: mock.SampleArtifactUri, SignatureMediaType: "application/jose+json"}
@@ -445,6 +465,7 @@ func assertPluginVerification(scheme signature.SigningScheme, t *testing.T) {
 
 	v = verifier{
 		trustPolicyDoc: &policyDocument,
+		trustStore:     x509TrustStore,
 		pluginManager:  pluginManager,
 	}
 	opts = notation.VerifyOptions{ArtifactReference: mock.SampleArtifactUri, SignatureMediaType: "application/jose+json"}
@@ -476,6 +497,7 @@ func assertPluginVerification(scheme signature.SigningScheme, t *testing.T) {
 
 	v = verifier{
 		trustPolicyDoc: &policyDocument,
+		trustStore:     x509TrustStore,
 		pluginManager:  pluginManager,
 	}
 	opts = notation.VerifyOptions{ArtifactReference: mock.SampleArtifactUri, SignatureMediaType: "application/jose+json"}
@@ -494,6 +516,7 @@ func assertPluginVerification(scheme signature.SigningScheme, t *testing.T) {
 
 	v = verifier{
 		trustPolicyDoc: &policyDocument,
+		trustStore:     x509TrustStore,
 		pluginManager:  pluginManager,
 	}
 	opts = notation.VerifyOptions{ArtifactReference: mock.SampleArtifactUri, SignatureMediaType: "application/jose+json"}

--- a/verifier/verifier_test.go
+++ b/verifier/verifier_test.go
@@ -48,7 +48,7 @@ func verifyResult(outcome *notation.VerificationOutcome, expectedResult notation
 func TestNewVerifier_Error(t *testing.T) {
 	policyDocument := dummyPolicyDocument()
 	_, err := New(&policyDocument, nil, nil)
-	expectedErr := errors.New("trustPolicy and trustStore cannot be nil")
+	expectedErr := errors.New("trustPolicy or trustStore cannot be nil")
 	if err == nil || err.Error() != expectedErr.Error() {
 		t.Fatalf("TestNewVerifier_Error expected error %v, got %v", expectedErr, err)
 	}


### PR DESCRIPTION
This PR fixed the verifier constructor design.
Previously, verifier constructor only takes in trust policy document and plugin manager.
Currently, it also takes in trustStore of type truststore.X509TrustStore.

This PR fixed #205.

Signed-off-by: Patrick Zheng <patrickzheng@microsoft.com>