### PR TITLE
fix: updated error message of errExceededMaxVerificationLimit

### DIFF
--- a/internal/mock/mocks.go
+++ b/internal/mock/mocks.go
@@ -110,6 +110,7 @@ type Repository struct {
 	ListSignaturesError        error
 	FetchSignatureBlobResponse []byte
 	FetchSignatureBlobError    error
+	ExceededNumOfSignatures    bool
 }
 
 func NewRepository() Repository {
@@ -125,6 +126,9 @@ func (t Repository) Resolve(ctx context.Context, reference string) (ocispec.Desc
 }
 
 func (t Repository) ListSignatures(ctx context.Context, desc ocispec.Descriptor, fn func(signatureManifests []ocispec.Descriptor) error) error {
+	if t.ExceededNumOfSignatures {
+		t.ListSignaturesResponse = []ocispec.Descriptor{SigManfiestDescriptor, SigManfiestDescriptor}
+	}
 	err := fn(t.ListSignaturesResponse)
 	if err != nil {
 		return err

--- a/notation.go
+++ b/notation.go
@@ -329,7 +329,7 @@ func Verify(ctx context.Context, verifier Verifier, repo registry.Repository, ve
 	}
 
 	var verificationOutcomes []*VerificationOutcome
-	errExceededMaxVerificationLimit := ErrorVerificationFailed{Msg: fmt.Sprintf("the number of signatures has surpassed the maximum limit of %d that can be evaluated", verifyOpts.MaxSignatureAttempts)}
+	errExceededMaxVerificationLimit := ErrorVerificationFailed{Msg: fmt.Sprintf("signature evaluation stopped. The configured limit of %d signatures to verify per artifact exceeded", verifyOpts.MaxSignatureAttempts)}
 	numOfSignatureProcessed := 0
 
 	var verificationFailedErr error = ErrorVerificationFailed{}

--- a/notation.go
+++ b/notation.go
@@ -327,7 +327,7 @@ func Verify(ctx context.Context, verifier Verifier, repo registry.Repository, ve
 	}
 
 	var verificationOutcomes []*VerificationOutcome
-	errExceededMaxVerificationLimit := ErrorVerificationFailed{Msg: fmt.Sprintf("total number of signatures associated with an artifact should be at most: %d", verifyOpts.MaxSignatureAttempts)}
+	errExceededMaxVerificationLimit := ErrorVerificationFailed{Msg: fmt.Sprintf("the number of signatures has surpassed the maximum limit of %d that can be evaluated", verifyOpts.MaxSignatureAttempts)}
 	numOfSignatureProcessed := 0
 
 	var verificationFailedErr error = ErrorVerificationFailed{}

--- a/notation_test.go
+++ b/notation_test.go
@@ -246,7 +246,7 @@ func TestExceededMaxSignatureAttempts(t *testing.T) {
 	repo := mock.NewRepository()
 	repo.ExceededNumOfSignatures = true
 	verifier := dummyVerifier{&policyDocument, mock.PluginManager{}, true, *trustpolicy.LevelStrict}
-	expectedErr := ErrorVerificationFailed{Msg: fmt.Sprintf("the number of signatures has surpassed the maximum limit of %d that can be evaluated", 1)}
+	expectedErr := ErrorVerificationFailed{Msg: fmt.Sprintf("signature evaluation stopped. The configured limit of %d signatures to verify per artifact exceeded", 1)}
 
 	// mock the repository
 	opts := VerifyOptions{ArtifactReference: mock.SampleArtifactUri, MaxSignatureAttempts: 1}

--- a/notation_test.go
+++ b/notation_test.go
@@ -224,6 +224,22 @@ func TestMaxSignatureAttemptsMissing(t *testing.T) {
 	}
 }
 
+func TestExceededMaxSignatureAttempts(t *testing.T) {
+	policyDocument := dummyPolicyDocument()
+	repo := mock.NewRepository()
+	repo.ExceededNumOfSignatures = true
+	verifier := dummyVerifier{&policyDocument, mock.PluginManager{}, true, *trustpolicy.LevelStrict}
+	expectedErr := ErrorVerificationFailed{Msg: fmt.Sprintf("the number of signatures has surpassed the maximum limit of %d that can be evaluated", 1)}
+
+	// mock the repository
+	opts := VerifyOptions{ArtifactReference: mock.SampleArtifactUri, MaxSignatureAttempts: 1}
+	_, _, err := Verify(context.Background(), &verifier, repo, opts)
+
+	if err == nil || !errors.Is(err, expectedErr) {
+		t.Fatalf("VerificationFailed expected: %v got: %v", expectedErr, err)
+	}
+}
+
 func TestVerifyFailed(t *testing.T) {
 	policyDocument := dummyPolicyDocument()
 	repo := mock.NewRepository()


### PR DESCRIPTION
This PR updates error message of `errExceededMaxVerificationLimit` to be more user friendly.