### PR TITLE
Add Rakesh Gariganti as notation maintainer

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-* @notaryproject/notation-maintainers
+* @rgnote

--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -1,0 +1,1 @@
+Rakesh Gariganti <garigant@amazon.com> (@rgnote)


### PR DESCRIPTION
Add Pritesh Bandi as a seed maintainer of Notation based on [their](https://github.com/notaryproject/notation-go/commits?author=rgnote) activity as per - https://github.com/notaryproject/notation-go/issues/249

Signed-off-by: vaninrao10 <111005862+vaninrao10@users.noreply.github.com>