### PR TITLE
Pass expiry to envelope-generator plugin

### DIFF
--- a/notation.go
+++ b/notation.go
@@ -56,7 +56,7 @@ func Sign(ctx context.Context, signer Signer, repo registry.Repository, opts Sig
 	if opts.ExpiryDuration != nil {
 		expDurInSec := opts.ExpiryDuration.Seconds()
 		if expDurInSec != float64(int64(expDurInSec)) {
-			return ocispec.Descriptor{}, fmt.Errorf("expiry duration supports minimum granulaity of second")
+			return ocispec.Descriptor{}, fmt.Errorf("expiry duration supports minimum granularity of second")
 		}
 		if expDurInSec <= 0 {
 			return ocispec.Descriptor{}, fmt.Errorf("expiry duration cannot be zero or negative")

--- a/notation_test.go
+++ b/notation_test.go
@@ -16,9 +16,21 @@ import (
 
 func TestSignSuccess(t *testing.T) {
 	repo := mock.NewRepository()
-	_, err := Sign(context.Background(), &dummySigner{}, repo, SignOptions{})
-	if err != nil {
-		t.Fatalf("Sign failed with error: %v", err)
+	testCases := []struct {
+		name string
+		dur  time.Duration
+	}{
+		{"expiryInHours", 24 * time.Hour},
+		{"oneSecondExpiry", 1 * time.Second},
+		{"zeroExpiry", 0},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(b *testing.T) {
+			_, err := Sign(context.Background(), &dummySigner{}, repo, SignOptions{ExpiryDuration: tc.dur})
+			if err != nil {
+				t.Fatalf("Sign failed with error: %v", err)
+			}
+		})
 	}
 }
 
@@ -29,12 +41,11 @@ func TestSignWithInvalidExpiry(t *testing.T) {
 		dur  time.Duration
 	}{
 		{"negativeExpiry", -24 * time.Hour},
-		{"zeroExpiry", 0},
-		{"ExpiryInMillisecond", 100 * time.Millisecond},
+		{"splitSecondExpiry", 1 * time.Millisecond},
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(b *testing.T) {
-			_, err := Sign(context.Background(), &dummySigner{}, repo, SignOptions{ExpiryDuration: &tc.dur})
+			_, err := Sign(context.Background(), &dummySigner{}, repo, SignOptions{ExpiryDuration: tc.dur})
 			if err == nil {
 				t.Fatalf("Expected error but not found")
 			}

--- a/notation_test.go
+++ b/notation_test.go
@@ -5,12 +5,42 @@ import (
 	"errors"
 	"fmt"
 	"testing"
+	"time"
 
+	"github.com/notaryproject/notation-core-go/signature"
 	"github.com/notaryproject/notation-go/internal/mock"
 	"github.com/notaryproject/notation-go/plugin"
 	"github.com/notaryproject/notation-go/verifier/trustpolicy"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 )
+
+func TestSignSuccess(t *testing.T) {
+	repo := mock.NewRepository()
+	_, err := Sign(context.Background(), &dummySigner{}, repo, SignOptions{})
+	if err != nil {
+		t.Fatalf("Sign failed with error: %v", err)
+	}
+}
+
+func TestSignWithInvalidExpiry(t *testing.T) {
+	repo := mock.NewRepository()
+	testCases := []struct {
+		name string
+		dur  time.Duration
+	}{
+		{"negativeExpiry", -24 * time.Hour},
+		{"zeroExpiry", 0},
+		{"ExpiryInMillisecond", 100 * time.Millisecond},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(b *testing.T) {
+			_, err := Sign(context.Background(), &dummySigner{}, repo, SignOptions{ExpiryDuration: &tc.dur})
+			if err == nil {
+				t.Fatalf("Expected error but not found")
+			}
+		})
+	}
+}
 
 func TestRegistryResolveError(t *testing.T) {
 	policyDocument := dummyPolicyDocument()
@@ -138,6 +168,12 @@ func dummyPolicyStatement() (policyStatement trustpolicy.TrustPolicy) {
 		TrustedIdentities:     []string{"x509.subject:CN=Notation Test Root,O=Notary,L=Seattle,ST=WA,C=US"},
 	}
 	return
+}
+
+type dummySigner struct{}
+
+func (s *dummySigner) Sign(ctx context.Context, desc ocispec.Descriptor, opts SignOptions) ([]byte, *signature.SignerInfo, error) {
+	return []byte("ABC"), &signature.SignerInfo{}, nil
 }
 
 type dummyVerifier struct {

--- a/plugin/proto/sign.go
+++ b/plugin/proto/sign.go
@@ -50,12 +50,13 @@ type GenerateSignatureResponse struct {
 // GenerateEnvelopeRequest contains the parameters passed in a generate-envelope
 // request.
 type GenerateEnvelopeRequest struct {
-	ContractVersion       string            `json:"contractVersion"`
-	KeyID                 string            `json:"keyId"`
-	PayloadType           string            `json:"payloadType"`
-	SignatureEnvelopeType string            `json:"signatureEnvelopeType"`
-	Payload               []byte            `json:"payload"`
-	PluginConfig          map[string]string `json:"pluginConfig,omitempty"`
+	ContractVersion         string            `json:"contractVersion"`
+	KeyID                   string            `json:"keyId"`
+	PayloadType             string            `json:"payloadType"`
+	SignatureEnvelopeType   string            `json:"signatureEnvelopeType"`
+	Payload                 []byte            `json:"payload"`
+	ExpiryDurationInSeconds uint64            `json:"expiryDurationInSeconds,omitempty"`
+	PluginConfig            map[string]string `json:"pluginConfig,omitempty"`
 }
 
 func (GenerateEnvelopeRequest) Command() Command {

--- a/signer/plugin.go
+++ b/signer/plugin.go
@@ -104,6 +104,12 @@ func (s *pluginSigner) generateSignatureEnvelope(ctx context.Context, desc ocisp
 		PayloadType:           envelope.MediaTypePayloadV1,
 		PluginConfig:          s.mergeConfig(opts.PluginConfig),
 	}
+
+	if opts.ExpiryDuration != nil {
+		// expiry duration will always be a positive value
+		req.ExpiryDurationInSeconds = uint64(opts.ExpiryDuration.Seconds())
+	}
+
 	resp, err := s.plugin.GenerateEnvelope(ctx, req)
 	if err != nil {
 		return nil, nil, fmt.Errorf("plugin failed to sign with following error: %w", err)

--- a/signer/plugin.go
+++ b/signer/plugin.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"time"
 
 	"github.com/notaryproject/notation-core-go/signature"
 	"github.com/notaryproject/notation-go"
@@ -98,18 +99,13 @@ func (s *pluginSigner) generateSignatureEnvelope(ctx context.Context, desc ocisp
 	}
 	// Execute plugin sign command.
 	req := &proto.GenerateEnvelopeRequest{
-		KeyID:                 s.keyID,
-		Payload:               payloadBytes,
-		SignatureEnvelopeType: opts.SignatureMediaType,
-		PayloadType:           envelope.MediaTypePayloadV1,
-		PluginConfig:          s.mergeConfig(opts.PluginConfig),
+		KeyID:                   s.keyID,
+		Payload:                 payloadBytes,
+		SignatureEnvelopeType:   opts.SignatureMediaType,
+		PayloadType:             envelope.MediaTypePayloadV1,
+		ExpiryDurationInSeconds: uint64(opts.ExpiryDuration / time.Second),
+		PluginConfig:            s.mergeConfig(opts.PluginConfig),
 	}
-
-	if opts.ExpiryDuration != nil {
-		// expiry duration will always be a positive value
-		req.ExpiryDurationInSeconds = uint64(opts.ExpiryDuration.Seconds())
-	}
-
 	resp, err := s.plugin.GenerateEnvelope(ctx, req)
 	if err != nil {
 		return nil, nil, fmt.Errorf("plugin failed to sign with following error: %w", err)

--- a/signer/plugin_test.go
+++ b/signer/plugin_test.go
@@ -13,6 +13,8 @@ import (
 	"time"
 
 	"github.com/notaryproject/notation-core-go/signature"
+	_ "github.com/notaryproject/notation-core-go/signature/cose"
+	_ "github.com/notaryproject/notation-core-go/signature/jws"
 	"github.com/notaryproject/notation-go"
 	"github.com/notaryproject/notation-go/internal/envelope"
 	"github.com/notaryproject/notation-go/plugin"
@@ -80,8 +82,9 @@ func (p *mockPlugin) GetMetadata(ctx context.Context, req *proto.GetMetadataRequ
 
 // DescribeKey returns the KeySpec of a key.
 func (p *mockPlugin) DescribeKey(ctx context.Context, req *proto.DescribeKeyRequest) (*proto.DescribeKeyResponse, error) {
+	ks, _ := proto.EncodeKeySpec(p.keySpec)
 	return &proto.DescribeKeyResponse{
-		KeySpec: proto.KeySpecRSA2048,
+		KeySpec: ks,
 	}, nil
 }
 
@@ -152,7 +155,7 @@ func TestNewFromPluginFailed(t *testing.T) {
 
 func TestSigner_Sign_EnvelopeNotSupported(t *testing.T) {
 	signer := pluginSigner{
-		plugin: newMockPlugin(false, false, false, false, nil, nil, signature.KeySpec{}),
+		plugin: newMockPlugin(false, false, false, false, nil, nil, signature.KeySpec{Type: signature.KeyTypeRSA, Size: 2048}),
 	}
 	opts := notation.SignOptions{SignatureMediaType: "unsupported"}
 	testSignerError(t, signer, fmt.Sprintf("signature envelope format with media type %q is not supported", opts.SignatureMediaType), opts)
@@ -178,7 +181,8 @@ func TestSigner_Sign_ExpiryInValid(t *testing.T) {
 			signer := pluginSigner{
 				plugin: newMockPlugin(false, false, false, false, keyCertPairCollections[0].key, keyCertPairCollections[0].certs, ks),
 			}
-			_, _, err := signer.Sign(context.Background(), ocispec.Descriptor{}, notation.SignOptions{Expiry: time.Now().Add(-100), SignatureMediaType: envelopeType})
+			exp := -24 * time.Hour
+			_, _, err := signer.Sign(context.Background(), ocispec.Descriptor{}, notation.SignOptions{ExpiryDuration: &exp, SignatureMediaType: envelopeType})
 			wantEr := "expiry cannot be equal or before the signing time"
 			if err == nil || !strings.Contains(err.Error(), wantEr) {
 				t.Errorf("Signer.Sign() error = %v, wantErr %v", err, wantEr)
@@ -204,7 +208,7 @@ func TestPluginSigner_Sign_SignatureVerifyError(t *testing.T) {
 			signer := pluginSigner{
 				plugin: newMockPlugin(false, false, true, false, defaultKeyCert.key, defaultKeyCert.certs, defaultKeySpec),
 			}
-			testSignerError(t, signer, "signature returned by generateSignature cannot be verified", notation.SignOptions{SignatureMediaType: envelopeType})
+			testSignerError(t, signer, "signature is invalid", notation.SignOptions{SignatureMediaType: envelopeType})
 		})
 	}
 }
@@ -233,7 +237,7 @@ func TestPluginSigner_SignEnvelope_RunFailed(t *testing.T) {
 			signer := pluginSigner{
 				plugin: p,
 			}
-			testSignerError(t, signer, "generate-envelope command failed: failed GenerateEnvelope", notation.SignOptions{SignatureMediaType: envelopeType})
+			testSignerError(t, signer, "failed GenerateEnvelope", notation.SignOptions{SignatureMediaType: envelopeType})
 		})
 	}
 }
@@ -300,8 +304,8 @@ func basicSignTest(t *testing.T, pluginSigner *pluginSigner, envelopeType string
 	if mockPlugin.keySpec.SignatureAlgorithm() != signerInfo.SignatureAlgorithm {
 		t.Fatalf("Signer.Sign() signing algorithm changed")
 	}
-	if validSignOpts.Expiry.Unix() != signerInfo.SignedAttributes.Expiry.Unix() {
-		t.Fatalf("Signer.Sign() expiry changed")
+	if *validSignOpts.ExpiryDuration != signerInfo.SignedAttributes.Expiry.Sub(signerInfo.SignedAttributes.SigningTime) {
+		t.Fatalf("Signer.Sign() expiry duration changed")
 	}
 	if !reflect.DeepEqual(mockPlugin.certs, signerInfo.CertificateChain) {
 		t.Fatalf(" Signer.Sign() cert chain changed")

--- a/signer/plugin_test.go
+++ b/signer/plugin_test.go
@@ -181,8 +181,7 @@ func TestSigner_Sign_ExpiryInValid(t *testing.T) {
 			signer := pluginSigner{
 				plugin: newMockPlugin(false, false, false, false, keyCertPairCollections[0].key, keyCertPairCollections[0].certs, ks),
 			}
-			exp := -24 * time.Hour
-			_, _, err := signer.Sign(context.Background(), ocispec.Descriptor{}, notation.SignOptions{ExpiryDuration: &exp, SignatureMediaType: envelopeType})
+			_, _, err := signer.Sign(context.Background(), ocispec.Descriptor{}, notation.SignOptions{ExpiryDuration: -24 * time.Hour, SignatureMediaType: envelopeType})
 			wantEr := "expiry cannot be equal or before the signing time"
 			if err == nil || !strings.Contains(err.Error(), wantEr) {
 				t.Errorf("Signer.Sign() error = %v, wantErr %v", err, wantEr)
@@ -304,7 +303,7 @@ func basicSignTest(t *testing.T, pluginSigner *pluginSigner, envelopeType string
 	if mockPlugin.keySpec.SignatureAlgorithm() != signerInfo.SignatureAlgorithm {
 		t.Fatalf("Signer.Sign() signing algorithm changed")
 	}
-	if *validSignOpts.ExpiryDuration != signerInfo.SignedAttributes.Expiry.Sub(signerInfo.SignedAttributes.SigningTime) {
+	if validSignOpts.ExpiryDuration != signerInfo.SignedAttributes.Expiry.Sub(signerInfo.SignedAttributes.SigningTime) {
 		t.Fatalf("Signer.Sign() expiry duration changed")
 	}
 	if !reflect.DeepEqual(mockPlugin.certs, signerInfo.CertificateChain) {

--- a/signer/signer.go
+++ b/signer/signer.go
@@ -90,9 +90,9 @@ func (s *genericSigner) Sign(ctx context.Context, desc ocispec.Descriptor, opts 
 		SigningAgent:  signingAgent, // TODO: include external signing plugin's name and version. https://github.com/notaryproject/notation-go/issues/80
 	}
 
-	// Add expiry only if ExpiryDuration is not nil and its value is not zero
-	if opts.ExpiryDuration != nil && opts.ExpiryDuration.Seconds() != 0 {
-		signReq.Expiry = signReq.SigningTime.Add(*opts.ExpiryDuration)
+	// Add expiry only if ExpiryDuration is not zero
+	if opts.ExpiryDuration != 0 {
+		signReq.Expiry = signReq.SigningTime.Add(opts.ExpiryDuration)
 	}
 
 	// perform signing

--- a/signer/signer.go
+++ b/signer/signer.go
@@ -90,8 +90,9 @@ func (s *genericSigner) Sign(ctx context.Context, desc ocispec.Descriptor, opts 
 		SigningAgent:  signingAgent, // TODO: include external signing plugin's name and version. https://github.com/notaryproject/notation-go/issues/80
 	}
 
-	if !opts.Expiry.IsZero() {
-		signReq.Expiry = opts.Expiry
+	// Add expiry only if ExpiryDuration is not nil and its value is not zero
+	if opts.ExpiryDuration != nil && opts.ExpiryDuration.Seconds() != 0 {
+		signReq.Expiry = signReq.SigningTime.Add(*opts.ExpiryDuration)
 	}
 
 	// perform signing

--- a/signer/signer_test.go
+++ b/signer/signer_test.go
@@ -212,7 +212,7 @@ func TestSignWithoutExpiry(t *testing.T) {
 
 				ctx := context.Background()
 				desc, sOpts := generateSigningContent(nil)
-				sOpts.ExpiryDuration = nil // reset expiry
+				sOpts.ExpiryDuration = 0 // reset expiry
 				sOpts.SignatureMediaType = envelopeType
 				sig, _, err := s.Sign(ctx, desc, sOpts)
 				if err != nil {
@@ -268,8 +268,7 @@ func generateSigningContent(tsa *timestamptest.TSA) (ocispec.Descriptor, notatio
 			"foo":      "bar",
 		},
 	}
-	expDuration := 24 * time.Hour
-	sOpts := notation.SignOptions{ExpiryDuration: &expDuration}
+	sOpts := notation.SignOptions{ExpiryDuration: 24 * time.Hour}
 	if tsa != nil {
 		tsaRoots := x509.NewCertPool()
 		tsaRoots.AddCert(tsa.Certificate())

--- a/signer/signer_test.go
+++ b/signer/signer_test.go
@@ -17,6 +17,8 @@ import (
 	"time"
 
 	"github.com/notaryproject/notation-core-go/signature"
+	_ "github.com/notaryproject/notation-core-go/signature/cose"
+	_ "github.com/notaryproject/notation-core-go/signature/jws"
 	"github.com/notaryproject/notation-core-go/testhelper"
 	"github.com/notaryproject/notation-core-go/timestamp/timestamptest"
 	"github.com/notaryproject/notation-go"
@@ -210,7 +212,7 @@ func TestSignWithoutExpiry(t *testing.T) {
 
 				ctx := context.Background()
 				desc, sOpts := generateSigningContent(nil)
-				sOpts.Expiry = time.Time{} // reset expiry
+				sOpts.ExpiryDuration = nil // reset expiry
 				sOpts.SignatureMediaType = envelopeType
 				sig, _, err := s.Sign(ctx, desc, sOpts)
 				if err != nil {
@@ -266,9 +268,8 @@ func generateSigningContent(tsa *timestamptest.TSA) (ocispec.Descriptor, notatio
 			"foo":      "bar",
 		},
 	}
-	sOpts := notation.SignOptions{
-		Expiry: time.Now().UTC().Add(time.Hour),
-	}
+	expDuration := 24 * time.Hour
+	sOpts := notation.SignOptions{ExpiryDuration: &expDuration}
 	if tsa != nil {
 		tsaRoots := x509.NewCertPool()
 		tsaRoots.AddCert(tsa.Certificate())


### PR DESCRIPTION
There will be two PRs, one in notation-go([PR#222](https://github.com/notaryproject/notation-go/pull/222)) and other in notation([PR#458](https://github.com/notaryproject/notation/pull/458)) repo.

*Tests are failing because this PR depends on https://github.com/notaryproject/notation-go/pull/222*

Issue: https://github.com/notaryproject/notation/issues/443

Signed-off-by: Pritesh Bandi <pritesb@amazon.com>