### PR TITLE
fix: don't add user-metadata to manifest's subject annotations

### DIFF
--- a/notation.go
+++ b/notation.go
@@ -105,12 +105,12 @@ func Sign(ctx context.Context, signer Signer, repo registry.Repository, remoteOp
 		logger.Infof("Resolved artifact tag `%s` to digest `%s` before signing", ref.Reference, targetDesc.Digest.String())
 	}
 
-	targetDesc, err = addUserMetadataToDescriptor(ctx, targetDesc, remoteOpts.UserMetadata)
+	descToSign, err := addUserMetadataToDescriptor(ctx, targetDesc, remoteOpts.UserMetadata)
 	if err != nil {
 		return ocispec.Descriptor{}, err
 	}
 
-	sig, signerInfo, err := signer.Sign(ctx, targetDesc, remoteOpts.SignOptions)
+	sig, signerInfo, err := signer.Sign(ctx, descToSign, remoteOpts.SignOptions)
 	if err != nil {
 		return ocispec.Descriptor{}, err
 	}


### PR DESCRIPTION
When signing with metadata, notation needs adds the metadata in signature blob as descriptor's annotation but it looks like we are also added it to image-manifest's subject's descriptor, which is undesirable. This PR removes user-metadata from manifest's subject annotations

```bash
# Notation command
notation sign %IMAGE% --user-metadata name=pmt
```
```
# Generated Image manifest

{
  "schemaVersion": 2,
  "mediaType": "application/vnd.oci.image.manifest.v1+json",
  "config": {
    "mediaType": "application/vnd.cncf.notary.signature",
    "digest": "sha256:44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a",
    "size": 2
  },
  "layers": [
    {
      "mediaType": "application/jose+json",
      "digest": "sha256:73a6eda31ccc00fc2b8058b79d728429246feebf790f877a0df6b57a0fcd86ad",
      "size": 4931
    }
  ],
  "subject": {
    "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
    "digest": "sha256:72932c375f25b11f9cff7265d3518341c9814e2ed7aa578afaa659c4e0411de6",
    "size": 942,
    "annotations": {
      "name": "pmt"
    }
  },
  "annotations": {
    "io.cncf.notary.x509chain.thumbprint#S256": "[\"24f098767fcceb4a4b0274001b81d3993c2b54410fc1bf0080f4d17964c19281\",\"e3bb10c07cf8c4e77a38d161ebba482230bd9b4d9e150a6eadac26c8885dd094\",\"574440599c0484b6acd845a373cee98d5b8eb867d6c11c5603ef939045e88da8\",\"43a8466811e4000dbab1610461f0c83a0969844ddcf4badbebb2a028714fbf34\"]",
    "org.opencontainers.image.created": "2023-03-15T18:17:07Z"
  }
}
```