### PR TITLE
Add Junjie Gao as notation-go maintainer

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-* @notaryproject/notation-maintainers
+* @JeyJeyGao

--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -1,0 +1,1 @@
+Junjie Gao <junjiegao@microsoft.com> (@JeyJeyGao)


### PR DESCRIPTION
Add Junjie Gao (@JeyJeyGao) as a seed maintainer of `notation-go` based on [their](https://github.com/notaryproject/notation-go/commits?author=JeyJeyGao) activity as per - https://github.com/notaryproject/notation-go/issues/249

Signed-off-by: Yi Zha <yizha1@microsoft.com>