### PR TITLE
Update: added ErrorPushSignatureFailed

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -1,5 +1,17 @@
 package notation
 
+//
+type ErrorPushSignatureFailed struct {
+	Msg string
+}
+
+func (e ErrorPushSignatureFailed) Error() string {
+	if e.Msg != "" {
+		return e.Msg
+	}
+	return "failed to push signature to registry"
+}
+
 // ErrorVerificationInconclusive is used when signature verification fails due to a runtime error (e.g. a network error)
 type ErrorVerificationInconclusive struct {
 	Msg string

--- a/errors.go
+++ b/errors.go
@@ -7,7 +7,7 @@ type ErrorPushSignatureFailed struct {
 
 func (e ErrorPushSignatureFailed) Error() string {
 	if e.Msg != "" {
-		return e.Msg
+		return "failed to push signature to registry with error: " + e.Msg
 	}
 	return "failed to push signature to registry"
 }

--- a/notation.go
+++ b/notation.go
@@ -111,7 +111,7 @@ func Sign(ctx context.Context, signer Signer, repo registry.Repository, opts Sig
 	_, _, err = repo.PushSignature(ctx, opts.SignatureMediaType, sig, targetDesc, annotations)
 	if err != nil {
 		logger.Error("Failed to push the signature")
-		return ocispec.Descriptor{}, err
+		return ocispec.Descriptor{}, ErrorPushSignatureFailed{Msg: err.Error()}
 	}
 
 	return targetDesc, nil


### PR DESCRIPTION
This PR adds a `ErrorPushSignatureFailed` error type so that users of notation.Sign() would be able to check error type on Signing failures. 
On notation CLI side, if the error is of type `ErrorPushSignatureFailed`, a suggestion of using OCI image manifest will be printed out.