### PR TITLE
update: replaced strings.Index with strings.Cut

### DIFF
--- a/internal/file/file.go
+++ b/internal/file/file.go
@@ -1,0 +1,8 @@
+package file
+
+import "regexp"
+
+// IsValidFileName checks if a file name is cross-platform compatible
+func IsValidFileName(fileName string) bool {
+	return regexp.MustCompile(`^[a-zA-Z0-9_.-]+$`).MatchString(fileName)
+}

--- a/verifier/helpers.go
+++ b/verifier/helpers.go
@@ -56,14 +56,14 @@ func loadX509TrustStores(ctx context.Context, scheme signature.SigningScheme, po
 			continue
 		}
 
-		// TODO: replace strings.Index() with Strings.Cut()
-		// https://github.com/notaryproject/notation-go/issues/204
-		i := strings.Index(trustStore, ":")
-		storeType := trustStore[:i]
+		storeType, name, found := strings.Cut(trustStore, ":")
+		if !found {
+			return nil, fmt.Errorf("trust policy statement %q is missing separator in trust store value %q", policy.Name, trustStore)
+		}
 		if typeToLoad != truststore.Type(storeType) {
 			continue
 		}
-		name := trustStore[i+1:]
+
 		certs, err := x509TrustStore.GetCertificates(ctx, typeToLoad, name)
 		if err != nil {
 			return nil, err

--- a/verifier/truststore/truststore.go
+++ b/verifier/truststore/truststore.go
@@ -9,10 +9,10 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
-	"regexp"
 
 	corex509 "github.com/notaryproject/notation-core-go/x509"
 	"github.com/notaryproject/notation-go/dir"
+	"github.com/notaryproject/notation-go/internal/file"
 	"github.com/notaryproject/notation-go/internal/slices"
 )
 
@@ -53,7 +53,7 @@ func (trustStore *x509TrustStore) GetCertificates(ctx context.Context, storeType
 	if !isValidStoreType(storeType) {
 		return nil, fmt.Errorf("unsupported store type: %s", storeType)
 	}
-	if !isValidNamedStore(namedStore) {
+	if !file.IsValidFileName(namedStore) {
 		return nil, errors.New("named store name needs to follow [a-zA-Z0-9_.-]+ format")
 	}
 	path, err := trustStore.trustStorefs.SysPath(dir.X509TrustStoreDir(string(storeType), namedStore))
@@ -129,9 +129,4 @@ func validateCerts(certs []*x509.Certificate, path string) error {
 // isValidStoreType checks if storeType is supported
 func isValidStoreType(storeType Type) bool {
 	return slices.Contains(Types, storeType)
-}
-
-// isValidFileName checks if a file name is cross-platform compatible
-func isValidNamedStore(namedStore string) bool {
-	return regexp.MustCompile(`^[a-zA-Z0-9_.-]+$`).MatchString(namedStore)
 }


### PR DESCRIPTION
This PR scans for strings.Index() in notation-go and replaced it with strings.Cut.

It also adds checks on outputs of strings.Cut based on the specs.

Resolves #204.

Signed-off-by: Patrick Zheng <patrickzheng@microsoft.com>