### PR TITLE
update: bump up notation-core-go in notation-go

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.18
 
 require (
 	github.com/go-ldap/ldap/v3 v3.4.4
-	github.com/notaryproject/notation-core-go v0.2.0-beta.1.0.20221123104522-9b5de089a023
+	github.com/notaryproject/notation-core-go v0.2.0-beta.1.0.20221205183432-3022517b84c1
 	github.com/opencontainers/go-digest v1.0.0
 	github.com/opencontainers/image-spec v1.1.0-rc2
 	github.com/veraison/go-cose v1.0.0-rc.2

--- a/go.sum
+++ b/go.sum
@@ -10,8 +10,8 @@ github.com/go-ldap/ldap/v3 v3.4.4 h1:qPjipEpt+qDa6SI/h1fzuGWoRUY+qqQ9sOZq67/PYUs
 github.com/go-ldap/ldap/v3 v3.4.4/go.mod h1:fe1MsuN5eJJ1FeLT/LEBVdWfNWKh459R7aXgXtJC+aI=
 github.com/golang-jwt/jwt/v4 v4.4.2 h1:rcc4lwaZgFMCZ5jxF9ABolDcIHdBytAFgqFPbSJQAYs=
 github.com/golang-jwt/jwt/v4 v4.4.2/go.mod h1:m21LjoU+eqJr34lmDMbreY2eSTRJ1cv77w39/MY0Ch0=
-github.com/notaryproject/notation-core-go v0.2.0-beta.1.0.20221123104522-9b5de089a023 h1:Z/2hxPJOjWfmgOPTNkGBDp/LVIEtizd9uJNQvjFE0Dc=
-github.com/notaryproject/notation-core-go v0.2.0-beta.1.0.20221123104522-9b5de089a023/go.mod h1:n8Gbvl9sKa00KptkKEL5XKUyMTIALe74QipKauE2rj4=
+github.com/notaryproject/notation-core-go v0.2.0-beta.1.0.20221205183432-3022517b84c1 h1:PkR2MA3WYXq92G2EK+f1O7ya87vEL8hw5aqrdto8WoQ=
+github.com/notaryproject/notation-core-go v0.2.0-beta.1.0.20221205183432-3022517b84c1/go.mod h1:n8Gbvl9sKa00KptkKEL5XKUyMTIALe74QipKauE2rj4=
 github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8Oi/yOhh5U=
 github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=
 github.com/opencontainers/image-spec v1.1.0-rc2 h1:2zx/Stx4Wc5pIPDvIxHXvXtQFW/7XWJGmnM7r3wg034=


### PR DESCRIPTION
All PRs in notation-core-go are merged. Updating dependency in notation-go.