### PR TITLE
update: removed Sign with OCI artifact manifest

### DIFF
--- a/example_localSign_test.go
+++ b/example_localSign_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 var (
-	// exampleDesc is an example of the target OCI artifact manifest descriptor.
+	// exampleDesc is an example of the target manifest descriptor.
 	exampleDesc = ocispec.Descriptor{
 		MediaType: "application/vnd.docker.distribution.manifest.v2+json",
 		Digest:    "sha256:c0d488a800e4127c334ad20d61d7bc21b4097540327217dfab52262adc02380c",

--- a/example_localVerify_test.go
+++ b/example_localVerify_test.go
@@ -43,8 +43,7 @@ func Example_localVerify() {
 	// signature mediaTypes are supported.
 	exampleSignatureMediaType := cose.MediaTypeEnvelope
 
-	// exampleTargetDescriptor is an example of the target OCI artifact manifest
-	// descriptor.
+	// exampleTargetDescriptor is an example of the target manifest descriptor.
 	exampleTargetDescriptor := ocispec.Descriptor{
 		MediaType: "application/vnd.docker.distribution.manifest.v2+json",
 		Digest:    "sha256:c0d488a800e4127c334ad20d61d7bc21b4097540327217dfab52262adc02380c",

--- a/example_remoteVerify_test.go
+++ b/example_remoteVerify_test.go
@@ -67,7 +67,7 @@ func Example_remoteVerify() {
 	}
 
 	// remote verify core process
-	// upon successful verification, the target OCI artifact manifest descriptor
+	// upon successful verification, the target manifest descriptor
 	// and signature verification outcome are returned.
 	targetDesc, _, err := notation.Verify(context.Background(), exampleVerifier, exampleRepo, exampleVerifyOptions)
 	if err != nil {

--- a/internal/mock/mocks.go
+++ b/internal/mock/mocks.go
@@ -73,7 +73,7 @@ var (
 		Annotations: Annotations,
 	}
 	SigManfiestDescriptor = ocispec.Descriptor{
-		MediaType:   "application/vnd.cncf.oras.artifact.manifest.v1+json",
+		MediaType:   "application/vnd.oci.image.manifest.v1+json",
 		Digest:      SampleDigest,
 		Size:        300,
 		Annotations: Annotations,

--- a/notation_test.go
+++ b/notation_test.go
@@ -327,7 +327,7 @@ func (s *ociDummySigner) Sign(ctx context.Context, desc ocispec.Descriptor, opts
 }
 
 func TestSignLocalContent(t *testing.T) {
-	repo, err := registry.NewOCIRepository(ociLayoutPath, registry.RepositoryOptions{OCIImageManifest: true})
+	repo, err := registry.NewOCIRepository(ociLayoutPath, registry.RepositoryOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -344,7 +344,7 @@ func TestSignLocalContent(t *testing.T) {
 }
 
 func TestVerifyLocalContent(t *testing.T) {
-	repo, err := registry.NewOCIRepository(ociLayoutPath, registry.RepositoryOptions{OCIImageManifest: true})
+	repo, err := registry.NewOCIRepository(ociLayoutPath, registry.RepositoryOptions{})
 	if err != nil {
 		t.Fatalf("failed to create oci.Store as registry.Repository: %v", err)
 	}

--- a/registry/interface.go
+++ b/registry/interface.go
@@ -14,7 +14,7 @@ type Repository interface {
 	Resolve(ctx context.Context, reference string) (ocispec.Descriptor, error)
 
 	// ListSignatures returns signature manifests filtered by fn given the
-	// artifact manifest descriptor
+	// target artifact's manifest descriptor
 	ListSignatures(ctx context.Context, desc ocispec.Descriptor, fn func(signatureManifests []ocispec.Descriptor) error) error
 
 	// FetchSignatureBlob returns signature envelope blob and descriptor for

--- a/registry/repository.go
+++ b/registry/repository.go
@@ -74,7 +74,7 @@ func (c *repositoryClient) Resolve(ctx context.Context, reference string) (ocisp
 }
 
 // ListSignatures returns signature manifests filtered by fn given the
-// artifact manifest descriptor
+// target artifact's manifest descriptor
 func (c *repositoryClient) ListSignatures(ctx context.Context, desc ocispec.Descriptor, fn func(signatureManifests []ocispec.Descriptor) error) error {
 	if repo, ok := c.GraphTarget.(registry.ReferrerLister); ok {
 		return repo.Referrers(ctx, desc, ArtifactTypeNotation, fn)

--- a/registry/repository.go
+++ b/registry/repository.go
@@ -19,18 +19,8 @@ const (
 )
 
 // RepositoryOptions provides user options when creating a Repository
-type RepositoryOptions struct {
-	// OCIImageManifest specifies if user wants to use OCI image manifest
-	// to store signatures in remote registries.
-	// By default, Notation will use OCI artifact manifest to store signatures.
-	// If OCIImageManifest flag is set to true, Notation will instead use
-	// OCI image manifest.
-	// Note, Notation will not automatically convert between these two types
-	// on any occasion.
-	// OCI artifact manifest: https://github.com/opencontainers/image-spec/blob/v1.1.0-rc2/artifact.md
-	// OCI image manifest: https://github.com/opencontainers/image-spec/blob/v1.1.0-rc2/manifest.md
-	OCIImageManifest bool
-}
+// it is kept for future extensibility
+type RepositoryOptions struct{}
 
 // repositoryClient implements Repository
 type repositoryClient struct {
@@ -186,7 +176,7 @@ func (c *repositoryClient) uploadSignatureManifest(ctx context.Context, subject,
 	opts := oras.PackOptions{
 		Subject:             &subject,
 		ManifestAnnotations: annotations,
-		PackImageManifest:   c.OCIImageManifest,
+		PackImageManifest:   true,
 	}
 
 	return oras.Pack(ctx, c.GraphTarget, ArtifactTypeNotation, []ocispec.Descriptor{blobDesc}, opts)

--- a/registry/repository_test.go
+++ b/registry/repository_test.go
@@ -407,9 +407,6 @@ func newRepositoryClientWithImageManifest(client remote.Client, ref registry.Ref
 			Reference: ref,
 			PlainHTTP: plainHTTP,
 		},
-		RepositoryOptions: RepositoryOptions{
-			OCIImageManifest: true,
-		},
 	}
 }
 
@@ -438,7 +435,7 @@ var (
 )
 
 func TestOciLayoutRepositoryResolveAndPush(t *testing.T) {
-	repo, err := NewOCIRepository(ociLayoutPath, RepositoryOptions{OCIImageManifest: true})
+	repo, err := NewOCIRepository(ociLayoutPath, RepositoryOptions{})
 	if err != nil {
 		t.Fatalf("failed to create oci.Store as registry.Repository: %v", err)
 	}
@@ -470,7 +467,7 @@ func TestOciLayoutRepositoryResolveAndPush(t *testing.T) {
 }
 
 func TestOciLayoutRepositoryListAndFetchBlob(t *testing.T) {
-	repo, err := NewOCIRepository(ociLayoutPath, RepositoryOptions{OCIImageManifest: true})
+	repo, err := NewOCIRepository(ociLayoutPath, RepositoryOptions{})
 	if err != nil {
 		t.Fatalf("failed to create oci.Store as registry.Repository: %v", err)
 	}


### PR DESCRIPTION
This PR removes notation-go `Sign`'s support of OCI artifact manifest as it is removed from [image-spec v1.0.0-rc.3](https://github.com/opencontainers/image-spec/releases/tag/v1.1.0-rc.3). In other words, Notation will only generate signatures stored as OCI image manifest in the future.
(Note: Notation can still consume signatures already stored as OCI artifact manifest for backwards compatibility.)

Related issue: https://github.com/notaryproject/notation/issues/660