### PR TITLE
Add Patrick Zheng as notation-go maintainer

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-* @notaryproject/notation-maintainers
+* @patrickzheng200

--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -1,0 +1,1 @@
+Patrick Zheng <patrickzheng@microsoft.com> (@patrickzheng200)


### PR DESCRIPTION
Add Patrick Zheng (@patrickzheng200) as a seed maintainer of `notation-go` based on [their](https://github.com/notaryproject/notation-go/commits?author=patrickzheng200) activity as per - https://github.com/notaryproject/notation-go/issues/249

Signed-off-by: Yi Zha <yizha1@microsoft.com>