### PR TITLE
update: upgraded to oras-go v2.0.0-rc.5

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/opencontainers/go-digest v1.0.0
 	github.com/opencontainers/image-spec v1.1.0-rc2
 	github.com/veraison/go-cose v1.0.0-rc.1.0.20220824135457-9d2fab636b83
-	oras.land/oras-go/v2 v2.0.0-rc.4
+	oras.land/oras-go/v2 v2.0.0-rc.5
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -39,5 +39,5 @@ golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGm
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
-oras.land/oras-go/v2 v2.0.0-rc.4 h1:hg/R2znUQ1+qd43gRmL16VeX1GIZ8hQlLalBjYhhKSk=
-oras.land/oras-go/v2 v2.0.0-rc.4/go.mod h1:YGHvWBGuqRlZgUyXUIoKsR3lcuCOb3DAtG0SEsEw1iY=
+oras.land/oras-go/v2 v2.0.0-rc.5 h1:enT2ZMNo383bH3INm1/+mw4d09AaMbqx0BMhsgEDUSg=
+oras.land/oras-go/v2 v2.0.0-rc.5/go.mod h1:YGHvWBGuqRlZgUyXUIoKsR3lcuCOb3DAtG0SEsEw1iY=

--- a/registry/repository.go
+++ b/registry/repository.go
@@ -3,7 +3,6 @@ package registry
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
@@ -37,13 +36,7 @@ func (c *repositoryClient) Resolve(ctx context.Context, reference string) (ocisp
 // ListSignatures returns signature manifests filtered by fn given the
 // artifact manifest descriptor
 func (c *repositoryClient) ListSignatures(ctx context.Context, desc ocispec.Descriptor, fn func(signatureManifests []ocispec.Descriptor) error) error {
-	// TODO: remove this part once oras v2.0.0-rc.5 is released
-	// https://github.com/notaryproject/notation-go/issues/195
-	refFinder, ok := c.Repository.(registry.ReferrerFinder)
-	if !ok {
-		return errors.New("repo is not a registry.ReferrerFinder")
-	}
-	return refFinder.Referrers(ctx, desc, ArtifactTypeNotation, fn)
+	return c.Repository.Referrers(ctx, desc, ArtifactTypeNotation, fn)
 }
 
 // FetchSignatureBlob returns signature envelope blob and descriptor given


### PR DESCRIPTION
This PR upgrades notation-go to use oras-go v2.0.0-rc.5.

Main change: ReferrerFinder is added into registry.Repository interface.

Signed-off-by: Patrick Zheng <patrickzheng@microsoft.com>