### PR TITLE
update: support OCI image manifest

### DIFF
--- a/example_remoteSign_test.go
+++ b/example_remoteSign_test.go
@@ -43,6 +43,11 @@ func Example_remoteSign() {
 	if err != nil {
 		panic(err) // Handle error
 	}
+	// when uploading OCI artifact manifest, Notation requires the registry
+	// to support the Referrers API as well. (This requirment exists only for
+	// the Sign process.)
+	// Reference: https://github.com/opencontainers/distribution-spec/blob/v1.1.0-rc1/spec.md#listing-referrers
+	remoteRepo.SetReferrersCapability(true)
 	exampleRepo := registry.NewRepository(remoteRepo)
 
 	// exampleSignOptions is an example of notation.SignOptions.

--- a/registry/repository.go
+++ b/registry/repository.go
@@ -84,6 +84,18 @@ func (c *repositoryClient) FetchSignatureBlob(ctx context.Context, desc ocispec.
 // linked signature envelope blob. Upon successful, PushSignature returns
 // signature envelope blob and manifest descriptors.
 func (c *repositoryClient) PushSignature(ctx context.Context, mediaType string, blob []byte, subject ocispec.Descriptor, annotations map[string]string) (blobDesc, manifestDesc ocispec.Descriptor, err error) {
+	// when uploading OCI artifact manifest, Notation requires the registry
+	// to support the Referrers API as well.
+	// Reference: https://github.com/opencontainers/distribution-spec/blob/v1.1.0-rc1/spec.md#listing-referrers
+	if !c.OCIImageManifest {
+		err := c.Repository.Referrers(ctx, subject, "", func(referrers []ocispec.Descriptor) error {
+			return nil
+		})
+		if err != nil {
+			return ocispec.Descriptor{}, ocispec.Descriptor{}, fmt.Errorf("failed to ping Referrers API on uploading OCI artifact manifest with error: %v. Try OCI image manifest instead", err)
+		}
+	}
+
 	blobDesc, err = oras.PushBytes(ctx, c.Repository.Blobs(), mediaType, blob)
 	if err != nil {
 		return ocispec.Descriptor{}, ocispec.Descriptor{}, err
@@ -142,18 +154,5 @@ func (c *repositoryClient) uploadSignatureManifest(ctx context.Context, subject,
 		ManifestAnnotations: annotations,
 		PackImageManifest:   c.OCIImageManifest,
 	}
-
-	// when uploading OCI artifact manifest, Notation requires the registry
-	// to support the Referrers API as well.
-	// Reference: https://github.com/opencontainers/distribution-spec/blob/v1.1.0-rc1/spec.md#listing-referrers
-	if !c.OCIImageManifest {
-		err := c.Repository.Referrers(ctx, subject, "", func(referrers []ocispec.Descriptor) error {
-			return nil
-		})
-		if err != nil {
-			return ocispec.Descriptor{}, fmt.Errorf("failed to ping Referrers API on uploading OCI artifact manifest with error: %v. Try OCI image manifest instead", err)
-		}
-	}
-
 	return oras.Pack(ctx, c.Repository, ArtifactTypeNotation, []ocispec.Descriptor{blobDesc}, opts)
 }

--- a/registry/repository.go
+++ b/registry/repository.go
@@ -14,6 +14,7 @@ import (
 const (
 	maxBlobSizeLimit     = 32 * 1024 * 1024 // 32 MiB
 	maxManifestSizeLimit = 4 * 1024 * 1024  // 4 MiB
+	zeroDigest           = "sha256:0000000000000000000000000000000000000000000000000000000000000000"
 )
 
 // RepositoryOptions provides user options when creating a Repository
@@ -88,7 +89,9 @@ func (c *repositoryClient) PushSignature(ctx context.Context, mediaType string, 
 	// to support the Referrers API as well.
 	// Reference: https://github.com/opencontainers/distribution-spec/blob/v1.1.0-rc1/spec.md#listing-referrers
 	if !c.OCIImageManifest {
-		err := c.Repository.Referrers(ctx, subject, "", func(referrers []ocispec.Descriptor) error {
+		var checkReferrerDesc ocispec.Descriptor
+		checkReferrerDesc.Digest = zeroDigest
+		err := c.Repository.Referrers(ctx, checkReferrerDesc, "", func(referrers []ocispec.Descriptor) error {
 			return nil
 		})
 		if err != nil {

--- a/registry/repository_test.go
+++ b/registry/repository_test.go
@@ -19,28 +19,13 @@ import (
 )
 
 const (
+	zeroDigest               = "sha256:0000000000000000000000000000000000000000000000000000000000000000"
 	validDigest              = "6c3c624b58dbbcd3c0dd82b4c53f04194d1247c6eebdaab7c610cf7d66709b3b"
-	validDigest2             = "9834876dcfb05cb167a5c24953eba58c4ac89b1adf57f28f2f9d09af107ee8f0"
-	validDigest3             = "1834876dcfb05cb167a5c24953eba58c4ac89b1adf57f28f2f9d09af107ee8f2"
-	validDigest4             = "277000f8d32d2b2a7d65f4533339f7d4c064e0540facf1d54c69d9916f05d28c"
-	validDigest5             = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
-	validDigest6             = "daffbe5f71beaf7b05c080e8ae4f9739cdf21e24c89561e35792f1251d38148d"
-	validDigest7             = "13b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
-	validDigest8             = "57f2c47061dae97063dc46598168a80a9f89302c1f24fe2a422a1ec0aba3017a"
-	validDigest9             = "023c624b58dbbcd3c0dd82b4c53f04194d1247c6eebdaab7c610cf7d66709b3b"
-	validDigest10            = "1761e09cad8aa44e48ffb41c78371a6c139bd0df555c90b5d99739b9551c7828"
+	validDigest2             = "1834876dcfb05cb167a5c24953eba58c4ac89b1adf57f28f2f9d09af107ee8f2"
 	invalidDigest            = "invaliddigest"
 	algo                     = "sha256"
 	validDigestWithAlgo      = algo + ":" + validDigest
 	validDigestWithAlgo2     = algo + ":" + validDigest2
-	validDigestWithAlgo3     = algo + ":" + validDigest3
-	validDigestWithAlgo4     = algo + ":" + validDigest4
-	validDigestWithAlgo5     = algo + ":" + validDigest5
-	validDigestWithAlgo6     = algo + ":" + validDigest6
-	validDigestWithAlgo7     = algo + ":" + validDigest7
-	validDigestWithAlgo8     = algo + ":" + validDigest8
-	validDigestWithAlgo9     = algo + ":" + validDigest9
-	validDigestWithAlgo10    = algo + ":" + validDigest10
 	validHost                = "localhost"
 	validRegistry            = validHost + ":5000"
 	invalidHost              = "badhost"
@@ -48,79 +33,49 @@ const (
 	validRepo                = "test"
 	msg                      = "message"
 	errMsg                   = "error message"
-	mediaType                = "application/json"
 	validReference           = validRegistry + "/" + validRepo + "@" + validDigestWithAlgo
 	referenceWithInvalidHost = invalidRegistry + "/" + validRepo + "@" + validDigestWithAlgo
-	validReference6          = validRegistry + "/" + validRepo + "@" + validDigestWithAlgo6
 	invalidReference         = "invalid reference"
 	joseTag                  = "application/jose+json"
 	coseTag                  = "application/cose"
 	validTimestamp           = "2022-07-29T02:23:10Z"
-	size                     = 104
-	size2                    = 135
 	validPage                = `
 	{
-		"referrers": [
-			{
-				"artifactType": "application/vnd.cncf.notary.signature",
-				"mediaType": "application/vnd.cncf.oras.artifact.manifest.v1+json",
-				"digest": "localhost:5000/test@57f2c47061dae97063dc46598168a80a9f89302c1f24fe2a422a1ec0aba3017a"
+		"Manifests": [
+			{	
+				"MediaType": "application/vnd.oci.artifact.manifest.v1+json",
+				"Digest": "sha256:cf2a0974295fc17b8351ef52abae2f40212e20e0359ea980ec5597bb0315347b",
+				"Size": 620,
+				"ArtifactType": "application/vnd.cncf.notary.signature"
 			}
 		]
 	}`
-	validPageImage = `
+	validPageDigest = "sha256:cf2a0974295fc17b8351ef52abae2f40212e20e0359ea980ec5597bb0315347b"
+	validPageImage  = `
 	{
-		"referrers": [
+		"Manifests": [
 			{
-				"artifactType": "application/vnd.cncf.notary.signature",
-				"mediaType": "application/vnd.oci.image.manifest.v1+json",
-				"digest": "localhost:5000/test@57f2c47061dae97063dc46598168a80a9f89302c1f24fe2a422a1ec0aba3017a"
+				"MediaType": "application/vnd.oci.image.manifest.v1+json",
+				"Digest": "sha256:c8f1c1a1bdf099fbc1b70ec4b98da3d8704e27d863f1407db06aad1e022a32cf",
+				"Size": 733,
+				"ArtifactType": "application/vnd.cncf.notary.signature"
 			}
 		]
 	}`
-	pageWithWrongMediaType = `
-	{
-		"referrers": [
-			{
-				"artifactType": "application/vnd.cncf.notary.signature",
-				"mediaType": "application/vnd.cncf.oras.artifact.manifest.invalid",
-				"digest": "localhost:5000/test@1834876dcfb05cb167a5c24953eba58c4ac89b1adf57f28f2f9d09af107ee8f2"
-			}
-		]
-	}`
-	pageWithBadDigest = `
-	{
-		"referrers": [
-			{
-				"artifactType": "application/vnd.cncf.notary.signature",
-				"mediaType": "application/vnd.cncf.oras.artifact.manifest.v1+json",
-				"digest": "localhost:5000/test@9834876dcfb05cb167a5c24953eba58c4ac89b1adf57f28f2f9d09af107ee8f0"
-			}
-		]
-	}`
-	validBlob = `{
-		"digest": "sha256:6c3c624b58dbbcd3c0dd82b4c53f04194d1247c6eebdaab7c610cf7d66709b3b",
+	validPageImageDigest = "sha256:c8f1c1a1bdf099fbc1b70ec4b98da3d8704e27d863f1407db06aad1e022a32cf"
+	validBlob            = `{
+		"digest": "sha256:1834876dcfb05cb167a5c24953eba58c4ac89b1adf57f28f2f9d09af107ee8f2",
 		"size": 90
-	}`
-	validManifest = `{
-		"blobs": [
-			{
-				"digest": "sha256:023c624b58dbbcd3c0dd82b4c53f04194d1247c6eebdaab7c610cf7d66709b3b",
-				"size": 90
-			}
-		]
 	}`
 )
 
-var validDigestWithAlgoSlice = []string{validDigestWithAlgo, validDigestWithAlgo2, validDigestWithAlgo3, validDigestWithAlgo4, validDigestWithAlgo5,
-	validDigestWithAlgo6, validDigestWithAlgo7, validDigestWithAlgo8, validDigestWithAlgo9, validDigestWithAlgo10}
+var validDigestWithAlgoSlice = []string{validDigestWithAlgo, validDigestWithAlgo2}
 
 type args struct {
 	ctx                   context.Context
 	reference             string
 	remoteClient          remote.Client
 	plainHttp             bool
-	digest                digest.Digest
 	annotations           map[string]string
 	subjectManifest       ocispec.Descriptor
 	signature             []byte
@@ -139,138 +94,29 @@ func (c mockRemoteClient) Do(req *http.Request) (*http.Response, error) {
 			StatusCode: http.StatusOK,
 			Body:       io.NopCloser(bytes.NewReader([]byte(msg))),
 			Header: map[string][]string{
-				"Content-Type":          {mediaType},
+				"Content-Type":          {joseTag},
 				"Docker-Content-Digest": {validDigestWithAlgo},
 			},
 		}, nil
-	case "/v2/test/blobs/" + validDigestWithAlgo6:
-		return &http.Response{
-			StatusCode:    http.StatusOK,
-			Body:          io.NopCloser(bytes.NewReader([]byte(validBlob))),
-			ContentLength: size,
-			Header: map[string][]string{
-				"Content-Type":          {mediaType},
-				"Docker-Content-Digest": {validDigestWithAlgo6},
-			},
-		}, nil
-	case "/v2/test/blobs/" + validDigestWithAlgo3:
+	case "/v2/test/blobs/" + validDigestWithAlgo2:
 		return &http.Response{
 			StatusCode:    http.StatusOK,
 			Body:          io.NopCloser(bytes.NewReader([]byte(validBlob))),
 			ContentLength: maxBlobSizeLimit + 1,
 			Header: map[string][]string{
-				"Content-Type":          {mediaType},
-				"Docker-Content-Digest": {validDigestWithAlgo3},
+				"Content-Type":          {joseTag},
+				"Docker-Content-Digest": {validDigestWithAlgo2},
 			},
 		}, nil
 	case "/v2/test/manifests/" + invalidDigest:
 		return &http.Response{}, fmt.Errorf(errMsg)
-	case "/v2/test/_oras/artifacts/referrers":
-		if strings.HasSuffix(req.URL.RawQuery, invalidDigest) {
-			return &http.Response{
-				StatusCode: http.StatusOK,
-				Body:       io.NopCloser(bytes.NewReader([]byte(pageWithBadDigest))),
-				Request: &http.Request{
-					Method: "GET",
-					URL:    &url.URL{Path: "/v2/test/_oras/artifacts/referrers"},
-				},
-			}, nil
-		} else if strings.HasSuffix(req.URL.RawQuery, validDigest7) {
-			return &http.Response{
-				StatusCode: http.StatusOK,
-				Body:       io.NopCloser(bytes.NewReader([]byte(pageWithWrongMediaType))),
-				Request: &http.Request{
-					Method: "GET",
-					URL:    &url.URL{Path: "/v2/test/_oras/artifacts/referrers"},
-				},
-			}, nil
-		} else if strings.HasSuffix(req.URL.RawQuery, validDigest8) {
-			return &http.Response{
-				StatusCode: http.StatusOK,
-				Body:       io.NopCloser(bytes.NewReader([]byte(validPage))),
-				Request: &http.Request{
-					Method: "GET",
-					URL:    &url.URL{Path: "/v2/test/_oras/artifacts/referrers"},
-				},
-			}, nil
-		}
-		return &http.Response{}, fmt.Errorf(msg)
-	case "/v2/test/manifests/" + validDigest2:
-		return &http.Response{
-			StatusCode:    http.StatusOK,
-			Body:          io.NopCloser(bytes.NewReader([]byte(validDigest2))),
-			ContentLength: size,
-			Header: map[string][]string{
-				"Content-Type":          {mediaType},
-				"Docker-Content-Digest": {validDigestWithAlgo4},
-			},
-		}, nil
-	case "v2/test/manifest/" + validDigest3:
+	case "v2/test/manifest/" + validDigest2:
 		return &http.Response{
 			StatusCode: http.StatusOK,
-			Body:       io.NopCloser(bytes.NewReader([]byte(validDigest3))),
+			Body:       io.NopCloser(bytes.NewReader([]byte(validDigest2))),
 			Header: map[string][]string{
-				"Content-Type":          {mediaType},
-				"Docker-Content-Digest": {validDigestWithAlgo3},
-			},
-		}, nil
-	case "/v2/test/manifests/" + validDigest8:
-		return &http.Response{
-			StatusCode:    http.StatusOK,
-			Body:          io.NopCloser(bytes.NewReader([]byte(validDigest8))),
-			ContentLength: size2,
-			Header: map[string][]string{
-				"Content-Type":          {mediaType},
-				"Docker-Content-Digest": {validDigestWithAlgo8},
-			},
-		}, nil
-	case "/v2/test/manifests/" + validDigestWithAlgo4:
-		if req.Method == "GET" {
-			return &http.Response{}, fmt.Errorf(msg)
-		}
-		return &http.Response{
-			StatusCode: http.StatusCreated,
-			Body:       io.NopCloser(bytes.NewReader([]byte(msg))),
-			Header: map[string][]string{
-				"Docker-Content-Digest": {validDigestWithAlgo4},
-			},
-		}, nil
-	case "/v2/test/manifests/" + validDigestWithAlgo7:
-		return &http.Response{
-			StatusCode: http.StatusOK,
-			Body:       io.NopCloser(bytes.NewReader([]byte(msg))),
-			Header: map[string][]string{
-				"Docker-Content-Digest": {validDigestWithAlgo4},
-			},
-		}, nil
-	case "/v2/test/manifests/" + validDigestWithAlgo8:
-		return &http.Response{
-			StatusCode:    http.StatusOK,
-			Body:          io.NopCloser(bytes.NewReader([]byte(validManifest))),
-			ContentLength: size2,
-			Header: map[string][]string{
-				"Docker-Content-Digest": {validDigestWithAlgo8},
-				"Content-Type":          {mediaType},
-			},
-		}, nil
-	case "/v2/test/manifests/" + validDigestWithAlgo2:
-		return &http.Response{
-			StatusCode: http.StatusOK,
-			Body:       io.NopCloser(bytes.NewReader([]byte(validBlob))),
-			Header: map[string][]string{
+				"Content-Type":          {joseTag},
 				"Docker-Content-Digest": {validDigestWithAlgo2},
-				"Content-Type":          {mediaType},
-			},
-		}, nil
-	case "/v2/test/manifests/" + validDigestWithAlgo10:
-		if req.Method == "GET" {
-			return &http.Response{}, fmt.Errorf(msg)
-		}
-		return &http.Response{
-			StatusCode: http.StatusCreated,
-			Body:       io.NopCloser(bytes.NewReader([]byte(msg))),
-			Header: map[string][]string{
-				"Docker-Content-Digest": {validDigestWithAlgo10},
 			},
 		}, nil
 	case "/v2/test/blobs/uploads/":
@@ -289,13 +135,22 @@ func (c mockRemoteClient) Do(req *http.Request) (*http.Response, error) {
 		default:
 			return &http.Response{}, fmt.Errorf(msg)
 		}
-	case "/v2/test/referrers/sha256:0000000000000000000000000000000000000000000000000000000000000000":
+	case "/v2/test/referrers/":
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(bytes.NewReader([]byte(validPage))),
+			Request: &http.Request{
+				Method: "GET",
+				URL:    &url.URL{Path: "/v2/test/referrers/"},
+			},
+		}, nil
+	case "/v2/test/referrers/" + zeroDigest:
 		return &http.Response{
 			StatusCode: http.StatusOK,
 			Body:       io.NopCloser(bytes.NewReader([]byte(validPageImage))),
 			Request: &http.Request{
 				Method: "GET",
-				URL:    &url.URL{Path: "/v2/test/referrers/sha256:0000000000000000000000000000000000000000000000000000000000000000"},
+				URL:    &url.URL{Path: "/v2/test/referrers/" + zeroDigest},
 			},
 		}, nil
 	case validRepo:
@@ -310,7 +165,57 @@ func (c mockRemoteClient) Do(req *http.Request) (*http.Response, error) {
 				StatusCode: http.StatusCreated,
 				Body:       io.NopCloser(bytes.NewReader([]byte(msg))),
 				Header: map[string][]string{
-					"Content-Type": {mediaType},
+					"Content-Type": {joseTag},
+				},
+			}, nil
+		}
+		return &http.Response{}, fmt.Errorf(errMsg)
+	}
+}
+
+type mockRemoteClientWithoutReferrersAPI struct {
+}
+
+func (c mockRemoteClientWithoutReferrersAPI) Do(req *http.Request) (*http.Response, error) {
+	switch req.URL.Path {
+	case "/v2/test/blobs/uploads/":
+		switch req.Host {
+		case validRegistry:
+			return &http.Response{
+				StatusCode: http.StatusAccepted,
+				Body:       io.NopCloser(bytes.NewReader([]byte(msg))),
+				Request: &http.Request{
+					Header: map[string][]string{},
+				},
+				Header: map[string][]string{
+					"Location": {"test"},
+				},
+			}, nil
+		default:
+			return &http.Response{}, fmt.Errorf(msg)
+		}
+	case "/v2/test/referrers/":
+		return &http.Response{
+			StatusCode: http.StatusNotFound,
+			Body:       io.NopCloser(bytes.NewReader([]byte("Referrers API not supported"))),
+			Request: &http.Request{
+				Method: "GET",
+				URL:    &url.URL{Path: "/v2/test/referrers/"},
+			},
+		}, nil
+	case validRepo:
+		return &http.Response{
+			StatusCode: http.StatusCreated,
+			Body:       io.NopCloser(bytes.NewReader([]byte(msg))),
+		}, nil
+	default:
+		_, digest, found := strings.Cut(req.URL.Path, "/v2/test/manifests/")
+		if found && !slices.Contains(validDigestWithAlgoSlice, digest) {
+			return &http.Response{
+				StatusCode: http.StatusCreated,
+				Body:       io.NopCloser(bytes.NewReader([]byte(msg))),
+				Header: map[string][]string{
+					"Content-Type": {joseTag},
 				},
 			}, nil
 		}
@@ -387,7 +292,7 @@ func TestFetchSignatureBlob(t *testing.T) {
 				plainHttp:    false,
 				signatureManifestDesc: ocispec.Descriptor{
 					MediaType: ocispec.MediaTypeArtifactManifest,
-					Digest:    digest.Digest(validDigestWithAlgo3),
+					Digest:    digest.Digest(validDigestWithAlgo2),
 				},
 			},
 		},
@@ -417,15 +322,14 @@ func TestListSignatures(t *testing.T) {
 		expectErr bool
 	}{
 		{
-			name:      "failed to fetch content",
-			expectErr: true,
+			name:      "successfully fetch content",
+			expectErr: false,
 			expect:    nil,
 			args: args{
 				ctx:          context.Background(),
 				reference:    validReference,
 				remoteClient: mockRemoteClient{},
 				plainHttp:    false,
-				digest:       digest.Digest(invalidDigest),
 			},
 		},
 	}
@@ -435,7 +339,18 @@ func TestListSignatures(t *testing.T) {
 			ref, _ := registry.ParseReference(args.reference)
 			client := newRepositoryClient(args.remoteClient, ref, args.plainHttp)
 
-			err := client.ListSignatures(args.ctx, args.artifactManifestDesc, nil)
+			err := client.ListSignatures(args.ctx, args.artifactManifestDesc, func(signatureManifests []ocispec.Descriptor) error {
+				if len(signatureManifests) != 1 {
+					return fmt.Errorf("length of signatureManifests expected 1, got %d", len(signatureManifests))
+				}
+				for _, sigManifest := range signatureManifests {
+					sigManifestDigest := sigManifest.Digest.String()
+					if sigManifestDigest != validPageDigest {
+						return fmt.Errorf("signature manifest digest expected: %s, got %s", validPageDigest, sigManifestDigest)
+					}
+				}
+				return nil
+			})
 			if (err != nil) != tt.expectErr {
 				t.Errorf("error = %v, expectErr = %v", err, tt.expectErr)
 			}
@@ -502,18 +417,48 @@ func TestPushSignatureImageManifest(t *testing.T) {
 	}
 }
 
-// newRepositoryClient creates a new repository client.
-func newRepositoryClient(client remote.Client, ref registry.Reference, plainHTTP bool) *repositoryClient {
-	return &repositoryClient{
-		Repository: &remote.Repository{
-			Client:    client,
-			Reference: ref,
-			PlainHTTP: plainHTTP,
-		},
+func TestPushSignatureWithoutReferrersAPI(t *testing.T) {
+	expectedErr := "failed to ping Referrers API on uploading OCI artifact manifest with error: GET \"/v2/test/referrers/\": response status code 404: Not Found. Try OCI image manifest instead"
+	ref, err := registry.ParseReference(validReference)
+	if err != nil {
+		t.Fatalf("failed to parse reference")
+	}
+	client := newRepositoryClientWithArtifactManifest(mockRemoteClientWithoutReferrersAPI{}, ref, false)
+
+	_, _, err = client.PushSignature(context.Background(), coseTag, make([]byte, 0), ocispec.Descriptor{}, nil)
+	if err == nil || err.Error() != expectedErr {
+		t.Fatalf("expected error %s but got %s", expectedErr, err.Error())
 	}
 }
 
-// newRepositoryClient creates a new repository client.
+// newRepositoryClient creates a new repository client
+func newRepositoryClient(client remote.Client, ref registry.Reference, plainHTTP bool) *repositoryClient {
+	repo := remote.Repository{
+		Client:    client,
+		Reference: ref,
+		PlainHTTP: plainHTTP,
+	}
+	return &repositoryClient{
+		Repository: &repo,
+	}
+}
+
+// newRepositoryClientWithArtifactManifest creates a new repository client for
+// pushing OCI artifact manifest
+func newRepositoryClientWithArtifactManifest(client remote.Client, ref registry.Reference, plainHTTP bool) *repositoryClient {
+	repo := remote.Repository{
+		Client:    client,
+		Reference: ref,
+		PlainHTTP: plainHTTP,
+	}
+	repo.SetReferrersCapability(true)
+	return &repositoryClient{
+		Repository: &repo,
+	}
+}
+
+// newRepositoryClientWithImageManifest creates a new repository client for
+// pushing OCI image manifest
 func newRepositoryClientWithImageManifest(client remote.Client, ref registry.Reference, plainHTTP bool) *repositoryClient {
 	return &repositoryClient{
 		Repository: &remote.Repository{


### PR DESCRIPTION
This PR targets on [issue 219](https://github.com/notaryproject/notaryproject/issues/219) and [issue 220](https://github.com/notaryproject/notaryproject/issues/220).

In this update, Notation will store signatures of type OCI artifact manifest only when:
     1. The registry supports OCI artifact manifest.
     2. The registry supports the Referrers API.