### PR TITLE
update: check SignatureMediaType in notation.Verify

### DIFF
--- a/notation.go
+++ b/notation.go
@@ -13,7 +13,6 @@ import (
 	"time"
 
 	"github.com/notaryproject/notation-core-go/signature"
-	"github.com/notaryproject/notation-go/internal/slices"
 	"github.com/notaryproject/notation-go/registry"
 	"github.com/notaryproject/notation-go/verifier/trustpolicy"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
@@ -141,12 +140,6 @@ type RemoteVerifyOptions struct {
 	// verified against to.
 	ArtifactReference string
 
-	// SignatureMediaTypes specifies the supported signature envelope types.
-	// If an empty list is present, all types are attempted.
-	// Currently both `application/jose+json` and `application/cose` are
-	// supported.
-	SignatureMediaTypes []string
-
 	// PluginConfig is a map of plugin configs.
 	PluginConfig map[string]string
 
@@ -203,11 +196,7 @@ func Verify(ctx context.Context, verifier Verifier, repo registry.Repository, re
 			if err != nil {
 				return ErrorSignatureRetrievalFailed{Msg: fmt.Sprintf("unable to retrieve digital signature with digest %q associated with %q from the registry, error : %v", sigManifestDesc.Digest, artifactRef, err.Error())}
 			}
-			// checking the media type after fetching the blob is slow
-			// created an issue to track this: https://github.com/notaryproject/notation-go/issues/215
-			if len(remoteOpts.SignatureMediaTypes) != 0 && !slices.Contains(remoteOpts.SignatureMediaTypes, sigDesc.MediaType) {
-				continue
-			}
+			// using signature media type fetched from registry
 			opts.SignatureMediaType = sigDesc.MediaType
 
 			// verify each signature

--- a/notation.go
+++ b/notation.go
@@ -184,13 +184,12 @@ func Verify(ctx context.Context, verifier Verifier, repo registry.Repository, re
 	}
 
 	var verificationOutcomes []*VerificationOutcome
-	errExceededMaxVerificationLimit := ErrorVerificationFailed{Msg: fmt.Sprintf("total number of signatures associated with an artifact should be less than: %d", remoteOpts.MaxSignatureAttempts)}
 	numOfSignatureProcessed := 0
 	err = repo.ListSignatures(ctx, artifactDescriptor, func(signatureManifests []ocispec.Descriptor) error {
 		// process signatures
 		for _, sigManifestDesc := range signatureManifests {
 			if numOfSignatureProcessed >= remoteOpts.MaxSignatureAttempts {
-				break
+				return ErrorVerificationFailed{Msg: fmt.Sprintf("total number of signatures associated with an artifact should be less than: %d", remoteOpts.MaxSignatureAttempts)}
 			}
 			numOfSignatureProcessed++
 			// get signature envelope
@@ -219,17 +218,10 @@ func Verify(ctx context.Context, verifier Verifier, repo registry.Repository, re
 			return errDoneVerification
 		}
 
-		if numOfSignatureProcessed >= remoteOpts.MaxSignatureAttempts {
-			return errExceededMaxVerificationLimit
-		}
-
 		return nil
 	})
 
 	if err != nil && !errors.Is(err, errDoneVerification) {
-		if errors.Is(err, errExceededMaxVerificationLimit) {
-			return ocispec.Descriptor{}, verificationOutcomes, err
-		}
 		return ocispec.Descriptor{}, nil, err
 	}
 

--- a/notation.go
+++ b/notation.go
@@ -169,6 +169,7 @@ func Verify(ctx context.Context, verifier Verifier, repo registry.Repository, op
 	}
 	errExceededMaxVerificationLimit := ErrorVerificationFailed{Msg: fmt.Sprintf("total number of signatures associated with an artifact should be less than: %d", opts.MaxSignatureAttempts)}
 	numOfSignatureProcessed := 0
+	userSignaureMediaType := opts.SignatureMediaType
 	err = repo.ListSignatures(ctx, artifactDescriptor, func(signatureManifests []ocispec.Descriptor) error {
 		// process signatures
 		for _, sigManifestDesc := range signatureManifests {
@@ -181,9 +182,9 @@ func Verify(ctx context.Context, verifier Verifier, repo registry.Repository, op
 			if err != nil {
 				return ErrorSignatureRetrievalFailed{Msg: fmt.Sprintf("unable to retrieve digital signature with digest %q associated with %q from the registry, error : %v", sigManifestDesc.Digest, artifactRef, err.Error())}
 			}
-			// opts.SignatureMediaType is non-emtpy but does not match the
+			// user specified SignaureMediaType is non-emtpy but does not match the
 			// sigDesc.MediaType, skip the current signature.
-			if opts.SignatureMediaType != "" && opts.SignatureMediaType != sigDesc.MediaType {
+			if userSignaureMediaType != "" && userSignaureMediaType != sigDesc.MediaType {
 				continue
 			}
 			// Otherwise, use the MediaType fetched from repo

--- a/notation_test.go
+++ b/notation_test.go
@@ -77,7 +77,7 @@ func TestRegistryFetchSignatureBlobError(t *testing.T) {
 	}
 }
 
-func TestSignaureMediaTypeMismatch(t *testing.T) {
+func TestSignaureMediaType(t *testing.T) {
 	policyDocument := dummyPolicyDocument()
 	repo := mock.NewRepository()
 	verifier := dummyVerifier{&policyDocument, mock.PluginManager{}, false, *trustpolicy.LevelStrict}
@@ -88,9 +88,10 @@ func TestSignaureMediaTypeMismatch(t *testing.T) {
 	_, _, err := Verify(context.Background(), &verifier, repo, opts)
 
 	if err == nil || !errors.Is(err, expectedErr) {
-		t.Fatalf("SignaureMediaTypeMismatch expected: %v got: %v", expectedErr, err)
+		t.Fatalf("SignaureMediaType expected: %v got: %v", expectedErr, err)
 	}
 }
+
 func TestVerifyValid(t *testing.T) {
 	policyDocument := dummyPolicyDocument()
 	repo := mock.NewRepository()

--- a/notation_test.go
+++ b/notation_test.go
@@ -22,7 +22,7 @@ func TestRegistryResolveError(t *testing.T) {
 
 	// mock the repository
 	repo.ResolveError = errors.New(errorMessage)
-	opts := VerifyOptions{ArtifactReference: mock.SampleArtifactUri, MaxSignatureAttempts: 50}
+	opts := RemoteVerifyOptions{ArtifactReference: mock.SampleArtifactUri, MaxSignatureAttempts: 50}
 	_, _, err := Verify(context.Background(), &verifier, repo, opts)
 
 	if err == nil || !errors.Is(err, expectedErr) {
@@ -35,7 +35,7 @@ func TestSkippedSignatureVerification(t *testing.T) {
 	repo := mock.NewRepository()
 	verifier := dummyVerifier{&policyDocument, mock.PluginManager{}, false, *trustpolicy.LevelSkip}
 
-	opts := VerifyOptions{ArtifactReference: mock.SampleArtifactUri, MaxSignatureAttempts: 50}
+	opts := RemoteVerifyOptions{ArtifactReference: mock.SampleArtifactUri, MaxSignatureAttempts: 50}
 	_, outcomes, err := Verify(context.Background(), &verifier, repo, opts)
 
 	if err != nil || outcomes[0].VerificationLevel.Name != trustpolicy.LevelSkip.Name {
@@ -52,7 +52,7 @@ func TestRegistryNoSignatureManifests(t *testing.T) {
 
 	// mock the repository
 	repo.ListSignaturesResponse = []ocispec.Descriptor{}
-	opts := VerifyOptions{ArtifactReference: mock.SampleArtifactUri, MaxSignatureAttempts: 50}
+	opts := RemoteVerifyOptions{ArtifactReference: mock.SampleArtifactUri, MaxSignatureAttempts: 50}
 	_, _, err := Verify(context.Background(), &verifier, repo, opts)
 
 	if err == nil || !errors.Is(err, expectedErr) {
@@ -69,7 +69,7 @@ func TestRegistryFetchSignatureBlobError(t *testing.T) {
 
 	// mock the repository
 	repo.FetchSignatureBlobError = errors.New("network error")
-	opts := VerifyOptions{ArtifactReference: mock.SampleArtifactUri, MaxSignatureAttempts: 50}
+	opts := RemoteVerifyOptions{ArtifactReference: mock.SampleArtifactUri, MaxSignatureAttempts: 50}
 	_, _, err := Verify(context.Background(), &verifier, repo, opts)
 
 	if err == nil || !errors.Is(err, expectedErr) {
@@ -84,7 +84,7 @@ func TestSignaureMediaTypeMismatch(t *testing.T) {
 	expectedErr := ErrorVerificationFailed{}
 
 	// mock the repository
-	opts := VerifyOptions{ArtifactReference: mock.SampleArtifactUri, SignatureMediaType: "application/cose", MaxSignatureAttempts: 50}
+	opts := RemoteVerifyOptions{ArtifactReference: mock.SampleArtifactUri, SignatureMediaTypes: []string{"application/cose"}, MaxSignatureAttempts: 50}
 	_, _, err := Verify(context.Background(), &verifier, repo, opts)
 
 	if err == nil || !errors.Is(err, expectedErr) {
@@ -97,7 +97,7 @@ func TestVerifyValid(t *testing.T) {
 	verifier := dummyVerifier{&policyDocument, mock.PluginManager{}, false, *trustpolicy.LevelStrict}
 
 	// mock the repository
-	opts := VerifyOptions{ArtifactReference: mock.SampleArtifactUri, MaxSignatureAttempts: 50}
+	opts := RemoteVerifyOptions{ArtifactReference: mock.SampleArtifactUri, MaxSignatureAttempts: 50}
 	_, _, err := Verify(context.Background(), &verifier, repo, opts)
 
 	if err != nil {

--- a/notation_test.go
+++ b/notation_test.go
@@ -73,7 +73,35 @@ func TestRegistryFetchSignatureBlobError(t *testing.T) {
 	_, _, err := Verify(context.Background(), &verifier, repo, opts)
 
 	if err == nil || !errors.Is(err, expectedErr) {
-		t.Fatalf("RegistryGetBlob expected: %v got: %v", expectedErr, err)
+		t.Fatalf("RegistryFetchSignatureBlob expected: %v got: %v", expectedErr, err)
+	}
+}
+
+func TestSignaureMediaTypeMismatch(t *testing.T) {
+	policyDocument := dummyPolicyDocument()
+	repo := mock.NewRepository()
+	verifier := dummyVerifier{&policyDocument, mock.PluginManager{}, false, *trustpolicy.LevelStrict}
+	expectedErr := ErrorVerificationFailed{}
+
+	// mock the repository
+	opts := VerifyOptions{ArtifactReference: mock.SampleArtifactUri, SignatureMediaType: "application/cose", MaxSignatureAttempts: 50}
+	_, _, err := Verify(context.Background(), &verifier, repo, opts)
+
+	if err == nil || !errors.Is(err, expectedErr) {
+		t.Fatalf("SignaureMediaTypeMismatch expected: %v got: %v", expectedErr, err)
+	}
+}
+func TestVerifyValid(t *testing.T) {
+	policyDocument := dummyPolicyDocument()
+	repo := mock.NewRepository()
+	verifier := dummyVerifier{&policyDocument, mock.PluginManager{}, false, *trustpolicy.LevelStrict}
+
+	// mock the repository
+	opts := VerifyOptions{ArtifactReference: mock.SampleArtifactUri, MaxSignatureAttempts: 50}
+	_, _, err := Verify(context.Background(), &verifier, repo, opts)
+
+	if err != nil {
+		t.Fatalf("SignaureMediaTypeMismatch expected: %v got: %v", nil, err)
 	}
 }
 


### PR DESCRIPTION
In this PR:
1. Created RemoteVerifyOptions for notation.Verify(), and therefore, VerifyOptions is now only for verifier.Verify().
2. In notation.Verify(), using signature media type fetched from registry.

Signed-off-by: Patrick Zheng <patrickzheng@microsoft.com>