### PR TITLE
Fix artifactType for notary project signatures

### DIFF
--- a/registry/mediatype.go
+++ b/registry/mediatype.go
@@ -1,4 +1,4 @@
 package registry
 
 // ArtifactTypeNotation specifies the artifact type for a notation object.
-const ArtifactTypeNotation = "application/vnd.cncf.notary.v2.signature"
+const ArtifactTypeNotation = "application/vnd.cncf.notary.signature"

--- a/registry/repository_test.go
+++ b/registry/repository_test.go
@@ -62,7 +62,7 @@ const (
 		"references": [{}],
 		"referrers": [
 			{
-				"artifactType": "application/vnd.cncf.notary.v2.signature",
+				"artifactType": "application/vnd.cncf.notary.signature",
 				"mediaType": "application/vnd.cncf.oras.artifact.manifest.v1+json",
 				"digest": "localhost:5000/test@57f2c47061dae97063dc46598168a80a9f89302c1f24fe2a422a1ec0aba3017a"
 			}
@@ -73,7 +73,7 @@ const (
 		"references": [{}],
 		"referrers": [
 			{
-				"artifactType": "application/vnd.cncf.notary.v2.signature",
+				"artifactType": "application/vnd.cncf.notary.signature",
 				"mediaType": "application/vnd.cncf.oras.artifact.manifest.invalid",
 				"digest": "localhost:5000/test@1834876dcfb05cb167a5c24953eba58c4ac89b1adf57f28f2f9d09af107ee8f2"
 			}
@@ -84,7 +84,7 @@ const (
 		"references": [{}],
 		"referrers": [
 			{
-				"artifactType": "application/vnd.cncf.notary.v2.signature",
+				"artifactType": "application/vnd.cncf.notary.signature",
 				"mediaType": "application/vnd.cncf.oras.artifact.manifest.v1+json",
 				"digest": "localhost:5000/test@9834876dcfb05cb167a5c24953eba58c4ac89b1adf57f28f2f9d09af107ee8f0"
 			}


### PR DESCRIPTION
The artifactType is defined in
https://github.com/notaryproject/notaryproject/blob/efc828223710f99ab9639d2d0f72d59036a8e80c/specs/signature-specification.md#storage

Signed-off-by: Sajay Antony <sajaya@microsoft.com>


-- Candidate PR to show changes that would happen in the mediaType 
