### PR TITLE
Use minimum(user only) file permissions

### DIFF
--- a/plugin/integration_test.go
+++ b/plugin/integration_test.go
@@ -38,11 +38,11 @@ func preparePlugin(t *testing.T) string {
 	if err != nil {
 		t.Fatal(err)
 	}
-	err = os.WriteFile(filepath.Join(root, "go.mod"), []byte("module main"), 0666)
+	err = os.WriteFile(filepath.Join(root, "go.mod"), []byte("module main"), 0600)
 	if err != nil {
 		t.Fatal(err)
 	}
-	err = os.Mkdir(filepath.Join(root, "foo"), 0755)
+	err = os.Mkdir(filepath.Join(root, "foo"), 0700)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/signer/signer_test.go
+++ b/signer/signer_test.go
@@ -113,10 +113,10 @@ func prepareTestKeyCertFile(keyCert *keyCertPair, envelopeType, dir string) (str
 		certBytes = append(certBytes, generateCertPem(cert)...)
 	}
 
-	if err := os.WriteFile(keyPath, keyBytes, 0666); err != nil {
+	if err := os.WriteFile(keyPath, keyBytes, 0600); err != nil {
 		return "", "", err
 	}
-	if err := os.WriteFile(certPath, certBytes, 0666); err != nil {
+	if err := os.WriteFile(certPath, certBytes, 0600); err != nil {
 		return "", "", err
 	}
 	return keyPath, certPath, nil

--- a/verifier/trustpolicy/trustpolicy_test.go
+++ b/verifier/trustpolicy/trustpolicy_test.go
@@ -548,7 +548,7 @@ func TestLoadDocument(t *testing.T) {
 	tempRoot = t.TempDir()
 	dir.UserConfigDir = tempRoot
 	path := filepath.Join(tempRoot, "invalid.json")
-	err = os.WriteFile(path, []byte(`{"invalid`), 0644)
+	err = os.WriteFile(path, []byte(`{"invalid`), 0600)
 	if err != nil {
 		t.Fatalf("TestLoadPolicyDocument create invalid policy file failed. Error: %v", err)
 	}
@@ -563,7 +563,7 @@ func TestLoadDocument(t *testing.T) {
 	path = filepath.Join(tempRoot, "trustpolicy.json")
 	policyDoc1 := dummyPolicyDocument()
 	policyJson, _ := json.Marshal(policyDoc1)
-	err = os.WriteFile(path, policyJson, 0644)
+	err = os.WriteFile(path, policyJson, 0600)
 	if err != nil {
 		t.Fatalf("TestLoadPolicyDocument create valid policy file failed. Error: %v", err)
 	}


### PR DESCRIPTION
Since we are not implementing system config behavior in rc1, updating code to have only user(r,w,x) permission.
Also, its a good practice to use minimum permission model


Signed-off-by: Pritesh Bandi <pritesb@amazon.com>