### PR TITLE
feat: add validations for symlink

### DIFF
--- a/config/base.go
+++ b/config/base.go
@@ -2,6 +2,8 @@ package config
 
 import (
 	"encoding/json"
+	"fmt"
+	"io/fs"
 	"os"
 	"path/filepath"
 
@@ -28,7 +30,22 @@ func save(filePath string, cfg interface{}) error {
 
 // load reads file, parses json and stores in cfg struct
 func load(filePath string, cfg interface{}) error {
-	file, err := dir.ConfigFS().Open(filePath)
+	path, err := dir.ConfigFS().SysPath(filePath)
+	if err != nil {
+		return err
+	}
+
+	// throw error if path is a directory or is a symlink or does not exist.
+	fileInfo, err := os.Lstat(path)
+	if err != nil {
+		return err
+	}
+	mode := fileInfo.Mode()
+	if mode.IsDir() || mode&fs.ModeSymlink != 0 {
+		return fmt.Errorf("%q is not a regular file (symlinks are not supported)", path)
+	}
+
+	file, err := os.Open(path)
 	if err != nil {
 		return err
 	}

--- a/config/base_test.go
+++ b/config/base_test.go
@@ -1,0 +1,34 @@
+package config
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/notaryproject/notation-go/dir"
+)
+
+func TestLoadNonExistentFile(t *testing.T) {
+	dir.UserConfigDir = "testdata/valid"
+
+	var config string
+	err := load("non-existent", &config)
+	if err == nil {
+		t.Fatalf("load() expected error but not found")
+	}
+}
+
+func TestLoadSymlink(t *testing.T) {
+	root := t.TempDir()
+	dir.UserConfigDir = root
+	fileName := "symlink"
+	os.Symlink("testdata/valid/config.json", filepath.Join(root, fileName))
+
+	expectedError := fmt.Sprintf("\"%s/%s\" is not a regular file (symlinks are not supported)", dir.UserConfigDir, fileName)
+	var config string
+	err := load(fileName, &config)
+	if err != nil && err.Error() != expectedError {
+		t.Fatalf("load() expected error= %s but found= %v", expectedError, err)
+	}
+}

--- a/verifier/trustpolicy/trustpolicy.go
+++ b/verifier/trustpolicy/trustpolicy.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -267,18 +268,34 @@ func (trustPolicyDoc *Document) GetApplicableTrustPolicy(artifactReference strin
 
 // LoadDocument loads a trust policy document from a local file system
 func LoadDocument() (*Document, error) {
-	jsonFile, err := dir.ConfigFS().Open(dir.PathTrustPolicy)
+	path, err := dir.ConfigFS().SysPath(dir.PathTrustPolicy)
 	if err != nil {
-		switch {
-		case errors.Is(err, os.ErrNotExist):
+		return nil, err
+	}
+
+	// throw error if path is a directory or a symlink or does not exist.
+	fileInfo, err := os.Lstat(path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
 			return nil, fmt.Errorf("trust policy is not present. To create a trust policy, see: %s", trustPolicyLink)
-		case errors.Is(err, os.ErrPermission):
-			return nil, fmt.Errorf("unable to read trust policy due to file permissions, please verify the permissions of %s", filepath.Join(dir.UserConfigDir, dir.PathTrustPolicy))
-		default:
-			return nil, err
 		}
+		return nil, err
+	}
+
+	mode := fileInfo.Mode()
+	if mode.IsDir() || mode&fs.ModeSymlink != 0 {
+		return nil, fmt.Errorf("trust policy is not a regular file (symlinks are not supported). To create a trust policy, see: %s", trustPolicyLink)
+	}
+
+	jsonFile, err := os.Open(path)
+	if err != nil {
+		if errors.Is(err, os.ErrPermission) {
+			return nil, fmt.Errorf("unable to read trust policy due to file permissions, please verify the permissions of %s", filepath.Join(dir.UserConfigDir, dir.PathTrustPolicy))
+		}
+		return nil, err
 	}
 	defer jsonFile.Close()
+
 	policyDocument := &Document{}
 	err = json.NewDecoder(jsonFile).Decode(policyDocument)
 	if err != nil {


### PR DESCRIPTION
Added validations to make sure singingkeys.json, trustpolicy.json and config.json doesnt read's symlink

closes https://github.com/notaryproject/notation/issues/634