### PR TITLE
bump: update oras-go to v2.3.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/veraison/go-cose v1.1.0
 	golang.org/x/crypto v0.12.0
 	golang.org/x/mod v0.12.0
-	oras.land/oras-go/v2 v2.2.1
+	oras.land/oras-go/v2 v2.3.0
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -75,5 +75,5 @@ gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
-oras.land/oras-go/v2 v2.2.1 h1:3VJTYqy5KfelEF9c2jo1MLSpr+TM3mX8K42wzZcd6qE=
-oras.land/oras-go/v2 v2.2.1/go.mod h1:GeAwLuC4G/JpNwkd+bSZ6SkDMGaaYglt6YK2WvZP7uQ=
+oras.land/oras-go/v2 v2.3.0 h1:lqX1aXdN+DAmDTKjiDyvq85cIaI4RkIKp/PghWlAGIU=
+oras.land/oras-go/v2 v2.3.0/go.mod h1:GeAwLuC4G/JpNwkd+bSZ6SkDMGaaYglt6YK2WvZP7uQ=

--- a/registry/repository.go
+++ b/registry/repository.go
@@ -220,6 +220,8 @@ func (c *repositoryClient) uploadSignatureManifest(ctx context.Context, subject,
 
 // pushNotationManifestConfig pushes an empty notation manifest config, if it
 // doesn't exist.
+//
+// if the config exists, it returns the descriptor of the config without error.
 func pushNotationManifestConfig(ctx context.Context, pusher content.Storage) (ocispec.Descriptor, error) {
 	// check if the config exists
 	exists, err := pusher.Exists(ctx, notationEmptyConfigDesc)
@@ -230,7 +232,7 @@ func pushNotationManifestConfig(ctx context.Context, pusher content.Storage) (oc
 		return notationEmptyConfigDesc, nil
 	}
 
-	// push the config
+	// return nil if the config pushed successfully or it already exists
 	if err := pusher.Push(ctx, notationEmptyConfigDesc, bytes.NewReader(notationEmptyConfigData)); err != nil && !errors.Is(err, errdef.ErrAlreadyExists) {
 		return ocispec.Descriptor{}, fmt.Errorf("unable to push: %s: %s. Details: %w", notationEmptyConfigDesc.Digest.String(), notationEmptyConfigDesc.MediaType, err)
 	}

--- a/registry/repository.go
+++ b/registry/repository.go
@@ -208,8 +208,11 @@ func (c *repositoryClient) uploadSignatureManifest(ctx context.Context, subject,
 // pushNotationManifestConfig pushes an empty notation manifest config, if it
 // doesn't exist.
 func pushNotationManifestConfig(ctx context.Context, pusher content.Pusher) (*ocispec.Descriptor, error) {
+	// generate a empty config descriptor for notation manifest
 	configContent := []byte("{}")
 	desc := content.NewDescriptorFromBytes(ArtifactTypeNotation, configContent)
+
+	// check if the config exists
 	if ros, ok := pusher.(content.ReadOnlyStorage); ok {
 		exists, err := ros.Exists(ctx, desc)
 		if err != nil {
@@ -220,6 +223,7 @@ func pushNotationManifestConfig(ctx context.Context, pusher content.Pusher) (*oc
 		}
 	}
 
+	// push the config
 	if err := pusher.Push(ctx, desc, bytes.NewReader(configContent)); err != nil && !errors.Is(err, errdef.ErrAlreadyExists) {
 		return nil, fmt.Errorf("failed to push: %s: %s: %w", desc.Digest.String(), desc.MediaType, err)
 	}

--- a/registry/repository_test.go
+++ b/registry/repository_test.go
@@ -38,6 +38,7 @@ import (
 
 const (
 	zeroDigest               = "sha256:0000000000000000000000000000000000000000000000000000000000000000"
+	emptyConfigDigest        = "sha256:44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a"
 	validDigest              = "6c3c624b58dbbcd3c0dd82b4c53f04194d1247c6eebdaab7c610cf7d66709b3b"
 	validDigest2             = "1834876dcfb05cb167a5c24953eba58c4ac89b1adf57f28f2f9d09af107ee8f2"
 	invalidDigest            = "invaliddigest"
@@ -128,6 +129,11 @@ func (c mockRemoteClient) Do(req *http.Request) (*http.Response, error) {
 				"Content-Type":          {joseTag},
 				"Docker-Content-Digest": {validDigestWithAlgo2},
 			},
+		}, nil
+	case "/v2/test/blobs/" + emptyConfigDigest:
+		return &http.Response{
+			StatusCode: http.StatusNotFound,
+			Body:       io.NopCloser(bytes.NewReader([]byte{})),
 		}, nil
 	case "/v2/test/manifests/" + invalidDigest:
 		return &http.Response{}, fmt.Errorf(errMsg)


### PR DESCRIPTION
- Update oras-go to v2.3.0.
- Replace oras.Pack() with oras.PackManifest() as it is deprecated in v2.3.0.
- Generate an empty config blob manually, as oras.PackManifest() does not generate the config blob with the notation artifact type as the media type.

Resolves #346 
Signed-off-by: Junjie Gao <junjiegao@microsoft.com>