### PR TITLE
update: improve missing trustpolicy error message

### DIFF
--- a/verifier/trustpolicy/trustpolicy.go
+++ b/verifier/trustpolicy/trustpolicy.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"path/filepath"
 	"regexp"
 	"strings"
 
@@ -265,7 +266,7 @@ func (trustPolicyDoc *Document) GetApplicableTrustPolicy(artifactReference strin
 func LoadDocument() (*Document, error) {
 	jsonFile, err := dir.ConfigFS().Open(dir.PathTrustPolicy)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("Trust policy is not present, please create trust policy at %s", filepath.Join(dir.UserConfigDir, dir.PathTrustPolicy))
 	}
 	defer jsonFile.Close()
 	policyDocument := &Document{}

--- a/verifier/trustpolicy/trustpolicy_test.go
+++ b/verifier/trustpolicy/trustpolicy_test.go
@@ -545,7 +545,7 @@ func TestLoadDocument(t *testing.T) {
 	tempRoot := t.TempDir()
 	dir.UserConfigDir = tempRoot
 	_, err := LoadDocument()
-	if err == nil {
+	if err == nil || err.Error() != fmt.Sprintf("Trust policy is not present, please create trust policy at %s/trustpolicy.json", tempRoot) {
 		t.Fatalf("TestLoadPolicyDocument should throw error for non existent policy")
 	}
 


### PR DESCRIPTION
This PR improves the error message for a missing trustpolicy file

This PR intends to resolve the last comment in the following issue:
[notaryproject/notation/#128](https://github.com/notaryproject/notation/issues/128#issuecomment-1448683454)

This is the output when the trustpolicy is missing:
```
c889f3b9d811:notation kodysk$ ./bin/notation verify $IMAGE
Warning: Always verify the artifact using digest(@sha256:...) rather than a tag(:v1) because resolved digest may not point to the same signed artifact, as tags are mutable.
Error: Trust policy is not present, please create trust policy at /Users/kodysk/Library/Application Support/notation/trustpolicy.json
```

Signed-off-by: Kody Kimberl kody.kimberl.work@gmail.com