### PR TITLE
fix: quick fix to use correct sign/verify plugin

### DIFF
--- a/signer/plugin.go
+++ b/signer/plugin.go
@@ -43,7 +43,7 @@ type pluginSigner struct {
 // NewFromPlugin creates a notation.Signer that signs artifacts and generates
 // signatures by delegating the one or more operations to the named plugin,
 // as defined in https://github.com/notaryproject/notaryproject/blob/main/specs/plugin-extensibility.md#signing-interfaces.
-func NewFromPlugin(plugin plugin.Plugin, keyID string, pluginConfig map[string]string) (notation.Signer, error) {
+func NewFromPlugin(plugin plugin.SignPlugin, keyID string, pluginConfig map[string]string) (notation.Signer, error) {
 	if plugin == nil {
 		return nil, errors.New("nil plugin")
 	}

--- a/verifier/verifier.go
+++ b/verifier/verifier.go
@@ -205,7 +205,7 @@ func (v *verifier) processSignature(ctx context.Context, sigBlob []byte, envelop
 		return err
 	}
 
-	var installedPlugin plugin.Plugin
+	var installedPlugin plugin.VerifyPlugin
 	if verificationPluginName != "" {
 		logger.Debugf("Finding verification plugin %s", verificationPluginName)
 		verificationPluginMinVersion, err := getVerificationPluginMinVersion(&outcome.EnvelopeContent.SignerInfo)
@@ -633,7 +633,7 @@ func verifyRevocation(outcome *notation.VerificationOutcome, r revocation.Revoca
 	return result
 }
 
-func executePlugin(ctx context.Context, installedPlugin plugin.Plugin, trustPolicy *trustpolicy.TrustPolicy, capabilitiesToVerify []proto.Capability, envelopeContent *signature.EnvelopeContent, pluginConfig map[string]string) (*proto.VerifySignatureResponse, error) {
+func executePlugin(ctx context.Context, installedPlugin plugin.VerifyPlugin, trustPolicy *trustpolicy.TrustPolicy, capabilitiesToVerify []proto.Capability, envelopeContent *signature.EnvelopeContent, pluginConfig map[string]string) (*proto.VerifySignatureResponse, error) {
 	logger := log.GetLogger(ctx)
 	// sanity check
 	if installedPlugin == nil {


### PR DESCRIPTION
Changes in this PR:
1. `signer.NewFromPlugin(plugin plugin.SignPlugin, ...)`
2. `verifer.executePlugin(ctx context.Context, installedPlugin plugin.VerifyPlugin, ...)`