### PR TITLE
fix: update plugin to add ContractVersion

### DIFF
--- a/internal/mock/mockfs/fs.go
+++ b/internal/mock/mockfs/fs.go
@@ -23,3 +23,9 @@ func NewSysFSMock(fsys fs.FS) dir.SysFS {
 		FS:   fsys,
 		root: ""}
 }
+
+func NewSysFSWithPathMock(fsys fs.FS, root string) dir.SysFS {
+	return sysFSMock{
+		FS:   fsys,
+		root: root}
+}

--- a/internal/mock/mockfs/fs.go
+++ b/internal/mock/mockfs/fs.go
@@ -24,7 +24,7 @@ func NewSysFSMock(fsys fs.FS) dir.SysFS {
 		root: ""}
 }
 
-func NewSysFSWithPathMock(fsys fs.FS, root string) dir.SysFS {
+func NewSysFSWithRootMock(fsys fs.FS, root string) dir.SysFS {
 	return sysFSMock{
 		FS:   fsys,
 		root: root}

--- a/internal/mock/mockfs/fs.go
+++ b/internal/mock/mockfs/fs.go
@@ -12,18 +12,22 @@ type sysFSMock struct {
 	root string
 }
 
+// SysPath returns the system path of the FS.
 func (s sysFSMock) SysPath(items ...string) (string, error) {
 	pathItems := []string{s.root}
 	pathItems = append(pathItems, items...)
 	return filepath.Join(pathItems...), nil
 }
 
+// NewSysFSMock returns a SysFS mock of the given FS.
 func NewSysFSMock(fsys fs.FS) dir.SysFS {
 	return sysFSMock{
 		FS:   fsys,
 		root: ""}
 }
 
+// NewSysFSWithRootMock returns a SysFS mock of the given fs and
+// a root directory
 func NewSysFSWithRootMock(fsys fs.FS, root string) dir.SysFS {
 	return sysFSMock{
 		FS:   fsys,

--- a/internal/mock/mocks.go
+++ b/internal/mock/mocks.go
@@ -138,7 +138,7 @@ type PluginManager struct {
 	PluginRunnerExecuteError    error
 }
 
-func (pm PluginManager) Get(ctx context.Context, name string, pluginConfig map[string]string) (plugin.Plugin, error) {
+func (pm PluginManager) Get(ctx context.Context, name string) (plugin.Plugin, error) {
 	return &PluginMock{
 		Metadata: proto.GetMetadataResponse{
 			Name:                      "plugin-name",

--- a/internal/mock/mocks.go
+++ b/internal/mock/mocks.go
@@ -138,7 +138,7 @@ type PluginManager struct {
 	PluginRunnerExecuteError    error
 }
 
-func (pm PluginManager) Get(ctx context.Context, name string) (plugin.Plugin, error) {
+func (pm PluginManager) Get(ctx context.Context, name string, pluginConfig map[string]string) (plugin.Plugin, error) {
 	return &PluginMock{
 		Metadata: proto.GetMetadataResponse{
 			Name:                      "plugin-name",

--- a/plugin/integration_test.go
+++ b/plugin/integration_test.go
@@ -74,7 +74,7 @@ func TestIntegration(t *testing.T) {
 	}
 
 	// validate and create
-	plugin, err := mgr.Get(context.Background(), "foo", nil)
+	plugin, err := mgr.Get(context.Background(), "foo")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/plugin/integration_test.go
+++ b/plugin/integration_test.go
@@ -18,7 +18,7 @@ var exampleMetadata = proto.GetMetadataResponse{
 	Description:               "friendly",
 	Version:                   "1",
 	URL:                       "example.com",
-	SupportedContractVersions: []string{"1"},
+	SupportedContractVersions: []string{"1.0"},
 	Capabilities:              []proto.Capability{"cap"}}
 
 func preparePlugin(t *testing.T) string {
@@ -74,7 +74,7 @@ func TestIntegration(t *testing.T) {
 	}
 
 	// validate and create
-	plugin, err := mgr.Get(context.Background(), "foo")
+	plugin, err := mgr.Get(context.Background(), "foo", nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/plugin/manager.go
+++ b/plugin/manager.go
@@ -18,7 +18,7 @@ var ErrNotRegularFile = errors.New("not regular file")
 
 // Manager manages plugins installed on the system.
 type Manager interface {
-	Get(ctx context.Context, name string) (Plugin, error)
+	Get(ctx context.Context, name string, pluginConfig map[string]string) (Plugin, error)
 	List(ctx context.Context) ([]string, error)
 }
 
@@ -35,7 +35,7 @@ func NewCLIManager(pluginFS dir.SysFS) *CLIManager {
 // Get returns a plugin on the system by its name.
 //
 // If the plugin is not found, the error is of type os.ErrNotExist.
-func (m *CLIManager) Get(ctx context.Context, name string) (Plugin, error) {
+func (m *CLIManager) Get(ctx context.Context, name string, pluginConfig map[string]string) (Plugin, error) {
 	// validate file existence
 	pluginPath := path.Join(name, binName(name))
 	fi, err := fs.Stat(m.pluginFS, pluginPath)
@@ -56,7 +56,7 @@ func (m *CLIManager) Get(ctx context.Context, name string) (Plugin, error) {
 	}
 
 	// validate and create plugin
-	return NewCLIPlugin(ctx, name, path)
+	return NewCLIPlugin(ctx, name, path, pluginConfig)
 }
 
 // List produces a list of the plugin names on the system.

--- a/plugin/manager.go
+++ b/plugin/manager.go
@@ -18,7 +18,7 @@ var ErrNotRegularFile = errors.New("not regular file")
 
 // Manager manages plugins installed on the system.
 type Manager interface {
-	Get(ctx context.Context, name string, pluginConfig map[string]string) (Plugin, error)
+	Get(ctx context.Context, name string) (Plugin, error)
 	List(ctx context.Context) ([]string, error)
 }
 
@@ -35,28 +35,15 @@ func NewCLIManager(pluginFS dir.SysFS) *CLIManager {
 // Get returns a plugin on the system by its name.
 //
 // If the plugin is not found, the error is of type os.ErrNotExist.
-func (m *CLIManager) Get(ctx context.Context, name string, pluginConfig map[string]string) (Plugin, error) {
-	// validate file existence
+func (m *CLIManager) Get(ctx context.Context, name string) (Plugin, error) {
 	pluginPath := path.Join(name, binName(name))
-	fi, err := fs.Stat(m.pluginFS, pluginPath)
-	if err != nil {
-		// Ignore any file which we cannot Stat
-		// (e.g. due to permissions or anything else).
-		return nil, err
-	}
-	if !fi.Mode().IsRegular() {
-		// Ignore non-regular files.
-		return nil, ErrNotRegularFile
-	}
-
-	// get path
 	path, err := m.pluginFS.SysPath(pluginPath)
 	if err != nil {
 		return nil, err
 	}
 
 	// validate and create plugin
-	return NewCLIPlugin(ctx, name, path, pluginConfig)
+	return NewCLIPlugin(ctx, name, path)
 }
 
 // List produces a list of the plugin names on the system.

--- a/plugin/manager_test.go
+++ b/plugin/manager_test.go
@@ -3,11 +3,8 @@ package plugin
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"io/fs"
-	"os"
 	"reflect"
-	"strings"
 	"testing"
 	"testing/fstest"
 
@@ -21,12 +18,17 @@ type testCommander struct {
 	err    error
 }
 
-func (t testCommander) Output(ctx context.Context, path string, command proto.Command, req []byte) (stdout []byte, stderr []byte, err error) {
+func (t testCommander) Output(ctx context.Context, path string, command proto.Command, req []byte) ([]byte, []byte, error) {
 	return t.stdout, t.stderr, t.err
 }
 
 var validMetadata = proto.GetMetadataResponse{
 	Name: "foo", Description: "friendly", Version: "1", URL: "example.com",
+	SupportedContractVersions: []string{"1.0"}, Capabilities: []proto.Capability{proto.CapabilitySignatureGenerator},
+}
+
+var invalidMetadataName = proto.GetMetadataResponse{
+	Name: "foobar", Description: "friendly", Version: "1", URL: "example.com",
 	SupportedContractVersions: []string{"1.0"}, Capabilities: []proto.Capability{proto.CapabilitySignatureGenerator},
 }
 
@@ -40,145 +42,13 @@ var invalidContractVersionMetadata = proto.GetMetadataResponse{
 	SupportedContractVersions: []string{"110.0"}, Capabilities: []proto.Capability{proto.CapabilitySignatureGenerator},
 }
 
-func TestManager_Get_Empty(t *testing.T) {
-	mgr := NewCLIManager(mockfs.NewSysFSMock(fstest.MapFS{}))
-	got, err := mgr.Get(context.Background(), "foo", nil)
-	if !errors.Is(err, os.ErrNotExist) {
-		t.Errorf("Manager.Get() error = %v, want %v", err, os.ErrNotExist)
-	}
-	if got != nil {
-		t.Errorf("Manager.Get() = %v, want nil", got)
-	}
-}
-
-func TestManager_Get_NotFound(t *testing.T) {
-	check := func(got Plugin, err error) {
-		t.Helper()
-		if !errors.Is(err, os.ErrNotExist) {
-			t.Errorf("Manager.Get() error = %v, want %v", err, os.ErrNotExist)
-		}
-		if got != nil {
-			t.Errorf("Manager.Get() = %v, want nil", got)
-		}
-	}
-	ctx := context.Background()
-
-	// empty fsys.
-	mgr := NewCLIManager(mockfs.NewSysFSMock(fstest.MapFS{}))
-	check(mgr.Get(ctx, "foo", nil))
-
-	// plugin directory exists without executable.
-	mgr = NewCLIManager(mockfs.NewSysFSMock(fstest.MapFS{
-		"foo": &fstest.MapFile{Mode: fs.ModeDir},
-	}))
-	check(mgr.Get(ctx, "foo", nil))
-
-	// plugin directory exists with symlinked executable.
-	mgr = NewCLIManager(mockfs.NewSysFSMock(fstest.MapFS{
-		"foo":                   &fstest.MapFile{Mode: fs.ModeDir},
-		"foo/" + binName("foo"): &fstest.MapFile{Mode: fs.ModeSymlink},
-	}))
-	got, err := mgr.Get(ctx, "foo", nil)
-	if !errors.Is(err, ErrNotRegularFile) {
-		t.Errorf("Manager.Get() error = %v, want %v", err, ErrNotRegularFile)
-	}
-	if got != nil {
-		t.Errorf("Manager.Get() = %v, want nil", got)
-	}
-	// valid plugin exists but is not the target.
-	mgr = NewCLIManager(mockfs.NewSysFSMock(fstest.MapFS{
-		"foo":                   &fstest.MapFile{Mode: fs.ModeDir},
-		"foo/" + binName("foo"): new(fstest.MapFile),
-	}))
-	executor = testCommander{stdout: metadataJSON(validMetadata)}
-	check(mgr.Get(ctx, "baz", nil))
-}
-
 func TestManager_Get(t *testing.T) {
-	t.Run("command error", func(t *testing.T) {
-		mgr := NewCLIManager(mockfs.NewSysFSMock(
-			fstest.MapFS{
-				"foo":                   &fstest.MapFile{Mode: fs.ModeDir},
-				"foo/" + binName("foo"): new(fstest.MapFile),
-			}))
-		executor = testCommander{}
-		_, err := mgr.Get(context.Background(), "foo", nil)
-		if !strings.Contains(err.Error(), "failed to fetch metadata") {
-			t.Fatal("should fail the Get operation.")
-		}
-	})
-
-	t.Run("invalid json", func(t *testing.T) {
-		mgr := NewCLIManager(mockfs.NewSysFSMock(
-			fstest.MapFS{
-				"foo":                   &fstest.MapFile{Mode: fs.ModeDir},
-				"foo/" + binName("foo"): new(fstest.MapFile),
-			}))
-		executor = testCommander{stdout: []byte("content")}
-		_, err := mgr.Get(context.Background(), "foo", nil)
-		if !strings.Contains(err.Error(), "failed to fetch metadata") {
-			t.Fatal("should fail the Get operation.")
-		}
-	})
-
-	t.Run("invalid metadata name", func(t *testing.T) {
-		mgr := NewCLIManager(mockfs.NewSysFSMock(
-			fstest.MapFS{
-				"baz":                   &fstest.MapFile{Mode: fs.ModeDir},
-				"baz/" + binName("baz"): new(fstest.MapFile),
-			}))
-		executor = testCommander{stdout: metadataJSON(validMetadata)}
-		_, err := mgr.Get(context.Background(), "baz", nil)
-		if !strings.Contains(err.Error(), "executable name must be") {
-			t.Fatal("should fail the Get operation.")
-		}
-	})
-
-	t.Run("invalid metadata content", func(t *testing.T) {
-		mgr := NewCLIManager(mockfs.NewSysFSMock(
-			fstest.MapFS{
-				"foo":                   &fstest.MapFile{Mode: fs.ModeDir},
-				"foo/" + binName("foo"): new(fstest.MapFile),
-			}))
-		executor = testCommander{stdout: metadataJSON(proto.GetMetadataResponse{Name: "foo"})}
-		_, err := mgr.Get(context.Background(), "foo", nil)
-		if !strings.Contains(err.Error(), "invalid metadata") {
-			t.Fatal("should fail the Get operation.")
-		}
-	})
-
-	t.Run("valid", func(t *testing.T) {
-		mgr := NewCLIManager(mockfs.NewSysFSMock(
-			fstest.MapFS{
-				"foo":                   &fstest.MapFile{Mode: fs.ModeDir},
-				"foo/" + binName("foo"): new(fstest.MapFile),
-			}))
-		executor = testCommander{stdout: metadataJSON(validMetadata)}
-		plugin, err := mgr.Get(context.Background(), "foo", nil)
-		if err != nil {
-			t.Fatalf("should valid. got err = %v", err)
-		}
-		metadata, err := plugin.GetMetadata(context.Background(), &proto.GetMetadataRequest{})
-		if err != nil {
-			t.Fatalf("should valid. got err = %v", err)
-		}
-		if !reflect.DeepEqual(metadata, &validMetadata) {
-			t.Fatalf("should be equal. got metadata = %+v, want %+v", metadata, validMetadata)
-		}
-	})
-
-	t.Run("invalid contract version", func(t *testing.T) {
-		mgr := NewCLIManager(mockfs.NewSysFSMock(
-			fstest.MapFS{
-				"foo":                   &fstest.MapFile{Mode: fs.ModeDir},
-				"foo/" + binName("foo"): new(fstest.MapFile),
-			}))
-		executor = testCommander{stdout: metadataJSON(invalidContractVersionMetadata)}
-		_, err := mgr.Get(context.Background(), "foo", nil)
-		if err == nil {
-			t.Fatal("should have an invalid contract version error")
-		}
-	})
+	executor = testCommander{stdout: metadataJSON(validMetadata)}
+	mgr := NewCLIManager(mockfs.NewSysFSWithPathMock(fstest.MapFS{}, "./testdata/plugins"))
+	_, err := mgr.Get(context.Background(), "foo")
+	if err != nil {
+		t.Errorf("Manager.Get() err %v, want nil", err)
+	}
 }
 
 func TestManager_List(t *testing.T) {

--- a/plugin/manager_test.go
+++ b/plugin/manager_test.go
@@ -44,7 +44,7 @@ var invalidContractVersionMetadata = proto.GetMetadataResponse{
 
 func TestManager_Get(t *testing.T) {
 	executor = testCommander{stdout: metadataJSON(validMetadata)}
-	mgr := NewCLIManager(mockfs.NewSysFSWithPathMock(fstest.MapFS{}, "./testdata/plugins"))
+	mgr := NewCLIManager(mockfs.NewSysFSWithRootMock(fstest.MapFS{}, "./testdata/plugins"))
 	_, err := mgr.Get(context.Background(), "foo")
 	if err != nil {
 		t.Errorf("Manager.Get() err %v, want nil", err)

--- a/plugin/plugin.go
+++ b/plugin/plugin.go
@@ -57,14 +57,14 @@ type CLIPlugin struct {
 }
 
 // NewCLIPlugin validate the metadata of the plugin and return a *CLIPlugin.
-func NewCLIPlugin(ctx context.Context, name, path string) (*CLIPlugin, error) {
+func NewCLIPlugin(ctx context.Context, name, path string, pluginConfig map[string]string) (*CLIPlugin, error) {
 	plugin := CLIPlugin{
 		name: name,
 		path: path,
 	}
 
 	// validate metadata
-	metadata, err := plugin.GetMetadata(ctx, &proto.GetMetadataRequest{})
+	metadata, err := plugin.GetMetadata(ctx, &proto.GetMetadataRequest{PluginConfig: pluginConfig})
 	if err != nil {
 		return nil, fmt.Errorf("failed to fetch metadata: %w", err)
 	}
@@ -88,6 +88,7 @@ func (p *CLIPlugin) GetMetadata(ctx context.Context, req *proto.GetMetadataReque
 // DescribeKey returns the KeySpec of a key.
 func (p *CLIPlugin) DescribeKey(ctx context.Context, req *proto.DescribeKeyRequest) (*proto.DescribeKeyResponse, error) {
 	var resp proto.DescribeKeyResponse
+	req.ContractVersion = proto.ContractVersion
 	err := run(ctx, p.name, p.path, req, &resp)
 	return &resp, err
 }
@@ -95,6 +96,7 @@ func (p *CLIPlugin) DescribeKey(ctx context.Context, req *proto.DescribeKeyReque
 // GenerateSignature generates the raw signature based on the request.
 func (p *CLIPlugin) GenerateSignature(ctx context.Context, req *proto.GenerateSignatureRequest) (*proto.GenerateSignatureResponse, error) {
 	var resp proto.GenerateSignatureResponse
+	req.ContractVersion = proto.ContractVersion
 	err := run(ctx, p.name, p.path, req, &resp)
 	return &resp, err
 }
@@ -102,6 +104,7 @@ func (p *CLIPlugin) GenerateSignature(ctx context.Context, req *proto.GenerateSi
 // GenerateEnvelope generates the Envelope with signature based on the request.
 func (p *CLIPlugin) GenerateEnvelope(ctx context.Context, req *proto.GenerateEnvelopeRequest) (*proto.GenerateEnvelopeResponse, error) {
 	var resp proto.GenerateEnvelopeResponse
+	req.ContractVersion = proto.ContractVersion
 	err := run(ctx, p.name, p.path, req, &resp)
 	return &resp, err
 }
@@ -109,6 +112,7 @@ func (p *CLIPlugin) GenerateEnvelope(ctx context.Context, req *proto.GenerateEnv
 // VerifySignature validates the signature based on the request.
 func (p *CLIPlugin) VerifySignature(ctx context.Context, req *proto.VerifySignatureRequest) (*proto.VerifySignatureResponse, error) {
 	var resp proto.VerifySignatureResponse
+	req.ContractVersion = proto.ContractVersion
 	err := run(ctx, p.name, p.path, req, &resp)
 	return &resp, err
 }

--- a/plugin/plugin.go
+++ b/plugin/plugin.go
@@ -12,6 +12,7 @@ import (
 	"os/exec"
 	"path/filepath"
 
+	"github.com/notaryproject/notation-go/internal/slices"
 	"github.com/notaryproject/notation-go/plugin/proto"
 )
 
@@ -194,22 +195,11 @@ func validate(metadata *proto.GetMetadataResponse) error {
 	if len(metadata.SupportedContractVersions) == 0 {
 		return errors.New("empty supported contract versions")
 	}
-	if !supportsContract(proto.ContractVersion, metadata) {
+	if !slices.Contains(metadata.SupportedContractVersions, proto.ContractVersion) {
 		return fmt.Errorf(
 			"contract version %q is not in the list of the plugin supported versions %v",
 			proto.ContractVersion, metadata.SupportedContractVersions,
 		)
 	}
 	return nil
-}
-
-// supportsContract return true if the metadata states that the
-// contract version is supported.
-func supportsContract(targetVer string, metadata *proto.GetMetadataResponse) bool {
-	for _, v := range metadata.SupportedContractVersions {
-		if v == targetVer {
-			return true
-		}
-	}
-	return false
 }

--- a/plugin/plugin.go
+++ b/plugin/plugin.go
@@ -101,7 +101,9 @@ func (p *CLIPlugin) GetMetadata(ctx context.Context, req *proto.GetMetadataReque
 // DescribeKey returns the KeySpec of a key.
 func (p *CLIPlugin) DescribeKey(ctx context.Context, req *proto.DescribeKeyRequest) (*proto.DescribeKeyResponse, error) {
 	var resp proto.DescribeKeyResponse
-	req.ContractVersion = proto.ContractVersion
+	if req.ContractVersion == "" {
+		req.ContractVersion = proto.ContractVersion
+	}
 	err := run(ctx, p.name, p.path, req, &resp)
 	return &resp, err
 }
@@ -109,7 +111,9 @@ func (p *CLIPlugin) DescribeKey(ctx context.Context, req *proto.DescribeKeyReque
 // GenerateSignature generates the raw signature based on the request.
 func (p *CLIPlugin) GenerateSignature(ctx context.Context, req *proto.GenerateSignatureRequest) (*proto.GenerateSignatureResponse, error) {
 	var resp proto.GenerateSignatureResponse
-	req.ContractVersion = proto.ContractVersion
+	if req.ContractVersion == "" {
+		req.ContractVersion = proto.ContractVersion
+	}
 	err := run(ctx, p.name, p.path, req, &resp)
 	return &resp, err
 }
@@ -117,7 +121,9 @@ func (p *CLIPlugin) GenerateSignature(ctx context.Context, req *proto.GenerateSi
 // GenerateEnvelope generates the Envelope with signature based on the request.
 func (p *CLIPlugin) GenerateEnvelope(ctx context.Context, req *proto.GenerateEnvelopeRequest) (*proto.GenerateEnvelopeResponse, error) {
 	var resp proto.GenerateEnvelopeResponse
-	req.ContractVersion = proto.ContractVersion
+	if req.ContractVersion == "" {
+		req.ContractVersion = proto.ContractVersion
+	}
 	err := run(ctx, p.name, p.path, req, &resp)
 	return &resp, err
 }
@@ -125,7 +131,9 @@ func (p *CLIPlugin) GenerateEnvelope(ctx context.Context, req *proto.GenerateEnv
 // VerifySignature validates the signature based on the request.
 func (p *CLIPlugin) VerifySignature(ctx context.Context, req *proto.VerifySignatureRequest) (*proto.VerifySignatureResponse, error) {
 	var resp proto.VerifySignatureResponse
-	req.ContractVersion = proto.ContractVersion
+	if req.ContractVersion == "" {
+		req.ContractVersion = proto.ContractVersion
+	}
 	err := run(ctx, p.name, p.path, req, &resp)
 	return &resp, err
 }
@@ -200,7 +208,7 @@ func validate(metadata *proto.GetMetadataResponse) error {
 		return errors.New("empty capabilities")
 	}
 	if len(metadata.SupportedContractVersions) == 0 {
-		return errors.New("empty supported contract versions")
+		return errors.New("supported contract versions not specified")
 	}
 	if !slices.Contains(metadata.SupportedContractVersions, proto.ContractVersion) {
 		return fmt.Errorf(

--- a/plugin/plugin.go
+++ b/plugin/plugin.go
@@ -99,6 +99,8 @@ func (p *CLIPlugin) GetMetadata(ctx context.Context, req *proto.GetMetadataReque
 }
 
 // DescribeKey returns the KeySpec of a key.
+//
+// if ContractVersion is not set, it will be set by the function.
 func (p *CLIPlugin) DescribeKey(ctx context.Context, req *proto.DescribeKeyRequest) (*proto.DescribeKeyResponse, error) {
 	var resp proto.DescribeKeyResponse
 	if req.ContractVersion == "" {
@@ -109,6 +111,8 @@ func (p *CLIPlugin) DescribeKey(ctx context.Context, req *proto.DescribeKeyReque
 }
 
 // GenerateSignature generates the raw signature based on the request.
+//
+// if ContractVersion is not set, it will be set by the function.
 func (p *CLIPlugin) GenerateSignature(ctx context.Context, req *proto.GenerateSignatureRequest) (*proto.GenerateSignatureResponse, error) {
 	var resp proto.GenerateSignatureResponse
 	if req.ContractVersion == "" {
@@ -119,6 +123,8 @@ func (p *CLIPlugin) GenerateSignature(ctx context.Context, req *proto.GenerateSi
 }
 
 // GenerateEnvelope generates the Envelope with signature based on the request.
+//
+// if ContractVersion is not set, it will be set by the function.
 func (p *CLIPlugin) GenerateEnvelope(ctx context.Context, req *proto.GenerateEnvelopeRequest) (*proto.GenerateEnvelopeResponse, error) {
 	var resp proto.GenerateEnvelopeResponse
 	if req.ContractVersion == "" {
@@ -129,6 +135,8 @@ func (p *CLIPlugin) GenerateEnvelope(ctx context.Context, req *proto.GenerateEnv
 }
 
 // VerifySignature validates the signature based on the request.
+//
+// if ContractVersion is not set, it will be set by the function.
 func (p *CLIPlugin) VerifySignature(ctx context.Context, req *proto.VerifySignatureRequest) (*proto.VerifySignatureResponse, error) {
 	var resp proto.VerifySignatureResponse
 	if req.ContractVersion == "" {

--- a/plugin/plugin_test.go
+++ b/plugin/plugin_test.go
@@ -170,26 +170,3 @@ func TestValidateMetadata(t *testing.T) {
 		})
 	}
 }
-
-func TestGetMetadataResponse_SupportsContract(t *testing.T) {
-	type args struct {
-		major string
-	}
-	tests := []struct {
-		name string
-		m    *proto.GetMetadataResponse
-		args args
-		want bool
-	}{
-		{"empty versions", &proto.GetMetadataResponse{}, args{"2"}, false},
-		{"other versions", &proto.GetMetadataResponse{SupportedContractVersions: []string{"1", "2"}}, args{"3"}, false},
-		{"found", &proto.GetMetadataResponse{SupportedContractVersions: []string{"1", "2"}}, args{"2"}, true},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if got := supportsContract(tt.args.major, tt.m); got != tt.want {
-				t.Errorf("GetMetadataResponse.SupportsContract() = %v, want %v", got, tt.want)
-			}
-		})
-	}
-}

--- a/plugin/proto/metadata.go
+++ b/plugin/proto/metadata.go
@@ -1,6 +1,9 @@
 package proto
 
-import "errors"
+import (
+	"errors"
+	"fmt"
+)
 
 // GetMetadataRequest contains the parameters passed in a get-plugin-metadata
 // request.
@@ -41,6 +44,12 @@ func (resp *GetMetadataResponse) Validate() error {
 	}
 	if len(resp.SupportedContractVersions) == 0 {
 		return errors.New("empty supported contract versions")
+	}
+	if !resp.SupportsContract(ContractVersion) {
+		return fmt.Errorf(
+			"contract version %q is not in the list of the plugin supported versions %v",
+			ContractVersion, resp.SupportedContractVersions,
+		)
 	}
 	return nil
 }

--- a/plugin/proto/metadata.go
+++ b/plugin/proto/metadata.go
@@ -1,10 +1,5 @@
 package proto
 
-import (
-	"errors"
-	"fmt"
-)
-
 // GetMetadataRequest contains the parameters passed in a get-plugin-metadata
 // request.
 type GetMetadataRequest struct {
@@ -25,35 +20,6 @@ type GetMetadataResponse struct {
 	Capabilities              []Capability `json:"capabilities"`
 }
 
-// Validate checks if the metadata is correctly populated.
-func (resp *GetMetadataResponse) Validate() error {
-	if resp.Name == "" {
-		return errors.New("empty name")
-	}
-	if resp.Description == "" {
-		return errors.New("empty description")
-	}
-	if resp.Version == "" {
-		return errors.New("empty version")
-	}
-	if resp.URL == "" {
-		return errors.New("empty url")
-	}
-	if len(resp.Capabilities) == 0 {
-		return errors.New("empty capabilities")
-	}
-	if len(resp.SupportedContractVersions) == 0 {
-		return errors.New("empty supported contract versions")
-	}
-	if !resp.SupportsContract(ContractVersion) {
-		return fmt.Errorf(
-			"contract version %q is not in the list of the plugin supported versions %v",
-			ContractVersion, resp.SupportedContractVersions,
-		)
-	}
-	return nil
-}
-
 // HasCapability return true if the metadata states that the
 // capability is supported.
 // Returns true if capability is empty.
@@ -63,17 +29,6 @@ func (resp *GetMetadataResponse) HasCapability(capability Capability) bool {
 	}
 	for _, c := range resp.Capabilities {
 		if c == capability {
-			return true
-		}
-	}
-	return false
-}
-
-// SupportsContract return true if the metadata states that the
-// contract version is supported.
-func (resp *GetMetadataResponse) SupportsContract(ver string) bool {
-	for _, v := range resp.SupportedContractVersions {
-		if v == ver {
 			return true
 		}
 	}

--- a/plugin/proto/metadata_test.go
+++ b/plugin/proto/metadata_test.go
@@ -16,8 +16,8 @@ func TestGetMetadataResponse_Validate(t *testing.T) {
 		{&GetMetadataResponse{Name: "name", Description: "friendly", Version: "1"}, true},
 		{&GetMetadataResponse{Name: "name", Description: "friendly", Version: "1", URL: "example.com"}, true},
 		{&GetMetadataResponse{Name: "name", Description: "friendly", Version: "1", URL: "example.com", Capabilities: []Capability{"cap"}}, true},
-		{&GetMetadataResponse{Name: "name", Description: "friendly", Version: "1", URL: "example.com", SupportedContractVersions: []string{"1"}}, true},
-		{&GetMetadataResponse{Name: "name", Description: "friendly", Version: "1", URL: "example.com", SupportedContractVersions: []string{"1"}, Capabilities: []Capability{"cap"}}, false},
+		{&GetMetadataResponse{Name: "name", Description: "friendly", Version: "1", URL: "example.com", SupportedContractVersions: []string{"1.0"}}, true},
+		{&GetMetadataResponse{Name: "name", Description: "friendly", Version: "1", URL: "example.com", SupportedContractVersions: []string{"1.0"}, Capabilities: []Capability{"cap"}}, false},
 	}
 	for i, tt := range tests {
 		t.Run(strconv.Itoa(i), func(t *testing.T) {

--- a/plugin/proto/metadata_test.go
+++ b/plugin/proto/metadata_test.go
@@ -1,32 +1,8 @@
 package proto
 
 import (
-	"strconv"
 	"testing"
 )
-
-func TestGetMetadataResponse_Validate(t *testing.T) {
-	tests := []struct {
-		m       *GetMetadataResponse
-		wantErr bool
-	}{
-		{&GetMetadataResponse{}, true},
-		{&GetMetadataResponse{Name: "name"}, true},
-		{&GetMetadataResponse{Name: "name", Description: "friendly"}, true},
-		{&GetMetadataResponse{Name: "name", Description: "friendly", Version: "1"}, true},
-		{&GetMetadataResponse{Name: "name", Description: "friendly", Version: "1", URL: "example.com"}, true},
-		{&GetMetadataResponse{Name: "name", Description: "friendly", Version: "1", URL: "example.com", Capabilities: []Capability{"cap"}}, true},
-		{&GetMetadataResponse{Name: "name", Description: "friendly", Version: "1", URL: "example.com", SupportedContractVersions: []string{"1.0"}}, true},
-		{&GetMetadataResponse{Name: "name", Description: "friendly", Version: "1", URL: "example.com", SupportedContractVersions: []string{"1.0"}, Capabilities: []Capability{"cap"}}, false},
-	}
-	for i, tt := range tests {
-		t.Run(strconv.Itoa(i), func(t *testing.T) {
-			if err := tt.m.Validate(); (err != nil) != tt.wantErr {
-				t.Errorf("GetMetadataResponse.Validate() error = %v, wantErr %v", err, tt.wantErr)
-			}
-		})
-	}
-}
 
 func TestGetMetadataResponse_HasCapability(t *testing.T) {
 	type args struct {
@@ -47,29 +23,6 @@ func TestGetMetadataResponse_HasCapability(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			if got := tt.m.HasCapability(tt.args.capability); got != tt.want {
 				t.Errorf("GetMetadataResponse.HasCapability() = %v, want %v", got, tt.want)
-			}
-		})
-	}
-}
-
-func TestGetMetadataResponse_SupportsContract(t *testing.T) {
-	type args struct {
-		major string
-	}
-	tests := []struct {
-		name string
-		m    *GetMetadataResponse
-		args args
-		want bool
-	}{
-		{"empty versions", &GetMetadataResponse{}, args{"2"}, false},
-		{"other versions", &GetMetadataResponse{SupportedContractVersions: []string{"1", "2"}}, args{"3"}, false},
-		{"found", &GetMetadataResponse{SupportedContractVersions: []string{"1", "2"}}, args{"2"}, true},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if got := tt.m.SupportsContract(tt.args.major); got != tt.want {
-				t.Errorf("GetMetadataResponse.SupportsContract() = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/plugin/testdata/main.go
+++ b/plugin/testdata/main.go
@@ -20,7 +20,7 @@ func main() {
 			URL                       string   `json:"url"`
 			SupportedContractVersions []string `json:"supportedContractVersions"`
 			Capabilities              []string `json:"capabilities"`
-		}{Name: "foo", Description: "friendly", Version: "1", URL: "example.com", SupportedContractVersions: []string{"1"}, Capabilities: []string{"cap"}}
+		}{Name: "foo", Description: "friendly", Version: "1", URL: "example.com", SupportedContractVersions: []string{"1.0"}, Capabilities: []string{"cap"}}
 		data, err := json.Marshal(&m)
 		if err != nil {
 			panic(err)

--- a/signer/plugin.go
+++ b/signer/plugin.go
@@ -52,12 +52,6 @@ func (s *pluginSigner) Sign(ctx context.Context, desc ocispec.Descriptor, opts n
 	if err != nil {
 		return nil, nil, err
 	}
-	if !metadata.SupportsContract(proto.ContractVersion) {
-		return nil, nil, fmt.Errorf(
-			"contract version %q is not in the list of the plugin supported versions %v",
-			proto.ContractVersion, metadata.SupportedContractVersions,
-		)
-	}
 	if metadata.HasCapability(proto.CapabilitySignatureGenerator) {
 		return s.generateSignature(ctx, desc, opts)
 	} else if metadata.HasCapability(proto.CapabilityEnvelopeGenerator) {

--- a/signer/plugin.go
+++ b/signer/plugin.go
@@ -98,7 +98,6 @@ func (s *pluginSigner) generateSignatureEnvelope(ctx context.Context, desc ocisp
 	}
 	// Execute plugin sign command.
 	req := &proto.GenerateEnvelopeRequest{
-		ContractVersion:       proto.ContractVersion,
 		KeyID:                 s.keyID,
 		Payload:               payloadBytes,
 		SignatureEnvelopeType: opts.SignatureMediaType,
@@ -160,9 +159,8 @@ func (s *pluginSigner) mergeConfig(config map[string]string) map[string]string {
 
 func (s *pluginSigner) describeKey(ctx context.Context, config map[string]string) (*proto.DescribeKeyResponse, error) {
 	req := &proto.DescribeKeyRequest{
-		ContractVersion: proto.ContractVersion,
-		KeyID:           s.keyID,
-		PluginConfig:    config,
+		KeyID:        s.keyID,
+		PluginConfig: config,
 	}
 	resp, err := s.plugin.DescribeKey(ctx, req)
 	if err != nil {
@@ -223,12 +221,11 @@ func (s *pluginPrimitiveSigner) Sign(payload []byte) ([]byte, []*x509.Certificat
 	}
 
 	req := &proto.GenerateSignatureRequest{
-		ContractVersion: proto.ContractVersion,
-		KeyID:           s.keyID,
-		KeySpec:         keySpec,
-		Hash:            keySpecHash,
-		Payload:         payload,
-		PluginConfig:    s.pluginConfig,
+		KeyID:        s.keyID,
+		KeySpec:      keySpec,
+		Hash:         keySpecHash,
+		Payload:      payload,
+		PluginConfig: s.pluginConfig,
 	}
 
 	resp, err := s.plugin.GenerateSignature(s.ctx, req)

--- a/verifier/helpers.go
+++ b/verifier/helpers.go
@@ -12,8 +12,6 @@ import (
 	"github.com/notaryproject/notation-go"
 	set "github.com/notaryproject/notation-go/internal/container"
 	"github.com/notaryproject/notation-go/internal/slices"
-	"github.com/notaryproject/notation-go/plugin"
-	"github.com/notaryproject/notation-go/plugin/proto"
 	"github.com/notaryproject/notation-go/verifier/trustpolicy"
 	"github.com/notaryproject/notation-go/verifier/truststore"
 )
@@ -137,23 +135,4 @@ func getVerificationPluginMinVersion(signerInfo *signature.SignerInfo) (string, 
 		return "", fmt.Errorf("%v from extended attribute is not a valid SemVer", HeaderVerificationPluginMinVersion)
 	}
 	return version, nil
-}
-
-// getPluginMetadata gets metadata of the plugin
-func getPluginMetadata(ctx context.Context, installedPlugin plugin.Plugin, pluginConfig map[string]string) (*proto.GetMetadataResponse, error) {
-	req := &proto.GetMetadataRequest{
-		PluginConfig: pluginConfig,
-	}
-	metadata, err := installedPlugin.GetMetadata(ctx, req)
-	if err != nil {
-		return nil, err
-	}
-	if !metadata.SupportsContract(proto.ContractVersion) {
-		return nil, fmt.Errorf(
-			"contract version %q is not in the list of the plugin supported versions %v",
-			proto.ContractVersion, metadata.SupportedContractVersions,
-		)
-	}
-
-	return metadata, nil
 }

--- a/verifier/verifier.go
+++ b/verifier/verifier.go
@@ -130,7 +130,7 @@ func (v *verifier) processSignature(ctx context.Context, sigBlob []byte, envelop
 		if v.pluginManager == nil {
 			return notation.ErrorVerificationInconclusive{Msg: "plugin unsupported due to nil verifier.pluginManager"}
 		}
-		installedPlugin, err = v.pluginManager.Get(ctx, verificationPluginName, pluginConfig)
+		installedPlugin, err = v.pluginManager.Get(ctx, verificationPluginName)
 		if err != nil {
 			return notation.ErrorVerificationInconclusive{Msg: fmt.Sprintf("error while locating the verification plugin %q, make sure the plugin is installed successfully before verifying the signature. error: %s", verificationPluginName, err)}
 		}

--- a/verifier/verifier.go
+++ b/verifier/verifier.go
@@ -130,13 +130,13 @@ func (v *verifier) processSignature(ctx context.Context, sigBlob []byte, envelop
 		if v.pluginManager == nil {
 			return notation.ErrorVerificationInconclusive{Msg: "plugin unsupported due to nil verifier.pluginManager"}
 		}
-		installedPlugin, err = v.pluginManager.Get(ctx, verificationPluginName)
+		installedPlugin, err = v.pluginManager.Get(ctx, verificationPluginName, pluginConfig)
 		if err != nil {
 			return notation.ErrorVerificationInconclusive{Msg: fmt.Sprintf("error while locating the verification plugin %q, make sure the plugin is installed successfully before verifying the signature. error: %s", verificationPluginName, err)}
 		}
 
 		// filter the "verification" capabilities supported by the installed plugin
-		metadata, err := getPluginMetadata(ctx, installedPlugin, pluginConfig)
+		metadata, err := installedPlugin.GetMetadata(ctx, &proto.GetMetadataRequest{PluginConfig: pluginConfig})
 		if err != nil {
 			return err
 		}
@@ -474,10 +474,9 @@ func executePlugin(ctx context.Context, installedPlugin plugin.Plugin, trustPoli
 	}
 
 	req := &proto.VerifySignatureRequest{
-		ContractVersion: proto.ContractVersion,
-		Signature:       signature,
-		TrustPolicy:     policy,
-		PluginConfig:    pluginConfig,
+		Signature:    signature,
+		TrustPolicy:  policy,
+		PluginConfig: pluginConfig,
 	}
 
 	return installedPlugin.VerifySignature(ctx, req)


### PR DESCRIPTION
- Add ContractVersion argument when executing plugin request
- Check ContractVersion when getting plugin metadata
- Moved the path existence check from manager.Get() to NewCLIPlugin()

Test:
Added invalid contract version unit test.

Signed-off-by: Junjie Gao <junjiegao@microsoft.com>