### PR TITLE
chore: running some chores for notation-go

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![codecov](https://codecov.io/gh/notaryproject/notation-go/branch/main/graph/badge.svg)](https://codecov.io/gh/notaryproject/notation-go)
 [![Go Reference](https://pkg.go.dev/badge/github.com/notaryproject/notation-go.svg)](https://pkg.go.dev/github.com/notaryproject/notation-go@main)
 
-A collection of libraries for supporting Notation sign, verify, push, pull of oci artifacts. Based on Notation standard.
+A collection of libraries for supporting Notation sign, verify, push, pull of oci artifacts. Based on Notary Project standard.
 
 ## Table of Contents
 - [Core Documents](#core-documents)

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![codecov](https://codecov.io/gh/notaryproject/notation-go/branch/main/graph/badge.svg)](https://codecov.io/gh/notaryproject/notation-go)
 [![Go Reference](https://pkg.go.dev/badge/github.com/notaryproject/notation-go.svg)](https://pkg.go.dev/github.com/notaryproject/notation-go@main)
 
-A collection of libraries for supporting Notation sign, verify, push, pull of oci artifacts. Based on Notary V2 standard.
+A collection of libraries for supporting Notation sign, verify, push, pull of oci artifacts. Based on Notation standard.
 
 ## Table of Contents
 - [Core Documents](#core-documents)

--- a/internal/pkix/pkix.go
+++ b/internal/pkix/pkix.go
@@ -7,7 +7,7 @@ import (
 	ldapv3 "github.com/go-ldap/ldap/v3"
 )
 
-// ParseDistinguishedName parses a DN name and validates Notary V2 rules
+// ParseDistinguishedName parses a DN name and validates Notation rules
 func ParseDistinguishedName(name string) (map[string]string, error) {
 	if strings.Contains(name, "=#") {
 		return nil, fmt.Errorf("unsupported distinguished name (DN) %q: notation does not support x509.subject identities containing \"=#\"", name)

--- a/internal/pkix/pkix.go
+++ b/internal/pkix/pkix.go
@@ -7,7 +7,7 @@ import (
 	ldapv3 "github.com/go-ldap/ldap/v3"
 )
 
-// ParseDistinguishedName parses a DN name and validates Notation rules
+// ParseDistinguishedName parses a DN name and validates Notary Project rules
 func ParseDistinguishedName(name string) (map[string]string, error) {
 	if strings.Contains(name, "=#") {
 		return nil, fmt.Errorf("unsupported distinguished name (DN) %q: notation does not support x509.subject identities containing \"=#\"", name)

--- a/plugin/proto/verify.go
+++ b/plugin/proto/verify.go
@@ -22,7 +22,7 @@ type Signature struct {
 	CertificateChain      [][]byte           `json:"certificateChain"`
 }
 
-// CriticalAttributes contains all Notary V2 defined critical
+// CriticalAttributes contains all Notation defined critical
 // attributes and their values in the signature envelope
 type CriticalAttributes struct {
 	ContentType          string                 `json:"contentType"`

--- a/plugin/proto/verify.go
+++ b/plugin/proto/verify.go
@@ -22,7 +22,7 @@ type Signature struct {
 	CertificateChain      [][]byte           `json:"certificateChain"`
 }
 
-// CriticalAttributes contains all Notation defined critical
+// CriticalAttributes contains all Notary Project defined critical
 // attributes and their values in the signature envelope
 type CriticalAttributes struct {
 	ContentType          string                 `json:"contentType"`

--- a/verifier/trustpolicy/trustpolicy.go
+++ b/verifier/trustpolicy/trustpolicy.go
@@ -235,7 +235,7 @@ func (policyDoc *Document) Validate() error {
 // GetApplicableTrustPolicy returns a pointer to the deep copied TrustPolicy
 // statement that applies to the given registry scope. If no applicable trust
 // policy is found, returns an error
-// see https://github.com/notaryproject/notaryproject/blob/main/specs/trust-store-trust-policy-specification.md#selecting-a-trust-policy-based-on-artifact-uri
+// see https://github.com/notaryproject/notaryproject/blob/v1.0.0-rc.2/specs/trust-store-trust-policy.md#selecting-a-trust-policy-based-on-artifact-uri
 func (trustPolicyDoc *Document) GetApplicableTrustPolicy(artifactReference string) (*TrustPolicy, error) {
 	artifactPath, err := getArtifactPathFromReference(artifactReference)
 	if err != nil {
@@ -261,7 +261,7 @@ func (trustPolicyDoc *Document) GetApplicableTrustPolicy(artifactReference strin
 	} else if wildcardPolicy != nil {
 		return wildcardPolicy, nil
 	} else {
-		return nil, fmt.Errorf("artifact %q has no applicable trust policy", artifactReference)
+		return nil, fmt.Errorf("artifact %q has no applicable trust policy. Trust policy applicability for a given artifact is determined by registryScopes.\nFor more details: %s", artifactReference, trustPolicyLink)
 	}
 }
 
@@ -282,7 +282,7 @@ func LoadDocument() (*Document, error) {
 	policyDocument := &Document{}
 	err = json.NewDecoder(jsonFile).Decode(policyDocument)
 	if err != nil {
-		return nil, errors.New("malformed trustpolicy.json file")
+		return nil, fmt.Errorf("malformed trustpolicy.json file.\nHow to create the Notation trust policy: %s", trustPolicyLink)
 	}
 	return policyDocument, nil
 }

--- a/verifier/trustpolicy/trustpolicy.go
+++ b/verifier/trustpolicy/trustpolicy.go
@@ -271,7 +271,7 @@ func LoadDocument() (*Document, error) {
 	if err != nil {
 		switch {
 		case errors.Is(err, os.ErrNotExist):
-			return nil, fmt.Errorf("trust policy is not present, please create trust policy at %s.\nHow to create the Notation trust policy: %q", filepath.Join(dir.UserConfigDir, dir.PathTrustPolicy), trustPolicyLink)
+			return nil, fmt.Errorf("trust policy is not present, please create trust policy at %s.\nHow to create the Notation trust policy: %s", filepath.Join(dir.UserConfigDir, dir.PathTrustPolicy), trustPolicyLink)
 		case errors.Is(err, os.ErrPermission):
 			return nil, fmt.Errorf("unable to read trust policy due to file permissions, please verify the permissions of %s", filepath.Join(dir.UserConfigDir, dir.PathTrustPolicy))
 		default:

--- a/verifier/trustpolicy/trustpolicy.go
+++ b/verifier/trustpolicy/trustpolicy.go
@@ -261,7 +261,7 @@ func (trustPolicyDoc *Document) GetApplicableTrustPolicy(artifactReference strin
 	} else if wildcardPolicy != nil {
 		return wildcardPolicy, nil
 	} else {
-		return nil, fmt.Errorf("artifact %q has no applicable trust policy. Trust policy applicability for a given artifact is determined by registryScopes. To create Notation trust policy: %s", artifactReference, trustPolicyLink)
+		return nil, fmt.Errorf("artifact %q has no applicable trust policy. Trust policy applicability for a given artifact is determined by registryScopes. To create a trust policy, see: %s", artifactReference, trustPolicyLink)
 	}
 }
 
@@ -271,7 +271,7 @@ func LoadDocument() (*Document, error) {
 	if err != nil {
 		switch {
 		case errors.Is(err, os.ErrNotExist):
-			return nil, fmt.Errorf("trust policy is not present. To create Notation trust policy: %s", trustPolicyLink)
+			return nil, fmt.Errorf("trust policy is not present. To create a trust policy, see: %s", trustPolicyLink)
 		case errors.Is(err, os.ErrPermission):
 			return nil, fmt.Errorf("unable to read trust policy due to file permissions, please verify the permissions of %s", filepath.Join(dir.UserConfigDir, dir.PathTrustPolicy))
 		default:
@@ -282,7 +282,7 @@ func LoadDocument() (*Document, error) {
 	policyDocument := &Document{}
 	err = json.NewDecoder(jsonFile).Decode(policyDocument)
 	if err != nil {
-		return nil, fmt.Errorf("malformed trust policy. To create Notation trust policy: %s", trustPolicyLink)
+		return nil, fmt.Errorf("malformed trust policy. To create a trust policy, see: %s", trustPolicyLink)
 	}
 	return policyDocument, nil
 }
@@ -371,7 +371,7 @@ func (t *TrustPolicy) clone() *TrustPolicy {
 }
 
 // validateTrustStore validates if the policy statement is following the
-// Notation spec rules for truststores
+// Notary Project spec rules for truststores
 func validateTrustStore(statement TrustPolicy) error {
 	for _, trustStore := range statement.TrustStores {
 		storeType, namedStore, found := strings.Cut(trustStore, ":")
@@ -390,7 +390,7 @@ func validateTrustStore(statement TrustPolicy) error {
 }
 
 // validateTrustedIdentities validates if the policy statement is following the
-// Notation spec rules for trusted identities
+// Notary Project spec rules for trusted identities
 func validateTrustedIdentities(statement TrustPolicy) error {
 	// If there is a wildcard in trusted identies, there shouldn't be any other
 	//identities
@@ -436,7 +436,7 @@ func validateTrustedIdentities(statement TrustPolicy) error {
 }
 
 // validateRegistryScopes validates if the policy document is following the
-// Notation spec rules for registry scopes
+// Notary Project spec rules for registry scopes
 func validateRegistryScopes(policyDoc *Document) error {
 	registryScopeCount := make(map[string]int)
 	for _, statement := range policyDoc.TrustPolicies {

--- a/verifier/trustpolicy/trustpolicy.go
+++ b/verifier/trustpolicy/trustpolicy.go
@@ -261,7 +261,7 @@ func (trustPolicyDoc *Document) GetApplicableTrustPolicy(artifactReference strin
 	} else if wildcardPolicy != nil {
 		return wildcardPolicy, nil
 	} else {
-		return nil, fmt.Errorf("artifact %q has no applicable trust policy. Trust policy applicability for a given artifact is determined by registryScopes.\nTo set up Notation trust policy: %s", artifactReference, trustPolicyLink)
+		return nil, fmt.Errorf("artifact %q has no applicable trust policy. Trust policy applicability for a given artifact is determined by registryScopes. How to set up Notation trust policy: %s", artifactReference, trustPolicyLink)
 	}
 }
 
@@ -271,7 +271,7 @@ func LoadDocument() (*Document, error) {
 	if err != nil {
 		switch {
 		case errors.Is(err, os.ErrNotExist):
-			return nil, fmt.Errorf("trust policy is not present, please create trust policy at %s.\nTo set up Notation trust policy: %s", filepath.Join(dir.UserConfigDir, dir.PathTrustPolicy), trustPolicyLink)
+			return nil, fmt.Errorf("trust policy is not present, please create trust policy at %s. How to set up Notation trust policy: %s", filepath.Join(dir.UserConfigDir, dir.PathTrustPolicy), trustPolicyLink)
 		case errors.Is(err, os.ErrPermission):
 			return nil, fmt.Errorf("unable to read trust policy due to file permissions, please verify the permissions of %s", filepath.Join(dir.UserConfigDir, dir.PathTrustPolicy))
 		default:
@@ -282,7 +282,7 @@ func LoadDocument() (*Document, error) {
 	policyDocument := &Document{}
 	err = json.NewDecoder(jsonFile).Decode(policyDocument)
 	if err != nil {
-		return nil, fmt.Errorf("malformed trustpolicy.json file.\nTo set up Notation trust policy: %s", trustPolicyLink)
+		return nil, fmt.Errorf("malformed trustpolicy.json file. How to set up Notation trust policy: %s", trustPolicyLink)
 	}
 	return policyDocument, nil
 }

--- a/verifier/trustpolicy/trustpolicy.go
+++ b/verifier/trustpolicy/trustpolicy.go
@@ -271,7 +271,7 @@ func LoadDocument() (*Document, error) {
 	if err != nil {
 		switch {
 		case errors.Is(err, os.ErrNotExist):
-			return nil, fmt.Errorf("trust policy is not present, please create trust policy at %s. How to create the Notation trust policy: %q", filepath.Join(dir.UserConfigDir, dir.PathTrustPolicy), trustPolicyLink)
+			return nil, fmt.Errorf("trust policy is not present, please create trust policy at %s.\nHow to create the Notation trust policy: %q", filepath.Join(dir.UserConfigDir, dir.PathTrustPolicy), trustPolicyLink)
 		case errors.Is(err, os.ErrPermission):
 			return nil, fmt.Errorf("unable to read trust policy due to file permissions, please verify the permissions of %s", filepath.Join(dir.UserConfigDir, dir.PathTrustPolicy))
 		default:

--- a/verifier/trustpolicy/trustpolicy.go
+++ b/verifier/trustpolicy/trustpolicy.go
@@ -19,6 +19,9 @@ import (
 	"github.com/notaryproject/notation-go/verifier/truststore"
 )
 
+// trustPolicyLink is a tutorial link for creating Notation's trust policy.
+const trustPolicyLink = "https://notaryproject.dev/docs/quickstart/#create-a-trust-policy"
+
 // ValidationType is an enum for signature verification types such as Integrity,
 // Authenticity, etc.
 type ValidationType string
@@ -268,7 +271,7 @@ func LoadDocument() (*Document, error) {
 	if err != nil {
 		switch {
 		case errors.Is(err, os.ErrNotExist):
-			return nil, fmt.Errorf("trust policy is not present, please create trust policy at %s", filepath.Join(dir.UserConfigDir, dir.PathTrustPolicy))
+			return nil, fmt.Errorf("trust policy is not present, please create trust policy at %s. How to create the Notation trust policy: %q", filepath.Join(dir.UserConfigDir, dir.PathTrustPolicy), trustPolicyLink)
 		case errors.Is(err, os.ErrPermission):
 			return nil, fmt.Errorf("unable to read trust policy due to file permissions, please verify the permissions of %s", filepath.Join(dir.UserConfigDir, dir.PathTrustPolicy))
 		default:
@@ -368,7 +371,7 @@ func (t *TrustPolicy) clone() *TrustPolicy {
 }
 
 // validateTrustStore validates if the policy statement is following the
-// Notary V2 spec rules for truststores
+// Notation spec rules for truststores
 func validateTrustStore(statement TrustPolicy) error {
 	for _, trustStore := range statement.TrustStores {
 		storeType, namedStore, found := strings.Cut(trustStore, ":")
@@ -387,7 +390,7 @@ func validateTrustStore(statement TrustPolicy) error {
 }
 
 // validateTrustedIdentities validates if the policy statement is following the
-// Notary V2 spec rules for trusted identities
+// Notation spec rules for trusted identities
 func validateTrustedIdentities(statement TrustPolicy) error {
 	// If there is a wildcard in trusted identies, there shouldn't be any other
 	//identities
@@ -433,7 +436,7 @@ func validateTrustedIdentities(statement TrustPolicy) error {
 }
 
 // validateRegistryScopes validates if the policy document is following the
-// Notary V2 spec rules for registry scopes
+// Notation spec rules for registry scopes
 func validateRegistryScopes(policyDoc *Document) error {
 	registryScopeCount := make(map[string]int)
 	for _, statement := range policyDoc.TrustPolicies {

--- a/verifier/trustpolicy/trustpolicy.go
+++ b/verifier/trustpolicy/trustpolicy.go
@@ -261,7 +261,7 @@ func (trustPolicyDoc *Document) GetApplicableTrustPolicy(artifactReference strin
 	} else if wildcardPolicy != nil {
 		return wildcardPolicy, nil
 	} else {
-		return nil, fmt.Errorf("artifact %q has no applicable trust policy. Trust policy applicability for a given artifact is determined by registryScopes. How to set up Notation trust policy: %s", artifactReference, trustPolicyLink)
+		return nil, fmt.Errorf("artifact %q has no applicable trust policy. Trust policy applicability for a given artifact is determined by registryScopes. To create Notation trust policy: %s", artifactReference, trustPolicyLink)
 	}
 }
 
@@ -271,7 +271,7 @@ func LoadDocument() (*Document, error) {
 	if err != nil {
 		switch {
 		case errors.Is(err, os.ErrNotExist):
-			return nil, fmt.Errorf("trust policy is not present, please create trust policy at %s. How to set up Notation trust policy: %s", filepath.Join(dir.UserConfigDir, dir.PathTrustPolicy), trustPolicyLink)
+			return nil, fmt.Errorf("trust policy is not present. To create Notation trust policy: %s", trustPolicyLink)
 		case errors.Is(err, os.ErrPermission):
 			return nil, fmt.Errorf("unable to read trust policy due to file permissions, please verify the permissions of %s", filepath.Join(dir.UserConfigDir, dir.PathTrustPolicy))
 		default:
@@ -282,7 +282,7 @@ func LoadDocument() (*Document, error) {
 	policyDocument := &Document{}
 	err = json.NewDecoder(jsonFile).Decode(policyDocument)
 	if err != nil {
-		return nil, fmt.Errorf("malformed trustpolicy.json file. How to set up Notation trust policy: %s", trustPolicyLink)
+		return nil, fmt.Errorf("malformed trust policy. To create Notation trust policy: %s", trustPolicyLink)
 	}
 	return policyDocument, nil
 }

--- a/verifier/trustpolicy/trustpolicy.go
+++ b/verifier/trustpolicy/trustpolicy.go
@@ -261,7 +261,7 @@ func (trustPolicyDoc *Document) GetApplicableTrustPolicy(artifactReference strin
 	} else if wildcardPolicy != nil {
 		return wildcardPolicy, nil
 	} else {
-		return nil, fmt.Errorf("artifact %q has no applicable trust policy. Trust policy applicability for a given artifact is determined by registryScopes.\nFor more details: %s", artifactReference, trustPolicyLink)
+		return nil, fmt.Errorf("artifact %q has no applicable trust policy. Trust policy applicability for a given artifact is determined by registryScopes.\nTo set up Notation trust policy: %s", artifactReference, trustPolicyLink)
 	}
 }
 
@@ -271,7 +271,7 @@ func LoadDocument() (*Document, error) {
 	if err != nil {
 		switch {
 		case errors.Is(err, os.ErrNotExist):
-			return nil, fmt.Errorf("trust policy is not present, please create trust policy at %s.\nHow to create the Notation trust policy: %s", filepath.Join(dir.UserConfigDir, dir.PathTrustPolicy), trustPolicyLink)
+			return nil, fmt.Errorf("trust policy is not present, please create trust policy at %s.\nTo set up Notation trust policy: %s", filepath.Join(dir.UserConfigDir, dir.PathTrustPolicy), trustPolicyLink)
 		case errors.Is(err, os.ErrPermission):
 			return nil, fmt.Errorf("unable to read trust policy due to file permissions, please verify the permissions of %s", filepath.Join(dir.UserConfigDir, dir.PathTrustPolicy))
 		default:
@@ -282,7 +282,7 @@ func LoadDocument() (*Document, error) {
 	policyDocument := &Document{}
 	err = json.NewDecoder(jsonFile).Decode(policyDocument)
 	if err != nil {
-		return nil, fmt.Errorf("malformed trustpolicy.json file.\nHow to create the Notation trust policy: %s", trustPolicyLink)
+		return nil, fmt.Errorf("malformed trustpolicy.json file.\nTo set up Notation trust policy: %s", trustPolicyLink)
 	}
 	return policyDocument, nil
 }

--- a/verifier/trustpolicy/trustpolicy_test.go
+++ b/verifier/trustpolicy/trustpolicy_test.go
@@ -546,7 +546,7 @@ func TestLoadDocument(t *testing.T) {
 	tempRoot := t.TempDir()
 	dir.UserConfigDir = tempRoot
 	_, err := LoadDocument()
-	if err == nil || err.Error() != fmt.Sprintf("trust policy is not present, please create trust policy at %s. How to create the Notation trust policy: %q", filepath.Join(dir.UserConfigDir, dir.PathTrustPolicy), trustPolicyLink) {
+	if err == nil || err.Error() != fmt.Sprintf("trust policy is not present, please create trust policy at %s.\nHow to create the Notation trust policy: %q", filepath.Join(dir.UserConfigDir, dir.PathTrustPolicy), trustPolicyLink) {
 		t.Fatalf("TestLoadPolicyDocument should throw error for non existent policy")
 	}
 

--- a/verifier/trustpolicy/trustpolicy_test.go
+++ b/verifier/trustpolicy/trustpolicy_test.go
@@ -519,7 +519,7 @@ func TestApplicableTrustPolicy(t *testing.T) {
 
 	// non-existing Registry Scope
 	policy, err = (&policyDoc).GetApplicableTrustPolicy("non.existing.scope/repo@sha256:hash")
-	if policy != nil || err == nil || err.Error() != "artifact \"non.existing.scope/repo@sha256:hash\" has no applicable trust policy. Trust policy applicability for a given artifact is determined by registryScopes.\nTo set up Notation trust policy: https://notaryproject.dev/docs/quickstart/#create-a-trust-policy" {
+	if policy != nil || err == nil || err.Error() != "artifact \"non.existing.scope/repo@sha256:hash\" has no applicable trust policy. Trust policy applicability for a given artifact is determined by registryScopes. How to set up Notation trust policy: https://notaryproject.dev/docs/quickstart/#create-a-trust-policy" {
 		t.Fatalf("getApplicableTrustPolicy should return nil for non existing registry scope")
 	}
 
@@ -546,7 +546,7 @@ func TestLoadDocument(t *testing.T) {
 	tempRoot := t.TempDir()
 	dir.UserConfigDir = tempRoot
 	_, err := LoadDocument()
-	if err == nil || err.Error() != fmt.Sprintf("trust policy is not present, please create trust policy at %s.\nTo set up Notation trust policy: %s", filepath.Join(dir.UserConfigDir, dir.PathTrustPolicy), trustPolicyLink) {
+	if err == nil || err.Error() != fmt.Sprintf("trust policy is not present, please create trust policy at %s. How to set up Notation trust policy: %s", filepath.Join(dir.UserConfigDir, dir.PathTrustPolicy), trustPolicyLink) {
 		t.Fatalf("TestLoadPolicyDocument should throw error for non existent policy")
 	}
 

--- a/verifier/trustpolicy/trustpolicy_test.go
+++ b/verifier/trustpolicy/trustpolicy_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strconv"
 	"testing"
 
@@ -545,7 +546,7 @@ func TestLoadDocument(t *testing.T) {
 	tempRoot := t.TempDir()
 	dir.UserConfigDir = tempRoot
 	_, err := LoadDocument()
-	if err == nil || err.Error() != fmt.Sprintf("trust policy is not present, please create trust policy at %s", filepath.Join(dir.UserConfigDir, dir.PathTrustPolicy)) {
+	if err == nil || err.Error() != fmt.Sprintf("trust policy is not present, please create trust policy at %s. How to create the Notation trust policy: %q", filepath.Join(dir.UserConfigDir, dir.PathTrustPolicy), trustPolicyLink) {
 		t.Fatalf("TestLoadPolicyDocument should throw error for non existent policy")
 	}
 
@@ -578,6 +579,9 @@ func TestLoadDocument(t *testing.T) {
 	}
 
 	// existing policy file with bad permissions
+	if runtime.GOOS == "windows" {
+		t.Skip("skipping test on Windows")
+	}
 	tempRoot = t.TempDir()
 	dir.UserConfigDir = tempRoot
 	path = filepath.Join(tempRoot, "trustpolicy.json")

--- a/verifier/trustpolicy/trustpolicy_test.go
+++ b/verifier/trustpolicy/trustpolicy_test.go
@@ -519,7 +519,7 @@ func TestApplicableTrustPolicy(t *testing.T) {
 
 	// non-existing Registry Scope
 	policy, err = (&policyDoc).GetApplicableTrustPolicy("non.existing.scope/repo@sha256:hash")
-	if policy != nil || err == nil || err.Error() != "artifact \"non.existing.scope/repo@sha256:hash\" has no applicable trust policy. Trust policy applicability for a given artifact is determined by registryScopes. To create Notation trust policy: https://notaryproject.dev/docs/quickstart/#create-a-trust-policy" {
+	if policy != nil || err == nil || err.Error() != "artifact \"non.existing.scope/repo@sha256:hash\" has no applicable trust policy. Trust policy applicability for a given artifact is determined by registryScopes. To create a trust policy, see: https://notaryproject.dev/docs/quickstart/#create-a-trust-policy" {
 		t.Fatalf("getApplicableTrustPolicy should return nil for non existing registry scope")
 	}
 
@@ -546,7 +546,7 @@ func TestLoadDocument(t *testing.T) {
 	tempRoot := t.TempDir()
 	dir.UserConfigDir = tempRoot
 	_, err := LoadDocument()
-	if err == nil || err.Error() != fmt.Sprintf("trust policy is not present. To create Notation trust policy: %s", trustPolicyLink) {
+	if err == nil || err.Error() != fmt.Sprintf("trust policy is not present. To create a trust policy, see: %s", trustPolicyLink) {
 		t.Fatalf("TestLoadPolicyDocument should throw error for non existent policy")
 	}
 

--- a/verifier/trustpolicy/trustpolicy_test.go
+++ b/verifier/trustpolicy/trustpolicy_test.go
@@ -546,7 +546,7 @@ func TestLoadDocument(t *testing.T) {
 	tempRoot := t.TempDir()
 	dir.UserConfigDir = tempRoot
 	_, err := LoadDocument()
-	if err == nil || err.Error() != fmt.Sprintf("trust policy is not present, please create trust policy at %s.\nHow to create the Notation trust policy: %q", filepath.Join(dir.UserConfigDir, dir.PathTrustPolicy), trustPolicyLink) {
+	if err == nil || err.Error() != fmt.Sprintf("trust policy is not present, please create trust policy at %s.\nHow to create the Notation trust policy: %s", filepath.Join(dir.UserConfigDir, dir.PathTrustPolicy), trustPolicyLink) {
 		t.Fatalf("TestLoadPolicyDocument should throw error for non existent policy")
 	}
 

--- a/verifier/trustpolicy/trustpolicy_test.go
+++ b/verifier/trustpolicy/trustpolicy_test.go
@@ -519,7 +519,7 @@ func TestApplicableTrustPolicy(t *testing.T) {
 
 	// non-existing Registry Scope
 	policy, err = (&policyDoc).GetApplicableTrustPolicy("non.existing.scope/repo@sha256:hash")
-	if policy != nil || err == nil || err.Error() != "artifact \"non.existing.scope/repo@sha256:hash\" has no applicable trust policy. Trust policy applicability for a given artifact is determined by registryScopes.\nFor more details: https://notaryproject.dev/docs/quickstart/#create-a-trust-policy" {
+	if policy != nil || err == nil || err.Error() != "artifact \"non.existing.scope/repo@sha256:hash\" has no applicable trust policy. Trust policy applicability for a given artifact is determined by registryScopes.\nTo set up Notation trust policy: https://notaryproject.dev/docs/quickstart/#create-a-trust-policy" {
 		t.Fatalf("getApplicableTrustPolicy should return nil for non existing registry scope")
 	}
 
@@ -546,7 +546,7 @@ func TestLoadDocument(t *testing.T) {
 	tempRoot := t.TempDir()
 	dir.UserConfigDir = tempRoot
 	_, err := LoadDocument()
-	if err == nil || err.Error() != fmt.Sprintf("trust policy is not present, please create trust policy at %s.\nHow to create the Notation trust policy: %s", filepath.Join(dir.UserConfigDir, dir.PathTrustPolicy), trustPolicyLink) {
+	if err == nil || err.Error() != fmt.Sprintf("trust policy is not present, please create trust policy at %s.\nTo set up Notation trust policy: %s", filepath.Join(dir.UserConfigDir, dir.PathTrustPolicy), trustPolicyLink) {
 		t.Fatalf("TestLoadPolicyDocument should throw error for non existent policy")
 	}
 

--- a/verifier/trustpolicy/trustpolicy_test.go
+++ b/verifier/trustpolicy/trustpolicy_test.go
@@ -519,7 +519,7 @@ func TestApplicableTrustPolicy(t *testing.T) {
 
 	// non-existing Registry Scope
 	policy, err = (&policyDoc).GetApplicableTrustPolicy("non.existing.scope/repo@sha256:hash")
-	if policy != nil || err == nil || err.Error() != "artifact \"non.existing.scope/repo@sha256:hash\" has no applicable trust policy. Trust policy applicability for a given artifact is determined by registryScopes. How to set up Notation trust policy: https://notaryproject.dev/docs/quickstart/#create-a-trust-policy" {
+	if policy != nil || err == nil || err.Error() != "artifact \"non.existing.scope/repo@sha256:hash\" has no applicable trust policy. Trust policy applicability for a given artifact is determined by registryScopes. To create Notation trust policy: https://notaryproject.dev/docs/quickstart/#create-a-trust-policy" {
 		t.Fatalf("getApplicableTrustPolicy should return nil for non existing registry scope")
 	}
 
@@ -546,7 +546,7 @@ func TestLoadDocument(t *testing.T) {
 	tempRoot := t.TempDir()
 	dir.UserConfigDir = tempRoot
 	_, err := LoadDocument()
-	if err == nil || err.Error() != fmt.Sprintf("trust policy is not present, please create trust policy at %s. How to set up Notation trust policy: %s", filepath.Join(dir.UserConfigDir, dir.PathTrustPolicy), trustPolicyLink) {
+	if err == nil || err.Error() != fmt.Sprintf("trust policy is not present. To create Notation trust policy: %s", trustPolicyLink) {
 		t.Fatalf("TestLoadPolicyDocument should throw error for non existent policy")
 	}
 

--- a/verifier/trustpolicy/trustpolicy_test.go
+++ b/verifier/trustpolicy/trustpolicy_test.go
@@ -519,7 +519,7 @@ func TestApplicableTrustPolicy(t *testing.T) {
 
 	// non-existing Registry Scope
 	policy, err = (&policyDoc).GetApplicableTrustPolicy("non.existing.scope/repo@sha256:hash")
-	if policy != nil || err == nil || err.Error() != "artifact \"non.existing.scope/repo@sha256:hash\" has no applicable trust policy" {
+	if policy != nil || err == nil || err.Error() != "artifact \"non.existing.scope/repo@sha256:hash\" has no applicable trust policy. Trust policy applicability for a given artifact is determined by registryScopes.\nFor more details: https://notaryproject.dev/docs/quickstart/#create-a-trust-policy" {
 		t.Fatalf("getApplicableTrustPolicy should return nil for non existing registry scope")
 	}
 

--- a/verifier/verifier_test.go
+++ b/verifier/verifier_test.go
@@ -104,7 +104,7 @@ func TestErrorNoApplicableTrustPolicy_Error(t *testing.T) {
 	}
 	opts := notation.VerifierVerifyOptions{ArtifactReference: "non-existent-domain.com/repo@sha256:73c803930ea3ba1e54bc25c2bdc53edd0284c62ed651fe7b00369da519a3c333"}
 	_, err := verifier.Verify(context.Background(), ocispec.Descriptor{}, []byte{}, opts)
-	if !errors.Is(err, notation.ErrorNoApplicableTrustPolicy{Msg: "artifact \"non-existent-domain.com/repo@sha256:73c803930ea3ba1e54bc25c2bdc53edd0284c62ed651fe7b00369da519a3c333\" has no applicable trust policy"}) {
+	if !errors.Is(err, notation.ErrorNoApplicableTrustPolicy{Msg: "artifact \"non-existent-domain.com/repo@sha256:73c803930ea3ba1e54bc25c2bdc53edd0284c62ed651fe7b00369da519a3c333\" has no applicable trust policy. Trust policy applicability for a given artifact is determined by registryScopes. To create Notation trust policy: https://notaryproject.dev/docs/quickstart/#create-a-trust-policy"}) {
 		t.Fatalf("no applicable trust policy must throw error")
 	}
 }

--- a/verifier/verifier_test.go
+++ b/verifier/verifier_test.go
@@ -104,7 +104,7 @@ func TestErrorNoApplicableTrustPolicy_Error(t *testing.T) {
 	}
 	opts := notation.VerifierVerifyOptions{ArtifactReference: "non-existent-domain.com/repo@sha256:73c803930ea3ba1e54bc25c2bdc53edd0284c62ed651fe7b00369da519a3c333"}
 	_, err := verifier.Verify(context.Background(), ocispec.Descriptor{}, []byte{}, opts)
-	if !errors.Is(err, notation.ErrorNoApplicableTrustPolicy{Msg: "artifact \"non-existent-domain.com/repo@sha256:73c803930ea3ba1e54bc25c2bdc53edd0284c62ed651fe7b00369da519a3c333\" has no applicable trust policy. Trust policy applicability for a given artifact is determined by registryScopes. To create Notation trust policy: https://notaryproject.dev/docs/quickstart/#create-a-trust-policy"}) {
+	if !errors.Is(err, notation.ErrorNoApplicableTrustPolicy{Msg: "artifact \"non-existent-domain.com/repo@sha256:73c803930ea3ba1e54bc25c2bdc53edd0284c62ed651fe7b00369da519a3c333\" has no applicable trust policy. Trust policy applicability for a given artifact is determined by registryScopes. To create a trust policy, see: https://notaryproject.dev/docs/quickstart/#create-a-trust-policy"}) {
 		t.Fatalf("no applicable trust policy must throw error")
 	}
 }


### PR DESCRIPTION
In this PR:
1. According to issue #287, updated `Notary v2` to `Notation`.
2. Updated error messages of trust policy to improve user experience. Related issue: https://github.com/notaryproject/notation/issues/621

Resolves #287