### PR TITLE
feat: add install method to plugin CLIManager

### DIFF
--- a/internal/file/file.go
+++ b/internal/file/file.go
@@ -28,36 +28,37 @@ func IsValidFileName(fileName string) bool {
 }
 
 // CopyToDir copies the src file to dst. Existing file will be overwritten.
-func CopyToDir(src, dst string) (int64, error) {
+func CopyToDir(src, dst string) error {
 	sourceFileStat, err := os.Stat(src)
 	if err != nil {
-		return 0, err
+		return err
 	}
 
 	if !sourceFileStat.Mode().IsRegular() {
-		return 0, fmt.Errorf("%s is not a regular file", src)
+		return fmt.Errorf("%s is not a regular file", src)
 	}
 
 	source, err := os.Open(src)
 	if err != nil {
-		return 0, err
+		return err
 	}
 	defer source.Close()
 
 	if err := os.MkdirAll(dst, 0700); err != nil {
-		return 0, err
+		return err
 	}
 	dstFile := filepath.Join(dst, filepath.Base(src))
 	destination, err := os.Create(dstFile)
 	if err != nil {
-		return 0, err
+		return err
 	}
 	defer destination.Close()
 	err = destination.Chmod(0600)
 	if err != nil {
-		return 0, err
+		return err
 	}
-	return io.Copy(destination, source)
+	_, err = io.Copy(destination, source)
+	return err
 }
 
 // FileNameWithoutExtension returns the file name without extension.

--- a/internal/file/file.go
+++ b/internal/file/file.go
@@ -34,24 +34,22 @@ func IsValidFileName(fileName string) bool {
 	return regexp.MustCompile(`^[a-zA-Z0-9_.-]+$`).MatchString(fileName)
 }
 
-// CopyToDir copies the src file to dst. Existing file will be overwritten.
+// CopyToDir copies the src file to dst dir. Existing file will be overwritten.
+// src file permission is preserved.
 func CopyToDir(src, dst string) error {
 	sourceFileStat, err := os.Stat(src)
 	if err != nil {
 		return err
 	}
-
 	if !sourceFileStat.Mode().IsRegular() {
 		return ErrNotRegularFile
 	}
-
 	source, err := os.Open(src)
 	if err != nil {
 		return err
 	}
 	defer source.Close()
-
-	if err := os.MkdirAll(dst, 0700); err != nil {
+	if err := os.MkdirAll(dst, 0777); err != nil {
 		return err
 	}
 	dstFile := filepath.Join(dst, filepath.Base(src))
@@ -60,7 +58,7 @@ func CopyToDir(src, dst string) error {
 		return err
 	}
 	defer destination.Close()
-	err = destination.Chmod(0600)
+	err = destination.Chmod(sourceFileStat.Mode())
 	if err != nil {
 		return err
 	}

--- a/internal/file/file.go
+++ b/internal/file/file.go
@@ -61,8 +61,11 @@ func CopyToDir(src, dst string) (int64, error) {
 }
 
 // FileNameWithoutExtension returns the file name without extension.
+//
 // For example,
+//
 // when input is xyz.exe, output is xyz
+//
 // when input is xyz.tar.gz, output is xyz.tar
 func FileNameWithoutExtension(fileName string) string {
 	return strings.TrimSuffix(fileName, filepath.Ext(fileName))

--- a/internal/file/file.go
+++ b/internal/file/file.go
@@ -61,13 +61,13 @@ func CopyToDir(src, dst string) error {
 	return err
 }
 
-// FileNameWithoutExtension returns the file name without extension.
+// TrimFileExtension returns the file name without extension.
 //
 // For example,
 //
 // when input is xyz.exe, output is xyz
 //
 // when input is xyz.tar.gz, output is xyz.tar
-func FileNameWithoutExtension(fileName string) string {
+func TrimFileExtension(fileName string) string {
 	return strings.TrimSuffix(fileName, filepath.Ext(fileName))
 }

--- a/internal/file/file_test.go
+++ b/internal/file/file_test.go
@@ -31,7 +31,7 @@ func TestCopyToDir(t *testing.T) {
 		}
 
 		destDir := filepath.Join(tempDir, "b")
-		if _, err := CopyToDir(filename, destDir); err != nil {
+		if err := CopyToDir(filename, destDir); err != nil {
 			t.Fatal(err)
 		}
 	})
@@ -54,7 +54,7 @@ func TestCopyToDir(t *testing.T) {
 		}
 		defer os.Chmod(tempDir, 0700)
 
-		if _, err := CopyToDir(filename, destDir); err == nil {
+		if err := CopyToDir(filename, destDir); err == nil {
 			t.Fatal("should have error")
 		}
 	})
@@ -62,7 +62,7 @@ func TestCopyToDir(t *testing.T) {
 	t.Run("not a regular file", func(t *testing.T) {
 		tempDir := t.TempDir()
 		destDir := t.TempDir()
-		if _, err := CopyToDir(tempDir, destDir); err == nil {
+		if err := CopyToDir(tempDir, destDir); err == nil {
 			t.Fatal("should have error")
 		}
 	})
@@ -85,7 +85,7 @@ func TestCopyToDir(t *testing.T) {
 			t.Fatal(err)
 		}
 		defer os.Chmod(filename, 0600)
-		if _, err := CopyToDir(filename, destDir); err == nil {
+		if err := CopyToDir(filename, destDir); err == nil {
 			t.Fatal("should have error")
 		}
 	})
@@ -108,7 +108,7 @@ func TestCopyToDir(t *testing.T) {
 			t.Fatal(err)
 		}
 		defer os.Chmod(destTempDir, 0700)
-		if _, err := CopyToDir(filename, filepath.Join(destTempDir, "a")); err == nil {
+		if err := CopyToDir(filename, filepath.Join(destTempDir, "a")); err == nil {
 			t.Fatal("should have error")
 		}
 	})
@@ -131,7 +131,7 @@ func TestCopyToDir(t *testing.T) {
 			t.Fatal(err)
 		}
 		defer os.Chmod(destTempDir, 0700)
-		if _, err := CopyToDir(filename, destTempDir); err == nil {
+		if err := CopyToDir(filename, destTempDir); err == nil {
 			t.Fatal("should have error")
 		}
 	})
@@ -145,7 +145,7 @@ func TestCopyToDir(t *testing.T) {
 		}
 
 		destDir := filepath.Join(tempDir, "b")
-		if _, err := CopyToDir(filename, destDir); err != nil {
+		if err := CopyToDir(filename, destDir); err != nil {
 			t.Fatal(err)
 		}
 		validFileContent(t, filepath.Join(destDir, "file.txt"), data)

--- a/internal/file/file_test.go
+++ b/internal/file/file_test.go
@@ -1,0 +1,179 @@
+// Copyright The Notary Project Authors.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package file
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+func TestCopyToDir(t *testing.T) {
+	t.Run("copy file", func(t *testing.T) {
+		tempDir := t.TempDir()
+		data := []byte("data")
+		filename := filepath.Join(tempDir, "a", "file.txt")
+		if err := writeFile(filename, data); err != nil {
+			t.Fatal(err)
+		}
+
+		destDir := filepath.Join(tempDir, "b")
+		if _, err := CopyToDir(filename, destDir); err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	t.Run("source directory permission error", func(t *testing.T) {
+		if runtime.GOOS == "windows" {
+			t.Skip("skipping test on Windows")
+		}
+
+		tempDir := t.TempDir()
+		destDir := t.TempDir()
+		data := []byte("data")
+		filename := filepath.Join(tempDir, "a", "file.txt")
+		if err := writeFile(filename, data); err != nil {
+			t.Fatal(err)
+		}
+
+		if err := os.Chmod(tempDir, 0000); err != nil {
+			t.Fatal(err)
+		}
+		defer os.Chmod(tempDir, 0700)
+
+		if _, err := CopyToDir(filename, destDir); err == nil {
+			t.Fatal("should have error")
+		}
+	})
+
+	t.Run("not a regular file", func(t *testing.T) {
+		tempDir := t.TempDir()
+		destDir := t.TempDir()
+		if _, err := CopyToDir(tempDir, destDir); err == nil {
+			t.Fatal("should have error")
+		}
+	})
+
+	t.Run("source file permission error", func(t *testing.T) {
+		if runtime.GOOS == "windows" {
+			t.Skip("skipping test on Windows")
+		}
+
+		tempDir := t.TempDir()
+		destDir := t.TempDir()
+		data := []byte("data")
+		// prepare file
+		filename := filepath.Join(tempDir, "a", "file.txt")
+		if err := writeFile(filename, data); err != nil {
+			t.Fatal(err)
+		}
+		// forbid reading
+		if err := os.Chmod(filename, 0000); err != nil {
+			t.Fatal(err)
+		}
+		defer os.Chmod(filename, 0600)
+		if _, err := CopyToDir(filename, destDir); err == nil {
+			t.Fatal("should have error")
+		}
+	})
+
+	t.Run("dest directory permission error", func(t *testing.T) {
+		if runtime.GOOS == "windows" {
+			t.Skip("skipping test on Windows")
+		}
+
+		tempDir := t.TempDir()
+		destTempDir := t.TempDir()
+		data := []byte("data")
+		// prepare file
+		filename := filepath.Join(tempDir, "a", "file.txt")
+		if err := writeFile(filename, data); err != nil {
+			t.Fatal(err)
+		}
+		// forbid dest directory operation
+		if err := os.Chmod(destTempDir, 0000); err != nil {
+			t.Fatal(err)
+		}
+		defer os.Chmod(destTempDir, 0700)
+		if _, err := CopyToDir(filename, filepath.Join(destTempDir, "a")); err == nil {
+			t.Fatal("should have error")
+		}
+	})
+
+	t.Run("dest directory permission error 2", func(t *testing.T) {
+		if runtime.GOOS == "windows" {
+			t.Skip("skipping test on Windows")
+		}
+
+		tempDir := t.TempDir()
+		destTempDir := t.TempDir()
+		data := []byte("data")
+		// prepare file
+		filename := filepath.Join(tempDir, "a", "file.txt")
+		if err := writeFile(filename, data); err != nil {
+			t.Fatal(err)
+		}
+		// forbid writing to destTempDir
+		if err := os.Chmod(destTempDir, 0000); err != nil {
+			t.Fatal(err)
+		}
+		defer os.Chmod(destTempDir, 0700)
+		if _, err := CopyToDir(filename, destTempDir); err == nil {
+			t.Fatal("should have error")
+		}
+	})
+
+	t.Run("copy file and check content", func(t *testing.T) {
+		tempDir := t.TempDir()
+		data := []byte("data")
+		filename := filepath.Join(tempDir, "a", "file.txt")
+		if err := writeFile(filename, data); err != nil {
+			t.Fatal(err)
+		}
+
+		destDir := filepath.Join(tempDir, "b")
+		if _, err := CopyToDir(filename, destDir); err != nil {
+			t.Fatal(err)
+		}
+		validFileContent(t, filepath.Join(destDir, "file.txt"), data)
+	})
+}
+
+func TestFileNameWithoutExtension(t *testing.T) {
+	input := "testfile.tar.gz"
+	expectedOutput := "testfile.tar"
+	actualOutput := FileNameWithoutExtension(input)
+	if actualOutput != expectedOutput {
+		t.Errorf("expected '%s', but got '%s'", expectedOutput, actualOutput)
+	}
+}
+
+func validFileContent(t *testing.T, filename string, content []byte) {
+	b, err := os.ReadFile(filename)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(content, b) {
+		t.Fatal("file content is not correct")
+	}
+}
+
+func writeFile(path string, data []byte) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0700); err != nil {
+		return err
+	}
+	return os.WriteFile(path, data, 0600)
+}

--- a/internal/file/file_test.go
+++ b/internal/file/file_test.go
@@ -155,7 +155,7 @@ func TestCopyToDir(t *testing.T) {
 func TestFileNameWithoutExtension(t *testing.T) {
 	input := "testfile.tar.gz"
 	expectedOutput := "testfile.tar"
-	actualOutput := FileNameWithoutExtension(input)
+	actualOutput := TrimFileExtension(input)
 	if actualOutput != expectedOutput {
 		t.Errorf("expected '%s', but got '%s'", expectedOutput, actualOutput)
 	}

--- a/internal/semver/semver.go
+++ b/internal/semver/semver.go
@@ -11,6 +11,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// Package semver provides functions related to semanic version.
+// This package is based on "golang.org/x/mod/semver"
 package semver
 
 import (

--- a/internal/semver/semver.go
+++ b/internal/semver/semver.go
@@ -17,17 +17,19 @@ package semver
 
 import (
 	"fmt"
-	"regexp"
+	"strings"
 
 	"golang.org/x/mod/semver"
 )
 
-// SemVerRegEx is takenfrom https://semver.org/#is-there-a-suggested-regular-expression-regex-to-check-a-semver-string
-var SemVerRegEx = regexp.MustCompile(`^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$`)
-
-// IsVersionSemverValid returns true if version is a valid semantic version
-func IsVersionSemverValid(version string) bool {
-	return SemVerRegEx.MatchString(version)
+// IsSemverValid returns true if version is a valid semantic version
+func IsSemverValid(version string) bool {
+	// a valid semanic version MUST not have prefix 'v'
+	if strings.HasPrefix(version, "v") {
+		return false
+	}
+	// golang package "golang.org/x/mod/semver" requires prefix 'v'
+	return semver.IsValid("v" + version)
 }
 
 // ComparePluginVersion validates and compares two plugin semantic versions.
@@ -37,10 +39,10 @@ func ComparePluginVersion(v, w string) (int, error) {
 	// sanity check
 	// a valid semantic version should not have prefix `v`
 	// Reference: https://semver.org/#semantic-versioning-200
-	if !IsVersionSemverValid(v) {
+	if !IsSemverValid(v) {
 		return 0, fmt.Errorf("%s is not a valid semantic version", v)
 	}
-	if !IsVersionSemverValid(w) {
+	if !IsSemverValid(w) {
 		return 0, fmt.Errorf("%s is not a valid semantic version", w)
 	}
 

--- a/internal/semver/semver.go
+++ b/internal/semver/semver.go
@@ -1,0 +1,44 @@
+// Copyright The Notary Project Authors.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package semver
+
+import (
+	"fmt"
+	"strings"
+
+	"golang.org/x/mod/semver"
+)
+
+// ComparePluginVersion validates and compares two plugin semantic versions.
+//
+// The result will be 0 if v == w, -1 if v < w, or +1 if v > w.
+func ComparePluginVersion(v, w string) (int, error) {
+	// golang.org/x/mod/semver requires semantic version strings must begin
+	// with a leading "v". Adding prefix "v" in case the input plugin version
+	// does not have it.
+	// Reference: https://pkg.go.dev/golang.org/x/mod/semver#pkg-overview
+	if !strings.HasPrefix(v, "v") {
+		v = "v" + v
+	}
+	if !semver.IsValid(v) {
+		return 0, fmt.Errorf("%s is not a valid semantic version", v)
+	}
+	if !strings.HasPrefix(w, "v") {
+		w = "v" + w
+	}
+	if !semver.IsValid(w) {
+		return 0, fmt.Errorf("%s is not a valid semantic version", w)
+	}
+	return semver.Compare(v, w), nil
+}

--- a/internal/semver/semver.go
+++ b/internal/semver/semver.go
@@ -22,11 +22,11 @@ import (
 	"golang.org/x/mod/semver"
 )
 
-// semVerRegEx is takenfrom https://semver.org/#is-there-a-suggested-regular-expression-regex-to-check-a-semver-string
+// semVerRegEx is taken from https://semver.org/#is-there-a-suggested-regular-expression-regex-to-check-a-semver-string
 var semVerRegEx = regexp.MustCompile(`^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$`)
 
-// IsValidSemver returns true if version is a valid semantic version
-func IsValidSemver(version string) bool {
+// IsValid returns true if version is a valid semantic version
+func IsValid(version string) bool {
 	return semVerRegEx.MatchString(version)
 }
 
@@ -35,10 +35,10 @@ func IsValidSemver(version string) bool {
 // The result will be 0 if v == w, -1 if v < w, or +1 if v > w.
 func ComparePluginVersion(v, w string) (int, error) {
 	// sanity check
-	if !IsValidSemver(v) {
+	if !IsValid(v) {
 		return 0, fmt.Errorf("%s is not a valid semantic version", v)
 	}
-	if !IsValidSemver(w) {
+	if !IsValid(w) {
 		return 0, fmt.Errorf("%s is not a valid semantic version", w)
 	}
 

--- a/internal/semver/semver.go
+++ b/internal/semver/semver.go
@@ -17,19 +17,17 @@ package semver
 
 import (
 	"fmt"
-	"strings"
+	"regexp"
 
 	"golang.org/x/mod/semver"
 )
 
-// IsSemverValid returns true if version is a valid semantic version
-func IsSemverValid(version string) bool {
-	// a valid semanic version MUST not have prefix 'v'
-	if strings.HasPrefix(version, "v") {
-		return false
-	}
-	// golang package "golang.org/x/mod/semver" requires prefix 'v'
-	return semver.IsValid("v" + version)
+// semVerRegEx is takenfrom https://semver.org/#is-there-a-suggested-regular-expression-regex-to-check-a-semver-string
+var semVerRegEx = regexp.MustCompile(`^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$`)
+
+// IsValidSemver returns true if version is a valid semantic version
+func IsValidSemver(version string) bool {
+	return semVerRegEx.MatchString(version)
 }
 
 // ComparePluginVersion validates and compares two plugin semantic versions.
@@ -37,12 +35,10 @@ func IsSemverValid(version string) bool {
 // The result will be 0 if v == w, -1 if v < w, or +1 if v > w.
 func ComparePluginVersion(v, w string) (int, error) {
 	// sanity check
-	// a valid semantic version should not have prefix `v`
-	// Reference: https://semver.org/#semantic-versioning-200
-	if !IsSemverValid(v) {
+	if !IsValidSemver(v) {
 		return 0, fmt.Errorf("%s is not a valid semantic version", v)
 	}
-	if !IsSemverValid(w) {
+	if !IsValidSemver(w) {
 		return 0, fmt.Errorf("%s is not a valid semantic version", w)
 	}
 

--- a/internal/semver/semver_test.go
+++ b/internal/semver/semver_test.go
@@ -1,0 +1,39 @@
+// Copyright The Notary Project Authors.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package semver
+
+import "testing"
+
+func TestComparePluginVersion(t *testing.T) {
+	comp, err := ComparePluginVersion("v1.0.0", "v1.0.1")
+	if err != nil || comp >= 0 {
+		t.Fatal("expected nil err and negative comp")
+	}
+
+	comp, err = ComparePluginVersion("1.0.0", "1.0.1")
+	if err != nil || comp >= 0 {
+		t.Fatal("expected nil err and negative comp")
+	}
+
+	comp, err = ComparePluginVersion("1.0.1", "1.0.1")
+	if err != nil || comp != 0 {
+		t.Fatal("expected nil err and comp equal to 0")
+	}
+
+	expectedErrMsg := "vabc is not a valid semantic version"
+	_, err = ComparePluginVersion("abc", "1.0.1")
+	if err == nil || err.Error() != expectedErrMsg {
+		t.Fatalf("expected err %s, got %s", expectedErrMsg, err)
+	}
+}

--- a/internal/semver/semver_test.go
+++ b/internal/semver/semver_test.go
@@ -16,24 +16,25 @@ package semver
 import "testing"
 
 func TestComparePluginVersion(t *testing.T) {
-	comp, err := ComparePluginVersion("v1.0.0", "v1.0.1")
-	if err != nil || comp >= 0 {
-		t.Fatal("expected nil err and negative comp")
-	}
+	t.Run("compare with lower version", func(t *testing.T) {
+		comp, err := ComparePluginVersion("1.0.0", "1.0.1")
+		if err != nil || comp >= 0 {
+			t.Fatal("expected nil err and negative comp")
+		}
+	})
 
-	comp, err = ComparePluginVersion("1.0.0", "1.0.1")
-	if err != nil || comp >= 0 {
-		t.Fatal("expected nil err and negative comp")
-	}
+	t.Run("compare with equal version", func(t *testing.T) {
+		comp, err := ComparePluginVersion("1.0.1", "1.0.1")
+		if err != nil || comp != 0 {
+			t.Fatal("expected nil err and comp equal to 0")
+		}
+	})
 
-	comp, err = ComparePluginVersion("1.0.1", "1.0.1")
-	if err != nil || comp != 0 {
-		t.Fatal("expected nil err and comp equal to 0")
-	}
-
-	expectedErrMsg := "vabc is not a valid semantic version"
-	_, err = ComparePluginVersion("abc", "1.0.1")
-	if err == nil || err.Error() != expectedErrMsg {
-		t.Fatalf("expected err %s, got %s", expectedErrMsg, err)
-	}
+	t.Run("failed due to invalid semantic version", func(t *testing.T) {
+		expectedErrMsg := "v1.0.0 is not a valid semantic version"
+		_, err := ComparePluginVersion("v1.0.0", "1.0.1")
+		if err == nil || err.Error() != expectedErrMsg {
+			t.Fatalf("expected err %s, but got %s", expectedErrMsg, err)
+		}
+	})
 }

--- a/plugin/errors.go
+++ b/plugin/errors.go
@@ -1,0 +1,49 @@
+// Copyright The Notary Project Authors.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package plugin
+
+import "errors"
+
+// ErrNotCompliant is returned by plugin methods when the response is not
+// compliant.
+var ErrNotCompliant = errors.New("plugin not compliant")
+
+// ErrNotRegularFile is returned when the plugin file is not an regular file.
+var ErrNotRegularFile = errors.New("not regular file")
+
+// ErrInstallLowerVersion is returned when installing a plugin with version
+// lower than the exisiting plugin version.
+type ErrInstallLowerVersion struct {
+	Msg string
+}
+
+func (e ErrInstallLowerVersion) Error() string {
+	if e.Msg != "" {
+		return e.Msg
+	}
+	return "installing plugin with version lower than the existing plugin version"
+}
+
+// ErrInstallEqualVersion is returned when installing a plugin with version
+// equal to the exisiting plugin version.
+type ErrInstallEqualVersion struct {
+	Msg string
+}
+
+func (e ErrInstallEqualVersion) Error() string {
+	if e.Msg != "" {
+		return e.Msg
+	}
+	return "installing plugin with version equal to the existing plugin version"
+}

--- a/plugin/errors.go
+++ b/plugin/errors.go
@@ -22,13 +22,13 @@ var ErrNotCompliant = errors.New("plugin not compliant")
 // ErrNotRegularFile is returned when the plugin file is not an regular file.
 var ErrNotRegularFile = errors.New("not regular file")
 
-// ErrInstallLowerVersion is returned when installing a plugin with version
+// ErrPluginDowngrade is returned when installing a plugin with version
 // lower than the exisiting plugin version.
-type ErrInstallLowerVersion struct {
+type ErrPluginDowngrade struct {
 	Msg string
 }
 
-func (e ErrInstallLowerVersion) Error() string {
+func (e ErrPluginDowngrade) Error() string {
 	if e.Msg != "" {
 		return e.Msg
 	}

--- a/plugin/errors.go
+++ b/plugin/errors.go
@@ -22,26 +22,26 @@ var ErrNotCompliant = errors.New("plugin not compliant")
 // ErrNotRegularFile is returned when the plugin file is not an regular file.
 var ErrNotRegularFile = errors.New("not regular file")
 
-// ErrPluginDowngrade is returned when installing a plugin with version
+// PluginDowngradeError is returned when installing a plugin with version
 // lower than the exisiting plugin version.
-type ErrPluginDowngrade struct {
+type PluginDowngradeError struct {
 	Msg string
 }
 
-func (e ErrPluginDowngrade) Error() string {
+func (e PluginDowngradeError) Error() string {
 	if e.Msg != "" {
 		return e.Msg
 	}
 	return "installing plugin with version lower than the existing plugin version"
 }
 
-// ErrInstallEqualVersion is returned when installing a plugin with version
+// InstallEqualVersionError is returned when installing a plugin with version
 // equal to the exisiting plugin version.
-type ErrInstallEqualVersion struct {
+type InstallEqualVersionError struct {
 	Msg string
 }
 
-func (e ErrInstallEqualVersion) Error() string {
+func (e InstallEqualVersionError) Error() string {
 	if e.Msg != "" {
 		return e.Msg
 	}

--- a/plugin/manager.go
+++ b/plugin/manager.go
@@ -172,7 +172,7 @@ func (m *CLIManager) Install(ctx context.Context, installOpts CLIInstallOptions)
 			}
 			switch {
 			case comp < 0:
-				return nil, nil, PluginDowngradeError{Msg: fmt.Sprintf("the installing plugin version %s is lower than the existing plugin version %s", newPluginMetadata.Version, existingPluginMetadata.Version)}
+				return nil, nil, PluginDowngradeError{Msg: fmt.Sprintf("failed to install plugin %s. The installing plugin version %s is lower than the existing plugin version %s", pluginName, newPluginMetadata.Version, existingPluginMetadata.Version)}
 			case comp == 0:
 				return nil, nil, InstallEqualVersionError{Msg: fmt.Sprintf("plugin %s with version %s already exists", pluginName, existingPluginMetadata.Version)}
 			}

--- a/plugin/manager.go
+++ b/plugin/manager.go
@@ -249,7 +249,7 @@ func parsePluginFromDir(path string) (string, string, error) {
 			}
 			if isExec {
 				if foundPluginExecutableFile {
-					return fmt.Errorf("found more than one plugin executable files under %s", path)
+					return errors.New("found more than one plugin executable files")
 				}
 				foundPluginExecutableFile = true
 				pluginExecutableFile = p
@@ -260,7 +260,7 @@ func parsePluginFromDir(path string) (string, string, error) {
 		return "", "", err
 	}
 	if !foundPluginExecutableFile {
-		return "", "", fmt.Errorf("no plugin executable file was found under %s", path)
+		return "", "", errors.New("no plugin executable file was found")
 	}
 	return pluginExecutableFile, pluginName, nil
 }

--- a/plugin/manager.go
+++ b/plugin/manager.go
@@ -97,8 +97,10 @@ func (m *CLIManager) List(ctx context.Context) ([]string, error) {
 	return plugins, nil
 }
 
-// Install installs a plugin at filePath to the system,
-// err == nil if and only if the installation succeeded.
+// Install installs a plugin at filePath to the system.
+//
+// It returns the new plugin metadata and a nil eror if and only if
+// the installation succeeded.
 //
 // If plugin already exists, and overwrite is not set, then the new plugin
 // version MUST be higher than the existing plugin version.

--- a/plugin/manager.go
+++ b/plugin/manager.go
@@ -87,7 +87,6 @@ func (m *CLIManager) List(ctx context.Context) ([]string, error) {
 // the installation succeeded.
 //
 // If plugin does not exist, directly install from filePath.
-// On success, the new plugin metadata is returned.
 //
 // If plugin already exists:
 //

--- a/plugin/manager.go
+++ b/plugin/manager.go
@@ -115,6 +115,9 @@ func (m *CLIManager) Install(ctx context.Context, filePath string, overwrite boo
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to get plugin name from file path: %w", err)
 	}
+	if err := validatePluginFileExtensionAgainstOS(filePath, pluginName); err != nil {
+		return nil, nil, err
+	}
 	newPlugin, err := NewCLIPlugin(ctx, pluginName, filePath)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to create new CLI plugin: %w", err)

--- a/plugin/manager.go
+++ b/plugin/manager.go
@@ -138,7 +138,7 @@ func (m *CLIManager) Install(ctx context.Context, installOpts CLIInstallOptions)
 			return nil, nil, fmt.Errorf("failed to check if file %s is executable: %w", pluginExecutableFile, err)
 		}
 		if !isExec {
-			return nil, nil, fmt.Errorf("file %s is not executable: %w", pluginExecutableFile, err)
+			return nil, nil, fmt.Errorf("file %s is not executable", pluginExecutableFile)
 		}
 	}
 	// validate and get new plugin metadata

--- a/plugin/manager.go
+++ b/plugin/manager.go
@@ -96,11 +96,12 @@ func (m *CLIManager) List(ctx context.Context) ([]string, error) {
 // On success, the new plugin metadata is returned.
 func (m *CLIManager) Install(ctx context.Context, filePath string, overwrite bool) (*proto.GetMetadataResponse, *proto.GetMetadataResponse, error) {
 	// validate and get new plugin metadata
-	pluginName, err := ExtractPluginNameFromFileName(filepath.Base(filePath))
+	pluginFile := filepath.Base(filePath)
+	pluginName, err := ExtractPluginNameFromFileName(pluginFile)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to get plugin name from file path: %w", err)
 	}
-	if err := validatePluginFileExtensionAgainstOS(filePath, pluginName); err != nil {
+	if err := validatePluginFileExtensionAgainstOS(pluginFile, pluginName); err != nil {
 		return nil, nil, err
 	}
 	newPlugin, err := NewCLIPlugin(ctx, pluginName, filePath)
@@ -146,7 +147,7 @@ func (m *CLIManager) Install(ctx context.Context, filePath string, overwrite boo
 		return nil, nil, fmt.Errorf("failed to copy plugin executable file from %s to %s: %w", filePath, pluginDirPath, err)
 	}
 	// plugin is always executable
-	pluginFilePath := path.Join(pluginDirPath, binName(pluginName))
+	pluginFilePath := path.Join(pluginDirPath, pluginFile)
 	if err := os.Chmod(pluginFilePath, 0700); err != nil {
 		return nil, nil, fmt.Errorf("failed to change the plugin executable file mode: %w", err)
 	}

--- a/plugin/manager.go
+++ b/plugin/manager.go
@@ -92,7 +92,7 @@ type CLIInstallOptions struct {
 	// It may contain extra lib files and LICENSE files.
 	// On success, these files will be installed as well.
 	//
-	// 2. A single plugin executalbe file following the spec.
+	// 2. A single plugin executable file following the spec.
 	PluginPath string
 
 	// Overwrite is a boolean flag. When set, always install the new plugin.
@@ -119,9 +119,7 @@ func (m *CLIManager) Install(ctx context.Context, installOpts CLIInstallOptions)
 		return nil, nil, errors.New("plugin path cannot be empty")
 	}
 	var installFromNonDir bool
-	var pluginExecutableFile, pluginName string
-	var err error
-	pluginExecutableFile, pluginName, err = parsePluginFromDir(installOpts.PluginPath)
+	pluginExecutableFile, pluginName, err := parsePluginFromDir(installOpts.PluginPath)
 	if err != nil {
 		if !errors.Is(err, file.ErrNotDirectory) {
 			return nil, nil, fmt.Errorf("failed to parse plugin from directory %s: %w", installOpts.PluginPath, err)

--- a/plugin/manager.go
+++ b/plugin/manager.go
@@ -116,7 +116,7 @@ func (m *CLIManager) Install(ctx context.Context, filePath string, overwrite boo
 	existingPlugin, err := m.Get(ctx, pluginName)
 	if err != nil {
 		if !errors.Is(err, os.ErrNotExist) {
-			return nil, nil, fmt.Errorf("failed to get existing plugin: %w", err)
+			return nil, nil, fmt.Errorf("failed to check plugin existence: %w", err)
 		}
 	} else { // plugin already exists
 		var err error

--- a/plugin/manager.go
+++ b/plugin/manager.go
@@ -95,7 +95,7 @@ func (m *CLIManager) List(ctx context.Context) ([]string, error) {
 // version MUST be higher than the existing plugin version.
 //
 // If overwrite is set, version check is skipped. If existing
-// plugin is malfunctioning, it will be overwritten as well.
+// plugin is malfunctioning, it will be overwritten.
 func (m *CLIManager) Install(ctx context.Context, filePath string, overwrite bool) (*proto.GetMetadataResponse, *proto.GetMetadataResponse, error) {
 	// validate and get new plugin metadata
 	pluginFile := filepath.Base(filePath)

--- a/plugin/manager.go
+++ b/plugin/manager.go
@@ -154,6 +154,7 @@ func (m *CLIManager) Install(ctx context.Context, installOpts CLIInstallOptions)
 		return nil, nil, fmt.Errorf("failed to get metadata of new plugin: %w", err)
 	}
 	// check plugin existence and get existing plugin metadata
+	var pluginExists bool
 	var existingPluginMetadata *proto.GetMetadataResponse
 	existingPlugin, err := m.Get(ctx, pluginName)
 	if err != nil {
@@ -161,6 +162,7 @@ func (m *CLIManager) Install(ctx context.Context, installOpts CLIInstallOptions)
 			return nil, nil, fmt.Errorf("failed to check plugin existence: %w", err)
 		}
 	} else { // plugin already exists
+		pluginExists = true
 		existingPluginMetadata, err = existingPlugin.GetMetadata(ctx, &proto.GetMetadataRequest{})
 		if err != nil && !overwrite { // fail only if overwrite is not set
 			return nil, nil, fmt.Errorf("failed to get metadata of existing plugin: %w", err)
@@ -184,23 +186,32 @@ func (m *CLIManager) Install(ctx context.Context, installOpts CLIInstallOptions)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to get the system path of plugin %s: %w", pluginName, err)
 	}
-	// clean up before installation, this guarantees idempotent for install
-	if err := os.RemoveAll(pluginDirPath); err != nil {
-		return nil, nil, fmt.Errorf("failed to clean up %s before installation: %w", pluginDirPath, err)
+	// back up existing plugin
+	if pluginExists {
+		if err := os.Rename(pluginDirPath, pluginDirPath+".bak"); err != nil {
+			return nil, nil, fmt.Errorf("failed to backup existing plugin %s before installation: %w", pluginDirPath, err)
+		}
 	}
 	if installFromNonDir {
 		if err := file.CopyToDir(pluginExecutableFile, pluginDirPath); err != nil {
+			defer cleanupOnInstallFailure(pluginDirPath, pluginDirPath+".bak", pluginExists)
 			return nil, nil, fmt.Errorf("failed to copy plugin executable file from %s to %s: %w", pluginExecutableFile, pluginDirPath, err)
 		}
 	} else {
 		if err := file.CopyDirToDir(installOpts.PluginPath, pluginDirPath); err != nil {
+			defer cleanupOnInstallFailure(pluginDirPath, pluginDirPath+".bak", pluginExists)
 			return nil, nil, fmt.Errorf("failed to copy plugin files from %s to %s: %w", installOpts.PluginPath, pluginDirPath, err)
 		}
 	}
 	// plugin binary file is always executable
 	pluginFilePath := path.Join(pluginDirPath, filepath.Base(pluginExecutableFile))
 	if err := os.Chmod(pluginFilePath, 0700); err != nil {
+		defer cleanupOnInstallFailure(pluginDirPath, pluginDirPath+".bak", pluginExists)
 		return nil, nil, fmt.Errorf("failed to change the plugin executable file mode: %w", err)
+	}
+	// on success, remove the old plugin's back-up if eixsts
+	if pluginExists {
+		defer os.RemoveAll(pluginDirPath + ".bak")
 	}
 	return existingPluginMetadata, newPluginMetadata, nil
 }
@@ -275,4 +286,16 @@ func parsePluginFromDir(path string) (string, string, error) {
 		return "", "", errors.New("no plugin executable file was found")
 	}
 	return pluginExecutableFile, pluginName, nil
+}
+
+// cleanupOnInstallFailure is called when CLIManager.Install failed at core
+// process, in this case, the plugin's original stage is recovered.
+func cleanupOnInstallFailure(pluginDirPath string, pluginBackupPath string, pluginExists bool) error {
+	// clean up on failure
+	_ = os.RemoveAll(pluginDirPath)
+	// recover if old plugin exists
+	if pluginExists {
+		return os.Rename(pluginBackupPath, pluginDirPath)
+	}
+	return nil
 }

--- a/plugin/manager.go
+++ b/plugin/manager.go
@@ -142,6 +142,9 @@ func (m *CLIManager) Install(ctx context.Context, installOpts CLIInstallOptions)
 		}
 	}
 	// validate and get new plugin metadata
+	if err := validatePluginFileExtensionAgainstOS(filepath.Base(pluginExecutableFile), pluginName); err != nil {
+		return nil, nil, err
+	}
 	newPlugin, err := NewCLIPlugin(ctx, pluginName, pluginExecutableFile)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to create new CLI plugin: %w", err)

--- a/plugin/manager.go
+++ b/plugin/manager.go
@@ -178,16 +178,16 @@ func (m *CLIManager) Install(ctx context.Context, installOpts CLIInstallOptions)
 			}
 		}
 	}
-	// core process
-	pluginDirPath, err := m.pluginFS.SysPath(pluginName)
-	if err != nil {
-		return nil, nil, fmt.Errorf("failed to get the system path of plugin %s: %w", pluginName, err)
-	}
 	// clean up before installation, this guarantees idempotent for install
 	if err := m.Uninstall(ctx, pluginName); err != nil {
 		if !errors.Is(err, os.ErrNotExist) {
 			return nil, nil, fmt.Errorf("failed to clean up plugin %s before installation: %w", pluginName, err)
 		}
+	}
+	// core process
+	pluginDirPath, err := m.pluginFS.SysPath(pluginName)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to get the system path of plugin %s: %w", pluginName, err)
 	}
 	if installFromNonDir {
 		if err := file.CopyToDir(pluginExecutableFile, pluginDirPath); err != nil {
@@ -197,11 +197,6 @@ func (m *CLIManager) Install(ctx context.Context, installOpts CLIInstallOptions)
 		if err := file.CopyDirToDir(installOpts.PluginPath, pluginDirPath); err != nil {
 			return nil, nil, fmt.Errorf("failed to copy plugin files from %s to %s: %w", installOpts.PluginPath, pluginDirPath, err)
 		}
-	}
-	// plugin binary file is always executable
-	pluginFilePath := path.Join(pluginDirPath, filepath.Base(pluginExecutableFile))
-	if err := os.Chmod(pluginFilePath, 0700); err != nil {
-		return nil, nil, fmt.Errorf("failed to change the plugin executable file mode: %w", err)
 	}
 	return existingPluginMetadata, newPluginMetadata, nil
 }

--- a/plugin/manager.go
+++ b/plugin/manager.go
@@ -184,7 +184,7 @@ func (m *CLIManager) Install(ctx context.Context, installOpts CLIInstallOptions)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to get the system path of plugin %s: %w", pluginName, err)
 	}
-	// clean up before installation
+	// clean up before installation, this guarantees idempotent for install
 	if err := os.RemoveAll(pluginDirPath); err != nil {
 		return nil, nil, fmt.Errorf("failed to clean up %s before installation: %w", pluginDirPath, err)
 	}

--- a/plugin/manager.go
+++ b/plugin/manager.go
@@ -179,9 +179,14 @@ func (m *CLIManager) Install(ctx context.Context, installOpts CLIInstallOptions)
 			}
 		}
 	}
+	// core process
 	pluginDirPath, err := m.pluginFS.SysPath(pluginName)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to get the system path of plugin %s: %w", pluginName, err)
+	}
+	// clean up before installation
+	if err := os.RemoveAll(pluginDirPath); err != nil {
+		return nil, nil, fmt.Errorf("failed to clean up %s before installation: %w", pluginDirPath, err)
 	}
 	if installFromNonDir {
 		if err := file.CopyToDir(pluginExecutableFile, pluginDirPath); err != nil {

--- a/plugin/manager.go
+++ b/plugin/manager.go
@@ -131,9 +131,9 @@ func (m *CLIManager) Install(ctx context.Context, filePath string, overwrite boo
 			}
 			switch {
 			case comp < 0:
-				return nil, nil, ErrInstallLowerVersion{Msg: fmt.Sprintf("The installing plugin version %s is lower than the existing plugin version %s.", newPluginMetadata.Version, existingPluginMetadata.Version)}
+				return nil, nil, ErrInstallLowerVersion{Msg: fmt.Sprintf("the installing plugin version %s is lower than the existing plugin version %s", newPluginMetadata.Version, existingPluginMetadata.Version)}
 			case comp == 0:
-				return nil, nil, ErrInstallEqualVersion{Msg: fmt.Sprintf("Plugin %s with version %s already exists.", pluginName, existingPluginMetadata.Version)}
+				return nil, nil, ErrInstallEqualVersion{Msg: fmt.Sprintf("plugin %s with version %s already exists", pluginName, existingPluginMetadata.Version)}
 			}
 		}
 	}

--- a/plugin/manager.go
+++ b/plugin/manager.go
@@ -28,21 +28,6 @@ import (
 	"github.com/notaryproject/notation-go/plugin/proto"
 )
 
-// ErrNotCompliant is returned by plugin methods when the response is not
-// compliant.
-var ErrNotCompliant = errors.New("plugin not compliant")
-
-// ErrNotRegularFile is returned when the plugin file is not an regular file.
-var ErrNotRegularFile = errors.New("not regular file")
-
-// ErrInstallLowerVersion is returned when installing a plugin with version
-// lower than the exisiting plugin version.
-var ErrInstallLowerVersion = errors.New("installing plugin with version lower than the existing plugin version")
-
-// ErrInstallEqualVersion is returned when installing a plugin with version
-// equal to the exisiting plugin version.
-var ErrInstallEqualVersion = errors.New("installing plugin with version equal to the existing plugin version")
-
 // Manager manages plugins installed on the system.
 type Manager interface {
 	Get(ctx context.Context, name string) (Plugin, error)
@@ -146,9 +131,9 @@ func (m *CLIManager) Install(ctx context.Context, filePath string, overwrite boo
 			}
 			switch {
 			case comp < 0:
-				return nil, nil, ErrInstallLowerVersion
+				return nil, nil, ErrInstallLowerVersion{Msg: fmt.Sprintf("The installing plugin version %s is lower than the existing plugin version %s.", newPluginMetadata.Version, existingPluginMetadata.Version)}
 			case comp == 0:
-				return nil, nil, ErrInstallEqualVersion
+				return nil, nil, ErrInstallEqualVersion{Msg: fmt.Sprintf("Plugin %s with version %s already exists.", pluginName, existingPluginMetadata.Version)}
 			}
 		}
 	}

--- a/plugin/manager_test.go
+++ b/plugin/manager_test.go
@@ -289,7 +289,7 @@ func TestManager_Install(t *testing.T) {
 		installOpts := CLIInstallOptions{
 			PluginPath: newPluginFilePath,
 		}
-		expectedErrorMsg := "file notation-bar is not executable"
+		expectedErrorMsg := "file testdata/bar/notation-bar is not executable"
 		_, _, err := mgr.Install(context.Background(), installOpts)
 		if err == nil || err.Error() != expectedErrorMsg {
 			t.Fatalf("expecting error %s, but got %v", expectedErrorMsg, err)

--- a/plugin/manager_test.go
+++ b/plugin/manager_test.go
@@ -398,10 +398,9 @@ func TestManager_Install(t *testing.T) {
 		installOpts := CLIInstallOptions{
 			PluginPath: newPluginDir,
 		}
-		expectedErrorMsg := "failed to get metadata of existing plugin: executable name must be \"notation-bar\" instead of \"notation-foo\""
 		existingPluginMetadata, newPluginMetadata, err := mgr.Install(context.Background(), installOpts)
-		if err == nil || err.Error() != expectedErrorMsg {
-			t.Fatalf("expecting error %s, but got %v", expectedErrorMsg, err)
+		if err != nil {
+			t.Fatalf("expecting nil error, but got %v", err)
 		}
 		if existingPluginMetadata.Version != "1.0.0" {
 			t.Fatalf("expecting existing plugin metadata to be 1.0.0, but got %s", existingPluginMetadata.Version)
@@ -431,7 +430,7 @@ func TestManager_Install(t *testing.T) {
 		installOpts := CLIInstallOptions{
 			PluginPath: newPluginDir,
 		}
-		expectedErrorMsg := "no plugin executable file was found under testdata/foo"
+		expectedErrorMsg := "failed to parse plugin from directory testdata/foo: no plugin executable file was found under testdata/foo"
 		_, _, err := mgr.Install(context.Background(), installOpts)
 		if err == nil || err.Error() != expectedErrorMsg {
 			t.Fatalf("expecting error %s, but got %v", expectedErrorMsg, err)
@@ -462,7 +461,7 @@ func TestManager_Install(t *testing.T) {
 		installOpts := CLIInstallOptions{
 			PluginPath: newPluginDir,
 		}
-		expectedErrorMsg := "found more than one plugin executable files under testdata/foo"
+		expectedErrorMsg := "failed to parse plugin from directory testdata/foo: found more than one plugin executable files under testdata/foo"
 		_, _, err := mgr.Install(context.Background(), installOpts)
 		if err == nil || err.Error() != expectedErrorMsg {
 			t.Fatalf("expecting error %s, but got %v", expectedErrorMsg, err)

--- a/plugin/manager_test.go
+++ b/plugin/manager_test.go
@@ -296,6 +296,30 @@ func TestManager_Install(t *testing.T) {
 		}
 	})
 
+	t.Run("fail to install due to invalid new plugin file extension", func(t *testing.T) {
+		newPluginFilePath := "testdata/bar/notation-bar.exe"
+		newPluginDir := filepath.Dir(newPluginFilePath)
+		if err := os.MkdirAll(newPluginDir, 0777); err != nil {
+			t.Fatalf("failed to create %s: %v", newPluginDir, err)
+		}
+		defer os.RemoveAll(newPluginDir)
+		if err := createFileAndChmod(newPluginFilePath, 0700); err != nil {
+			t.Fatal(err)
+		}
+		executor = testInstallCommander{
+			newPluginFilePath: newPluginFilePath,
+			newPluginStdout:   metadataJSON(validMetadataBar),
+		}
+		installOpts := CLIInstallOptions{
+			PluginPath: newPluginFilePath,
+		}
+		expectedErrorMsg := "invalid plugin file extension. Expecting file notation-bar, but got notation-bar.exe"
+		_, _, err := mgr.Install(context.Background(), installOpts)
+		if err == nil || err.Error() != expectedErrorMsg {
+			t.Fatalf("expecting error %s, but got %v", expectedErrorMsg, err)
+		}
+	})
+
 	t.Run("fail to install due to new plugin executable file does not exist", func(t *testing.T) {
 		newPluginFilePath := "testdata/bar/notation-bar"
 		executor = testInstallCommander{

--- a/plugin/manager_test.go
+++ b/plugin/manager_test.go
@@ -241,7 +241,7 @@ func TestManager_Install(t *testing.T) {
 		installOpts := CLIInstallOptions{
 			PluginPath: newPluginFilePath,
 		}
-		expectedErrorMsg := "the installing plugin version 0.1.0 is lower than the existing plugin version 1.0.0"
+		expectedErrorMsg := "failed to install plugin foo. The installing plugin version 0.1.0 is lower than the existing plugin version 1.0.0"
 		_, _, err := mgr.Install(context.Background(), installOpts)
 		if err == nil || err.Error() != expectedErrorMsg {
 			t.Fatalf("expecting error %s, but got %v", expectedErrorMsg, err)

--- a/plugin/manager_test.go
+++ b/plugin/manager_test.go
@@ -221,7 +221,7 @@ func TestManager_Install(t *testing.T) {
 			newPluginStdout:       metadataJSON(validMetadata),
 		}
 		_, _, err = mgr.Install(context.Background(), newPluginFilePath, false)
-		expectedErrorMsg := "Plugin foo with version 1.0.0 already exists."
+		expectedErrorMsg := "plugin foo with version 1.0.0 already exists"
 		if err == nil || err.Error() != expectedErrorMsg {
 			t.Fatalf("expecting error %s, but got %v", expectedErrorMsg, err)
 		}
@@ -235,7 +235,7 @@ func TestManager_Install(t *testing.T) {
 			newPluginStdout:       metadataJSON(validMetadataLowerVersion),
 		}
 		_, _, err = mgr.Install(context.Background(), newPluginFilePath, false)
-		expectedErrorMsg := "The installing plugin version 0.1.0 is lower than the existing plugin version 1.0.0."
+		expectedErrorMsg := "the installing plugin version 0.1.0 is lower than the existing plugin version 1.0.0"
 		if err == nil || err.Error() != expectedErrorMsg {
 			t.Fatalf("expecting error %s, but got %v", expectedErrorMsg, err)
 		}

--- a/plugin/manager_test.go
+++ b/plugin/manager_test.go
@@ -407,6 +407,9 @@ func TestManager_Install(t *testing.T) {
 		if err := pluginFile.Close(); err != nil {
 			t.Fatalf("failed to close %s: %v", newPluginFilePath, err)
 		}
+		if err := pluginFile.Chmod(0700); err != nil {
+			t.Fatalf("failed to chmod %s: %v", newPluginFilePath, err)
+		}
 		pluginLibFile, err := os.Create(newPluginLibPath)
 		if err != nil {
 			t.Fatalf("failed to create %s: %v", newPluginLibPath, err)

--- a/plugin/manager_test.go
+++ b/plugin/manager_test.go
@@ -141,12 +141,8 @@ func TestManager_Install(t *testing.T) {
 		t.Fatalf("failed to create %s: %v", newPluginDir, err)
 	}
 	defer os.RemoveAll(newPluginDir)
-	pluginFile, err := os.Create(newPluginFilePath)
-	if err != nil {
-		t.Fatalf("failed to create %s: %v", newPluginFilePath, err)
-	}
-	if err := pluginFile.Close(); err != nil {
-		t.Fatalf("failed to close %s: %v", newPluginFilePath, err)
+	if err := createFileAndChmod(newPluginFilePath, 0666); err != nil {
+		t.Fatal(err)
 	}
 	mgr := NewCLIManager(mockfs.NewSysFSWithRootMock(fstest.MapFS{}, "testdata/plugins"))
 
@@ -183,8 +179,7 @@ func TestManager_Install(t *testing.T) {
 			PluginPath: newPluginFilePath,
 			Overwrite:  true,
 		}
-		_, _, err = mgr.Install(context.Background(), installOpts)
-		if err != nil {
+		if _, _, err := mgr.Install(context.Background(), installOpts); err != nil {
 			t.Fatalf("expecting error to be nil, but got %v", err)
 		}
 	})
@@ -196,12 +191,8 @@ func TestManager_Install(t *testing.T) {
 			t.Fatalf("failed to create %s: %v", newPluginDir, err)
 		}
 		defer os.RemoveAll(newPluginDir)
-		pluginFile, err := os.Create(newPluginFilePath)
-		if err != nil {
-			t.Fatalf("failed to create %s: %v", newPluginFilePath, err)
-		}
-		if err := pluginFile.Close(); err != nil {
-			t.Fatalf("failed to close %s: %v", newPluginFilePath, err)
+		if err := createFileAndChmod(newPluginFilePath, 0666); err != nil {
+			t.Fatal(err)
 		}
 		executor = testInstallCommander{
 			newPluginFilePath: newPluginFilePath,
@@ -233,8 +224,8 @@ func TestManager_Install(t *testing.T) {
 		installOpts := CLIInstallOptions{
 			PluginPath: newPluginFilePath,
 		}
-		_, _, err = mgr.Install(context.Background(), installOpts)
 		expectedErrorMsg := "plugin foo with version 1.0.0 already exists"
+		_, _, err := mgr.Install(context.Background(), installOpts)
 		if err == nil || err.Error() != expectedErrorMsg {
 			t.Fatalf("expecting error %s, but got %v", expectedErrorMsg, err)
 		}
@@ -250,8 +241,8 @@ func TestManager_Install(t *testing.T) {
 		installOpts := CLIInstallOptions{
 			PluginPath: newPluginFilePath,
 		}
-		_, _, err = mgr.Install(context.Background(), installOpts)
 		expectedErrorMsg := "the installing plugin version 0.1.0 is lower than the existing plugin version 1.0.0"
+		_, _, err := mgr.Install(context.Background(), installOpts)
 		if err == nil || err.Error() != expectedErrorMsg {
 			t.Fatalf("expecting error %s, but got %v", expectedErrorMsg, err)
 		}
@@ -264,12 +255,8 @@ func TestManager_Install(t *testing.T) {
 			t.Fatalf("failed to create %s: %v", newPluginDir, err)
 		}
 		defer os.RemoveAll(newPluginDir)
-		pluginFile, err := os.Create(newPluginFilePath)
-		if err != nil {
-			t.Fatalf("failed to create %s: %v", newPluginFilePath, err)
-		}
-		if err := pluginFile.Close(); err != nil {
-			t.Fatalf("failed to close %s: %v", newPluginFilePath, err)
+		if err := createFileAndChmod(newPluginFilePath, 0666); err != nil {
+			t.Fatal(err)
 		}
 		executor = testInstallCommander{
 			newPluginFilePath: newPluginFilePath,
@@ -278,8 +265,8 @@ func TestManager_Install(t *testing.T) {
 		installOpts := CLIInstallOptions{
 			PluginPath: newPluginFilePath,
 		}
-		_, _, err = mgr.Install(context.Background(), installOpts)
 		expectedErrorMsg := "failed to get plugin name from file path testdata/bar/bar: invalid plugin executable file name. Plugin file name requires format notation-{plugin-name}, but got bar"
+		_, _, err := mgr.Install(context.Background(), installOpts)
 		if err == nil || err.Error() != expectedErrorMsg {
 			t.Fatalf("expecting error %s, but got %v", expectedErrorMsg, err)
 		}
@@ -292,12 +279,8 @@ func TestManager_Install(t *testing.T) {
 			t.Fatalf("failed to create %s: %v", newPluginDir, err)
 		}
 		defer os.RemoveAll(newPluginDir)
-		pluginFile, err := os.Create(newPluginFilePath)
-		if err != nil {
-			t.Fatalf("failed to create %s: %v", newPluginFilePath, err)
-		}
-		if err := pluginFile.Close(); err != nil {
-			t.Fatalf("failed to close %s: %v", newPluginFilePath, err)
+		if err := createFileAndChmod(newPluginFilePath, 0666); err != nil {
+			t.Fatal(err)
 		}
 		executor = testInstallCommander{
 			newPluginFilePath: newPluginFilePath,
@@ -306,8 +289,8 @@ func TestManager_Install(t *testing.T) {
 		installOpts := CLIInstallOptions{
 			PluginPath: newPluginFilePath,
 		}
-		_, _, err = mgr.Install(context.Background(), installOpts)
 		expectedErrorMsg := "invalid plugin file extension. Expecting file notation-bar, but got notation-bar.exe"
+		_, _, err := mgr.Install(context.Background(), installOpts)
 		if err == nil || err.Error() != expectedErrorMsg {
 			t.Fatalf("expecting error %s, but got %v", expectedErrorMsg, err)
 		}
@@ -322,8 +305,8 @@ func TestManager_Install(t *testing.T) {
 		installOpts := CLIInstallOptions{
 			PluginPath: newPluginFilePath,
 		}
-		_, _, err = mgr.Install(context.Background(), installOpts)
 		expectedErrorMsg := "failed to parse plugin from directory testdata/bar/notation-bar: stat testdata/bar/notation-bar: no such file or directory"
+		_, _, err := mgr.Install(context.Background(), installOpts)
 		if err == nil || err.Error() != expectedErrorMsg {
 			t.Fatalf("expecting error %s, but got %v", expectedErrorMsg, err)
 		}
@@ -350,8 +333,8 @@ func TestManager_Install(t *testing.T) {
 		installOpts := CLIInstallOptions{
 			PluginPath: newPluginFilePath,
 		}
-		_, _, err = mgr.Install(context.Background(), installOpts)
 		expectedErrorMsg := "failed to get metadata of new plugin: executable name must be \"notation-foobar\" instead of \"notation-bar\""
+		_, _, err = mgr.Install(context.Background(), installOpts)
 		if err == nil || err.Error() != expectedErrorMsg {
 			t.Fatalf("expecting error %s, but got %v", expectedErrorMsg, err)
 		}
@@ -367,8 +350,8 @@ func TestManager_Install(t *testing.T) {
 		installOpts := CLIInstallOptions{
 			PluginPath: newPluginFilePath,
 		}
-		_, _, err = mgr.Install(context.Background(), installOpts)
 		expectedErrorMsg := "failed to get metadata of existing plugin: executable name must be \"notation-bar\" instead of \"notation-foo\""
+		_, _, err := mgr.Install(context.Background(), installOpts)
 		if err == nil || err.Error() != expectedErrorMsg {
 			t.Fatalf("expecting error %s, but got %v", expectedErrorMsg, err)
 		}
@@ -385,7 +368,7 @@ func TestManager_Install(t *testing.T) {
 			PluginPath: newPluginFilePath,
 			Overwrite:  true,
 		}
-		_, _, err = mgr.Install(context.Background(), installOpts)
+		_, _, err := mgr.Install(context.Background(), installOpts)
 		if err != nil {
 			t.Fatalf("expecting error to be nil, but got %v", err)
 		}
@@ -400,22 +383,11 @@ func TestManager_Install(t *testing.T) {
 			t.Fatalf("failed to create %s: %v", newPluginDir, err)
 		}
 		defer os.RemoveAll(newPluginDir)
-		pluginFile, err := os.Create(newPluginFilePath)
-		if err != nil {
-			t.Fatalf("failed to create %s: %v", newPluginFilePath, err)
+		if err := createFileAndChmod(newPluginFilePath, 0700); err != nil {
+			t.Fatal(err)
 		}
-		if err := pluginFile.Chmod(0700); err != nil {
-			t.Fatalf("failed to chmod %s: %v", newPluginFilePath, err)
-		}
-		if err := pluginFile.Close(); err != nil {
-			t.Fatalf("failed to close %s: %v", newPluginFilePath, err)
-		}
-		pluginLibFile, err := os.Create(newPluginLibPath)
-		if err != nil {
-			t.Fatalf("failed to create %s: %v", newPluginLibPath, err)
-		}
-		if err := pluginLibFile.Close(); err != nil {
-			t.Fatalf("failed to close %s: %v", newPluginLibPath, err)
+		if err := createFileAndChmod(newPluginLibPath, 0666); err != nil {
+			t.Fatal(err)
 		}
 		executor = testInstallCommander{
 			existedPluginFilePath: existedPluginFilePath,
@@ -426,9 +398,74 @@ func TestManager_Install(t *testing.T) {
 		installOpts := CLIInstallOptions{
 			PluginPath: newPluginDir,
 		}
-		_, _, err = mgr.Install(context.Background(), installOpts)
-		if err != nil {
-			t.Fatalf("expecting error to be nil, but got %v", err)
+		expectedErrorMsg := "failed to get metadata of existing plugin: executable name must be \"notation-bar\" instead of \"notation-foo\""
+		existingPluginMetadata, newPluginMetadata, err := mgr.Install(context.Background(), installOpts)
+		if err == nil || err.Error() != expectedErrorMsg {
+			t.Fatalf("expecting error %s, but got %v", expectedErrorMsg, err)
+		}
+		if existingPluginMetadata.Version != "1.0.0" {
+			t.Fatalf("expecting existing plugin metadata to be 1.0.0, but got %s", existingPluginMetadata.Version)
+		}
+		if newPluginMetadata.Version != "1.1.0" {
+			t.Fatalf("expecting new plugin metadata to be 1.1.0, but got %s", newPluginMetadata.Version)
+		}
+	})
+
+	t.Run("fail to install from plugin dir due to no plugin executable file", func(t *testing.T) {
+		existedPluginFilePath := "testdata/plugins/foo/notation-foo"
+		newPluginFilePath := "testdata/foo/foo"
+		newPluginDir := filepath.Dir(newPluginFilePath)
+		if err := os.MkdirAll(newPluginDir, 0777); err != nil {
+			t.Fatalf("failed to create %s: %v", newPluginDir, err)
+		}
+		defer os.RemoveAll(newPluginDir)
+		if err := createFileAndChmod(newPluginFilePath, 0666); err != nil {
+			t.Fatal(err)
+		}
+		executor = testInstallCommander{
+			existedPluginFilePath: existedPluginFilePath,
+			newPluginFilePath:     newPluginFilePath,
+			existedPluginStdout:   metadataJSON(validMetadata),
+			newPluginStdout:       metadataJSON(validMetadataHigherVersion),
+		}
+		installOpts := CLIInstallOptions{
+			PluginPath: newPluginDir,
+		}
+		expectedErrorMsg := "no plugin executable file was found under testdata/foo"
+		_, _, err := mgr.Install(context.Background(), installOpts)
+		if err == nil || err.Error() != expectedErrorMsg {
+			t.Fatalf("expecting error %s, but got %v", expectedErrorMsg, err)
+		}
+	})
+
+	t.Run("fail to install from plugin dir due to more than one plugin executable file", func(t *testing.T) {
+		existedPluginFilePath := "testdata/plugins/foo/notation-foo"
+		newPluginFilePath := "testdata/foo/notation-foo1"
+		newPluginFilePath2 := "testdata/foo/notation-foo2"
+		newPluginDir := filepath.Dir(newPluginFilePath)
+		if err := os.MkdirAll(newPluginDir, 0777); err != nil {
+			t.Fatalf("failed to create %s: %v", newPluginDir, err)
+		}
+		defer os.RemoveAll(newPluginDir)
+		if err := createFileAndChmod(newPluginFilePath, 0700); err != nil {
+			t.Fatal(err)
+		}
+		if err := createFileAndChmod(newPluginFilePath2, 0700); err != nil {
+			t.Fatal(err)
+		}
+		executor = testInstallCommander{
+			existedPluginFilePath: existedPluginFilePath,
+			newPluginFilePath:     newPluginFilePath,
+			existedPluginStdout:   metadataJSON(validMetadata),
+			newPluginStdout:       metadataJSON(validMetadataHigherVersion),
+		}
+		installOpts := CLIInstallOptions{
+			PluginPath: newPluginDir,
+		}
+		expectedErrorMsg := "found more than one plugin executable files under testdata/foo"
+		_, _, err := mgr.Install(context.Background(), installOpts)
+		if err == nil || err.Error() != expectedErrorMsg {
+			t.Fatalf("expecting error %s, but got %v", expectedErrorMsg, err)
 		}
 	})
 }
@@ -467,4 +504,15 @@ func metadataJSON(m proto.GetMetadataResponse) []byte {
 		panic(err)
 	}
 	return d
+}
+
+func createFileAndChmod(path string, mode fs.FileMode) error {
+	f, err := os.Create(path)
+	if err != nil {
+		return err
+	}
+	if err := f.Chmod(mode); err != nil {
+		return err
+	}
+	return f.Close()
 }

--- a/plugin/manager_test.go
+++ b/plugin/manager_test.go
@@ -265,7 +265,7 @@ func TestManager_Install(t *testing.T) {
 		installOpts := CLIInstallOptions{
 			PluginPath: newPluginFilePath,
 		}
-		expectedErrorMsg := "failed to get plugin name from file path testdata/bar/bar: invalid plugin executable file name. Plugin file name requires format notation-{plugin-name}, but got bar"
+		expectedErrorMsg := "failed to read plugin name from file path testdata/bar/bar: invalid plugin executable file name. Plugin file name requires format notation-{plugin-name}, but got bar"
 		_, _, err := mgr.Install(context.Background(), installOpts)
 		if err == nil || err.Error() != expectedErrorMsg {
 			t.Fatalf("expecting error %s, but got %v", expectedErrorMsg, err)
@@ -329,7 +329,7 @@ func TestManager_Install(t *testing.T) {
 		installOpts := CLIInstallOptions{
 			PluginPath: newPluginFilePath,
 		}
-		expectedErrorMsg := "failed to parse plugin from directory testdata/bar/notation-bar: stat testdata/bar/notation-bar: no such file or directory"
+		expectedErrorMsg := "failed to read plugin from directory testdata/bar/notation-bar: stat testdata/bar/notation-bar: no such file or directory"
 		_, _, err := mgr.Install(context.Background(), installOpts)
 		if err == nil || err.Error() != expectedErrorMsg {
 			t.Fatalf("expecting error %s, but got %v", expectedErrorMsg, err)
@@ -450,7 +450,7 @@ func TestManager_Install(t *testing.T) {
 		installOpts := CLIInstallOptions{
 			PluginPath: newPluginDir,
 		}
-		expectedErrorMsg := "failed to parse plugin from directory testdata/foo: no plugin executable file was found"
+		expectedErrorMsg := "failed to read plugin from directory testdata/foo: no plugin executable file was found"
 		_, _, err := mgr.Install(context.Background(), installOpts)
 		if err == nil || err.Error() != expectedErrorMsg {
 			t.Fatalf("expecting error %s, but got %v", expectedErrorMsg, err)
@@ -481,7 +481,7 @@ func TestManager_Install(t *testing.T) {
 		installOpts := CLIInstallOptions{
 			PluginPath: newPluginDir,
 		}
-		expectedErrorMsg := "failed to parse plugin from directory testdata/foo: found more than one plugin executable files"
+		expectedErrorMsg := "failed to read plugin from directory testdata/foo: found more than one plugin executable files"
 		_, _, err := mgr.Install(context.Background(), installOpts)
 		if err == nil || err.Error() != expectedErrorMsg {
 			t.Fatalf("expecting error %s, but got %v", expectedErrorMsg, err)

--- a/plugin/manager_test.go
+++ b/plugin/manager_test.go
@@ -279,7 +279,7 @@ func TestManager_Install(t *testing.T) {
 			PluginPath: newPluginFilePath,
 		}
 		_, _, err = mgr.Install(context.Background(), installOpts)
-		expectedErrorMsg := "failed to get plugin name from file path: invalid plugin executable file name. Plugin file name requires format notation-{plugin-name}, but got bar"
+		expectedErrorMsg := "failed to get plugin name from file path testdata/bar/bar: invalid plugin executable file name. Plugin file name requires format notation-{plugin-name}, but got bar"
 		if err == nil || err.Error() != expectedErrorMsg {
 			t.Fatalf("expecting error %s, but got %v", expectedErrorMsg, err)
 		}
@@ -323,7 +323,7 @@ func TestManager_Install(t *testing.T) {
 			PluginPath: newPluginFilePath,
 		}
 		_, _, err = mgr.Install(context.Background(), installOpts)
-		expectedErrorMsg := "failed to validate plugin directory: stat testdata/bar/notation-bar: no such file or directory"
+		expectedErrorMsg := "failed to parse plugin from directory testdata/bar/notation-bar: stat testdata/bar/notation-bar: no such file or directory"
 		if err == nil || err.Error() != expectedErrorMsg {
 			t.Fatalf("expecting error %s, but got %v", expectedErrorMsg, err)
 		}

--- a/plugin/manager_test.go
+++ b/plugin/manager_test.go
@@ -279,7 +279,7 @@ func TestManager_Install(t *testing.T) {
 			t.Fatalf("failed to create %s: %v", newPluginDir, err)
 		}
 		defer os.RemoveAll(newPluginDir)
-		if err := createFileAndChmod(newPluginFilePath, 0666); err != nil {
+		if err := createFileAndChmod(newPluginFilePath, 0066); err != nil {
 			t.Fatal(err)
 		}
 		executor = testInstallCommander{
@@ -289,7 +289,7 @@ func TestManager_Install(t *testing.T) {
 		installOpts := CLIInstallOptions{
 			PluginPath: newPluginFilePath,
 		}
-		expectedErrorMsg := "invalid plugin file extension. Expecting file notation-bar, but got notation-bar.exe"
+		expectedErrorMsg := "file notation-bar.exe is not executable"
 		_, _, err := mgr.Install(context.Background(), installOpts)
 		if err == nil || err.Error() != expectedErrorMsg {
 			t.Fatalf("expecting error %s, but got %v", expectedErrorMsg, err)

--- a/plugin/manager_test.go
+++ b/plugin/manager_test.go
@@ -273,7 +273,7 @@ func TestManager_Install(t *testing.T) {
 			newPluginStdout:   metadataJSON(validMetadataBar),
 		}
 		_, _, err = mgr.Install(context.Background(), newPluginFilePath, false)
-		expectedErrorMsg := "invalid plugin file name extension. Expecting file notation-bar, but got notation-bar.exe"
+		expectedErrorMsg := "invalid plugin file extension. Expecting file notation-bar, but got notation-bar.exe"
 		if err == nil || err.Error() != expectedErrorMsg {
 			t.Fatalf("expecting error %s, but got %v", expectedErrorMsg, err)
 		}
@@ -328,6 +328,19 @@ func TestManager_Install(t *testing.T) {
 		expectedErrorMsg := "failed to get metadata of existing plugin: executable name must be \"notation-bar\" instead of \"notation-foo\""
 		if err == nil || err.Error() != expectedErrorMsg {
 			t.Fatalf("expecting error %s, but got %v", expectedErrorMsg, err)
+		}
+	})
+
+	t.Run("success to install with overwrite and invalid existing plugin metadata", func(t *testing.T) {
+		executor = testInstallCommander{
+			existedPluginFilePath: existedPluginFilePath,
+			newPluginFilePath:     newPluginFilePath,
+			existedPluginStdout:   metadataJSON(validMetadataBar),
+			newPluginStdout:       metadataJSON(validMetadata),
+		}
+		_, _, err = mgr.Install(context.Background(), newPluginFilePath, true)
+		if err != nil {
+			t.Fatalf("expecting error to be nil, but got %v", err)
 		}
 	})
 }

--- a/plugin/manager_test.go
+++ b/plugin/manager_test.go
@@ -264,6 +264,19 @@ func TestManager_Install(t *testing.T) {
 		}
 	})
 
+	t.Run("fail to install due to invalid new plugin file extension", func(t *testing.T) {
+		newPluginFilePath := "testdata/bar/notation-bar.exe"
+		executor = testInstallCommander{
+			newPluginFilePath: newPluginFilePath,
+			newPluginStdout:   metadataJSON(validMetadataBar),
+		}
+		_, _, err = mgr.Install(context.Background(), newPluginFilePath, false)
+		expectedErrorMsg := "invalid plugin file name extension. Expecting file notation-bar, but got notation-bar.exe"
+		if err == nil || err.Error() != expectedErrorMsg {
+			t.Fatalf("expecting error %s, but got %v", expectedErrorMsg, err)
+		}
+	})
+
 	t.Run("fail to install due to new plugin executable file does not exist", func(t *testing.T) {
 		newPluginFilePath := "testdata/bar/notation-bar"
 		executor = testInstallCommander{

--- a/plugin/manager_test.go
+++ b/plugin/manager_test.go
@@ -430,7 +430,7 @@ func TestManager_Install(t *testing.T) {
 		installOpts := CLIInstallOptions{
 			PluginPath: newPluginDir,
 		}
-		expectedErrorMsg := "failed to parse plugin from directory testdata/foo: no plugin executable file was found under testdata/foo"
+		expectedErrorMsg := "failed to parse plugin from directory testdata/foo: no plugin executable file was found"
 		_, _, err := mgr.Install(context.Background(), installOpts)
 		if err == nil || err.Error() != expectedErrorMsg {
 			t.Fatalf("expecting error %s, but got %v", expectedErrorMsg, err)
@@ -461,7 +461,7 @@ func TestManager_Install(t *testing.T) {
 		installOpts := CLIInstallOptions{
 			PluginPath: newPluginDir,
 		}
-		expectedErrorMsg := "failed to parse plugin from directory testdata/foo: found more than one plugin executable files under testdata/foo"
+		expectedErrorMsg := "failed to parse plugin from directory testdata/foo: found more than one plugin executable files"
 		_, _, err := mgr.Install(context.Background(), installOpts)
 		if err == nil || err.Error() != expectedErrorMsg {
 			t.Fatalf("expecting error %s, but got %v", expectedErrorMsg, err)

--- a/plugin/manager_test.go
+++ b/plugin/manager_test.go
@@ -404,11 +404,11 @@ func TestManager_Install(t *testing.T) {
 		if err != nil {
 			t.Fatalf("failed to create %s: %v", newPluginFilePath, err)
 		}
-		if err := pluginFile.Close(); err != nil {
-			t.Fatalf("failed to close %s: %v", newPluginFilePath, err)
-		}
 		if err := pluginFile.Chmod(0700); err != nil {
 			t.Fatalf("failed to chmod %s: %v", newPluginFilePath, err)
+		}
+		if err := pluginFile.Close(); err != nil {
+			t.Fatalf("failed to close %s: %v", newPluginFilePath, err)
 		}
 		pluginLibFile, err := os.Create(newPluginLibPath)
 		if err != nil {

--- a/plugin/manager_test.go
+++ b/plugin/manager_test.go
@@ -221,8 +221,9 @@ func TestManager_Install(t *testing.T) {
 			newPluginStdout:       metadataJSON(validMetadata),
 		}
 		_, _, err = mgr.Install(context.Background(), newPluginFilePath, false)
-		if err == nil || err.Error() != ErrInstallEqualVersion.Error() {
-			t.Fatalf("expecting error %v, but got %v", ErrInstallEqualVersion, err)
+		expectedErrorMsg := "Plugin foo with version 1.0.0 already exists."
+		if err == nil || err.Error() != expectedErrorMsg {
+			t.Fatalf("expecting error %s, but got %v", expectedErrorMsg, err)
 		}
 	})
 
@@ -234,8 +235,9 @@ func TestManager_Install(t *testing.T) {
 			newPluginStdout:       metadataJSON(validMetadataLowerVersion),
 		}
 		_, _, err = mgr.Install(context.Background(), newPluginFilePath, false)
-		if err == nil || err.Error() != ErrInstallLowerVersion.Error() {
-			t.Fatalf("expecting error %v, but got %v", ErrInstallLowerVersion, err)
+		expectedErrorMsg := "The installing plugin version 0.1.0 is lower than the existing plugin version 1.0.0."
+		if err == nil || err.Error() != expectedErrorMsg {
+			t.Fatalf("expecting error %s, but got %v", expectedErrorMsg, err)
 		}
 	})
 

--- a/plugin/manager_test.go
+++ b/plugin/manager_test.go
@@ -141,7 +141,7 @@ func TestManager_Install(t *testing.T) {
 		t.Fatalf("failed to create %s: %v", newPluginDir, err)
 	}
 	defer os.RemoveAll(newPluginDir)
-	if err := createFileAndChmod(newPluginFilePath, 0666); err != nil {
+	if err := createFileAndChmod(newPluginFilePath, 0700); err != nil {
 		t.Fatal(err)
 	}
 	mgr := NewCLIManager(mockfs.NewSysFSWithRootMock(fstest.MapFS{}, "testdata/plugins"))
@@ -191,7 +191,7 @@ func TestManager_Install(t *testing.T) {
 			t.Fatalf("failed to create %s: %v", newPluginDir, err)
 		}
 		defer os.RemoveAll(newPluginDir)
-		if err := createFileAndChmod(newPluginFilePath, 0666); err != nil {
+		if err := createFileAndChmod(newPluginFilePath, 0700); err != nil {
 			t.Fatal(err)
 		}
 		executor = testInstallCommander{
@@ -255,7 +255,7 @@ func TestManager_Install(t *testing.T) {
 			t.Fatalf("failed to create %s: %v", newPluginDir, err)
 		}
 		defer os.RemoveAll(newPluginDir)
-		if err := createFileAndChmod(newPluginFilePath, 0666); err != nil {
+		if err := createFileAndChmod(newPluginFilePath, 0700); err != nil {
 			t.Fatal(err)
 		}
 		executor = testInstallCommander{
@@ -272,14 +272,14 @@ func TestManager_Install(t *testing.T) {
 		}
 	})
 
-	t.Run("fail to install due to invalid new plugin file extension", func(t *testing.T) {
-		newPluginFilePath := "testdata/bar/notation-bar.exe"
+	t.Run("fail to install due to wrong plugin file permission", func(t *testing.T) {
+		newPluginFilePath := "testdata/bar/notation-bar"
 		newPluginDir := filepath.Dir(newPluginFilePath)
 		if err := os.MkdirAll(newPluginDir, 0777); err != nil {
 			t.Fatalf("failed to create %s: %v", newPluginDir, err)
 		}
 		defer os.RemoveAll(newPluginDir)
-		if err := createFileAndChmod(newPluginFilePath, 0066); err != nil {
+		if err := createFileAndChmod(newPluginFilePath, 0600); err != nil {
 			t.Fatal(err)
 		}
 		executor = testInstallCommander{
@@ -289,7 +289,7 @@ func TestManager_Install(t *testing.T) {
 		installOpts := CLIInstallOptions{
 			PluginPath: newPluginFilePath,
 		}
-		expectedErrorMsg := "file notation-bar.exe is not executable"
+		expectedErrorMsg := "file notation-bar is not executable"
 		_, _, err := mgr.Install(context.Background(), installOpts)
 		if err == nil || err.Error() != expectedErrorMsg {
 			t.Fatalf("expecting error %s, but got %v", expectedErrorMsg, err)
@@ -319,12 +319,8 @@ func TestManager_Install(t *testing.T) {
 			t.Fatalf("failed to create %s: %v", newPluginDir, err)
 		}
 		defer os.RemoveAll(newPluginDir)
-		pluginFile, err := os.Create(newPluginFilePath)
-		if err != nil {
-			t.Fatalf("failed to create %s: %v", newPluginFilePath, err)
-		}
-		if err := pluginFile.Close(); err != nil {
-			t.Fatalf("failed to close %s: %v", newPluginFilePath, err)
+		if err := createFileAndChmod(newPluginFilePath, 0700); err != nil {
+			t.Fatal(err)
 		}
 		executor = testInstallCommander{
 			newPluginFilePath: newPluginFilePath,
@@ -334,7 +330,7 @@ func TestManager_Install(t *testing.T) {
 			PluginPath: newPluginFilePath,
 		}
 		expectedErrorMsg := "failed to get metadata of new plugin: executable name must be \"notation-foobar\" instead of \"notation-bar\""
-		_, _, err = mgr.Install(context.Background(), installOpts)
+		_, _, err := mgr.Install(context.Background(), installOpts)
 		if err == nil || err.Error() != expectedErrorMsg {
 			t.Fatalf("expecting error %s, but got %v", expectedErrorMsg, err)
 		}
@@ -386,7 +382,7 @@ func TestManager_Install(t *testing.T) {
 		if err := createFileAndChmod(newPluginFilePath, 0700); err != nil {
 			t.Fatal(err)
 		}
-		if err := createFileAndChmod(newPluginLibPath, 0666); err != nil {
+		if err := createFileAndChmod(newPluginLibPath, 0600); err != nil {
 			t.Fatal(err)
 		}
 		executor = testInstallCommander{
@@ -418,7 +414,7 @@ func TestManager_Install(t *testing.T) {
 			t.Fatalf("failed to create %s: %v", newPluginDir, err)
 		}
 		defer os.RemoveAll(newPluginDir)
-		if err := createFileAndChmod(newPluginFilePath, 0666); err != nil {
+		if err := createFileAndChmod(newPluginFilePath, 0700); err != nil {
 			t.Fatal(err)
 		}
 		executor = testInstallCommander{
@@ -437,7 +433,7 @@ func TestManager_Install(t *testing.T) {
 		}
 	})
 
-	t.Run("fail to install from plugin dir due to more than one plugin executable file", func(t *testing.T) {
+	t.Run("fail to install from plugin dir due to more than one plugin executable files", func(t *testing.T) {
 		existedPluginFilePath := "testdata/plugins/foo/notation-foo"
 		newPluginFilePath := "testdata/foo/notation-foo1"
 		newPluginFilePath2 := "testdata/foo/notation-foo2"

--- a/plugin/manager_test.go
+++ b/plugin/manager_test.go
@@ -20,6 +20,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"runtime"
 	"testing"
 	"testing/fstest"
 
@@ -90,6 +91,9 @@ var invalidContractVersionMetadata = proto.GetMetadataResponse{
 }
 
 func TestManager_Get(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("skipping test on Windows")
+	}
 	executor = testCommander{stdout: metadataJSON(validMetadata)}
 	mgr := NewCLIManager(mockfs.NewSysFSWithRootMock(fstest.MapFS{}, "./testdata/plugins"))
 	_, err := mgr.Get(context.Background(), "foo")
@@ -127,6 +131,9 @@ func TestManager_List(t *testing.T) {
 }
 
 func TestManager_Install(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("skipping test on Windows")
+	}
 	existedPluginFilePath := "testdata/plugins/foo/notation-foo"
 	newPluginFilePath := "testdata/foo/notation-foo"
 	newPluginDir := filepath.Dir(newPluginFilePath)
@@ -171,7 +178,7 @@ func TestManager_Install(t *testing.T) {
 		}
 		_, _, err = mgr.Install(context.Background(), newPluginFilePath, true)
 		if err != nil {
-			t.Fatalf("expecting error to be nil, bug got %v", err)
+			t.Fatalf("expecting error to be nil, but got %v", err)
 		}
 	})
 
@@ -193,20 +200,16 @@ func TestManager_Install(t *testing.T) {
 			newPluginFilePath: newPluginFilePath,
 			newPluginStdout:   metadataJSON(validMetadataBar),
 		}
+		defer mgr.Uninstall(context.Background(), "bar")
 		existingPluginMetadata, newPluginMetadata, err := mgr.Install(context.Background(), newPluginFilePath, false)
 		if err != nil {
-			t.Fatalf("expecting error to be nil, bug got %v", err)
+			t.Fatalf("expecting error to be nil, but got %v", err)
 		}
 		if existingPluginMetadata != nil {
-			t.Fatalf("expecting existingPluginMetadata to be nil, bug got %v", existingPluginMetadata)
+			t.Fatalf("expecting existingPluginMetadata to be nil, but got %v", existingPluginMetadata)
 		}
 		if newPluginMetadata.Version != validMetadataBar.Version {
 			t.Fatalf("new plugin version mismatch, new plugin version: %s, but got: %s", validMetadataBar.Version, newPluginMetadata.Version)
-		}
-		// clean up
-		err = mgr.Uninstall(context.Background(), "bar")
-		if err != nil {
-			t.Fatal("failed to clean up test plugin bar")
 		}
 	})
 
@@ -219,7 +222,7 @@ func TestManager_Install(t *testing.T) {
 		}
 		_, _, err = mgr.Install(context.Background(), newPluginFilePath, false)
 		if err == nil || err.Error() != ErrInstallEqualVersion.Error() {
-			t.Fatalf("expecting error %v, bug got %v", ErrInstallEqualVersion, err)
+			t.Fatalf("expecting error %v, but got %v", ErrInstallEqualVersion, err)
 		}
 	})
 
@@ -232,7 +235,7 @@ func TestManager_Install(t *testing.T) {
 		}
 		_, _, err = mgr.Install(context.Background(), newPluginFilePath, false)
 		if err == nil || err.Error() != ErrInstallLowerVersion.Error() {
-			t.Fatalf("expecting error %v, bug got %v", ErrInstallLowerVersion, err)
+			t.Fatalf("expecting error %v, but got %v", ErrInstallLowerVersion, err)
 		}
 	})
 
@@ -257,7 +260,7 @@ func TestManager_Install(t *testing.T) {
 		_, _, err = mgr.Install(context.Background(), newPluginFilePath, false)
 		expectedErrorMsg := "failed to get plugin name from file path: invalid plugin executable file name. Plugin file name requires format notation-{plugin-name}, but got bar"
 		if err == nil || err.Error() != expectedErrorMsg {
-			t.Fatalf("expecting error %s, bug got %v", expectedErrorMsg, err)
+			t.Fatalf("expecting error %s, but got %v", expectedErrorMsg, err)
 		}
 	})
 
@@ -270,7 +273,7 @@ func TestManager_Install(t *testing.T) {
 		_, _, err = mgr.Install(context.Background(), newPluginFilePath, false)
 		expectedErrorMsg := "failed to create new CLI plugin: stat testdata/bar/notation-bar: no such file or directory"
 		if err == nil || err.Error() != expectedErrorMsg {
-			t.Fatalf("expecting error %s, bug got %v", expectedErrorMsg, err)
+			t.Fatalf("expecting error %s, but got %v", expectedErrorMsg, err)
 		}
 	})
 
@@ -295,7 +298,7 @@ func TestManager_Install(t *testing.T) {
 		_, _, err = mgr.Install(context.Background(), newPluginFilePath, false)
 		expectedErrorMsg := "failed to get metadata of new plugin: executable name must be \"notation-foobar\" instead of \"notation-bar\""
 		if err == nil || err.Error() != expectedErrorMsg {
-			t.Fatalf("expecting error %s, bug got %v", expectedErrorMsg, err)
+			t.Fatalf("expecting error %s, but got %v", expectedErrorMsg, err)
 		}
 	})
 
@@ -309,12 +312,15 @@ func TestManager_Install(t *testing.T) {
 		_, _, err = mgr.Install(context.Background(), newPluginFilePath, false)
 		expectedErrorMsg := "failed to get metadata of existing plugin: executable name must be \"notation-bar\" instead of \"notation-foo\""
 		if err == nil || err.Error() != expectedErrorMsg {
-			t.Fatalf("expecting error %s, bug got %v", expectedErrorMsg, err)
+			t.Fatalf("expecting error %s, but got %v", expectedErrorMsg, err)
 		}
 	})
 }
 
 func TestManager_Uninstall(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("skipping test on Windows")
+	}
 	executor = testCommander{stdout: metadataJSON(validMetadata)}
 	mgr := NewCLIManager(mockfs.NewSysFSWithRootMock(fstest.MapFS{}, "./testdata/plugins"))
 	if err := os.MkdirAll("./testdata/plugins/toUninstall", 0777); err != nil {

--- a/plugin/manager_unix.go
+++ b/plugin/manager_unix.go
@@ -16,8 +16,25 @@
 
 package plugin
 
-import "github.com/notaryproject/notation-go/plugin/proto"
+import (
+	"errors"
+	"os"
+
+	"github.com/notaryproject/notation-go/plugin/proto"
+)
 
 func binName(name string) string {
 	return proto.Prefix + name
+}
+
+// isExecutableFile checks if a file at filePath is executable
+func isExecutableFile(filePath string) (bool, error) {
+	fi, err := os.Stat(filePath)
+	if err != nil {
+		return false, err
+	}
+	if !fi.Mode().IsRegular() {
+		return false, errors.New("not regular file")
+	}
+	return fi.Mode()&0100 != 0, nil
 }

--- a/plugin/manager_unix.go
+++ b/plugin/manager_unix.go
@@ -17,7 +17,6 @@
 package plugin
 
 import (
-	"errors"
 	"os"
 
 	"github.com/notaryproject/notation-go/plugin/proto"
@@ -27,14 +26,14 @@ func binName(name string) string {
 	return proto.Prefix + name
 }
 
-// isExecutableFile checks if a file at filePath is executable
+// isExecutableFile checks if a file at filePath is user executable
 func isExecutableFile(filePath string) (bool, error) {
 	fi, err := os.Stat(filePath)
 	if err != nil {
 		return false, err
 	}
 	if !fi.Mode().IsRegular() {
-		return false, errors.New("not regular file")
+		return false, ErrNotRegularFile
 	}
 	return fi.Mode()&0100 != 0, nil
 }

--- a/plugin/manager_unix.go
+++ b/plugin/manager_unix.go
@@ -32,8 +32,9 @@ func isExecutableFile(filePath string) (bool, error) {
 	if err != nil {
 		return false, err
 	}
-	if !fi.Mode().IsRegular() {
+	mode := fi.Mode()
+	if !mode.IsRegular() {
 		return false, ErrNotRegularFile
 	}
-	return fi.Mode()&0100 != 0, nil
+	return mode.Perm()&0100 != 0, nil
 }

--- a/plugin/manager_windows.go
+++ b/plugin/manager_windows.go
@@ -13,8 +13,26 @@
 
 package plugin
 
-import "github.com/notaryproject/notation-go/plugin/proto"
+import (
+	"errors"
+	"os"
+	"path/filepath"
+
+	"github.com/notaryproject/notation-go/plugin/proto"
+)
 
 func binName(name string) string {
 	return proto.Prefix + name + ".exe"
+}
+
+// isExecutableFile checks if a file at filePath is executable
+func isExecutableFile(filePath string) (bool, error) {
+	fi, err := os.Stat(filePath)
+	if err != nil {
+		return false, err
+	}
+	if !fi.Mode().IsRegular() {
+		return false, errors.New("not regular file")
+	}
+	return filepath.Ext(filepath.Base(filePath)) == ".exe", nil
 }

--- a/plugin/manager_windows.go
+++ b/plugin/manager_windows.go
@@ -14,7 +14,6 @@
 package plugin
 
 import (
-	"errors"
 	"os"
 	"path/filepath"
 
@@ -32,7 +31,7 @@ func isExecutableFile(filePath string) (bool, error) {
 		return false, err
 	}
 	if !fi.Mode().IsRegular() {
-		return false, errors.New("not regular file")
+		return false, ErrNotRegularFile
 	}
 	return filepath.Ext(filepath.Base(filePath)) == ".exe", nil
 }

--- a/plugin/manager_windows.go
+++ b/plugin/manager_windows.go
@@ -16,6 +16,7 @@ package plugin
 import (
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/notaryproject/notation-go/plugin/proto"
 )
@@ -33,5 +34,5 @@ func isExecutableFile(filePath string) (bool, error) {
 	if !fi.Mode().IsRegular() {
 		return false, ErrNotRegularFile
 	}
-	return filepath.Ext(filepath.Base(filePath)) == ".exe", nil
+	return strings.EqualFold(filepath.Ext(filepath.Base(filePath)), ".exe"), nil
 }

--- a/plugin/plugin.go
+++ b/plugin/plugin.go
@@ -264,3 +264,16 @@ func validate(metadata *proto.GetMetadataResponse) error {
 	}
 	return nil
 }
+
+// validatePluginFileExtensionAgainstOS validates if plugin executable file
+// extension aligns with the runtime OS.
+//
+// On windows, `.exe` extension is required.
+// On other OS, MUST not have the `.exe` extension.
+func validatePluginFileExtensionAgainstOS(fileName, pluginName string) error {
+	expectedPluginFile := binName(pluginName)
+	if filepath.Ext(fileName) != filepath.Ext(expectedPluginFile) {
+		return fmt.Errorf("invalid plugin file extension. Expecting file %s, but got %s", expectedPluginFile, fileName)
+	}
+	return nil
+}

--- a/plugin/plugin.go
+++ b/plugin/plugin.go
@@ -25,7 +25,9 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 
+	"github.com/notaryproject/notation-go/internal/file"
 	"github.com/notaryproject/notation-go/internal/slices"
 	"github.com/notaryproject/notation-go/log"
 	"github.com/notaryproject/notation-go/plugin/proto"
@@ -74,7 +76,7 @@ type CLIPlugin struct {
 	path string
 }
 
-// NewCLIPlugin validate the metadata of the plugin and return a *CLIPlugin.
+// NewCLIPlugin returns a *CLIPlugin.
 func NewCLIPlugin(ctx context.Context, name, path string) (*CLIPlugin, error) {
 	// validate file existence
 	fi, err := os.Stat(path)
@@ -250,4 +252,15 @@ func validate(metadata *proto.GetMetadataResponse) error {
 		)
 	}
 	return nil
+}
+
+// ExtractPluginNameFromFileName checks if fileName is a valid plugin file name
+// and gets plugin name from it based on spec: https://github.com/notaryproject/specifications/blob/main/specs/plugin-extensibility.md#installation
+func ExtractPluginNameFromFileName(fileName string) (string, error) {
+	fname := file.FileNameWithoutExtension(fileName)
+	pluginName, found := strings.CutPrefix(fname, proto.Prefix)
+	if !found {
+		return "", fmt.Errorf("invalid plugin executable file name. Plugin file name requires format notation-{plugin-name}, but got %s", fname)
+	}
+	return pluginName, nil
 }

--- a/plugin/plugin.go
+++ b/plugin/plugin.go
@@ -225,9 +225,9 @@ func (c execCommander) Output(ctx context.Context, name string, command proto.Co
 	return stdout.Bytes(), nil, nil
 }
 
-// ExtractPluginNameFromFileName checks if fileName is a valid plugin file name
+// ParsePluginName checks if fileName is a valid plugin file name
 // and gets plugin name from it based on spec: https://github.com/notaryproject/specifications/blob/main/specs/plugin-extensibility.md#installation
-func ExtractPluginNameFromFileName(fileName string) (string, error) {
+func ParsePluginName(fileName string) (string, error) {
 	fname := file.TrimFileExtension(fileName)
 	pluginName, found := strings.CutPrefix(fname, proto.Prefix)
 	if !found {

--- a/plugin/plugin.go
+++ b/plugin/plugin.go
@@ -270,10 +270,10 @@ func validate(metadata *proto.GetMetadataResponse) error {
 //
 // On windows, `.exe` extension is required.
 // On other OS, MUST not have the `.exe` extension.
-func validatePluginFileExtensionAgainstOS(fileName string, pluginName string) error {
+func validatePluginFileExtensionAgainstOS(fileName, pluginName string) error {
 	expectedPluginFile := binName(pluginName)
 	if filepath.Ext(fileName) != filepath.Ext(expectedPluginFile) {
-		return fmt.Errorf("invalid plugin file name extension. Expecting file %s, but got %s", expectedPluginFile, fileName)
+		return fmt.Errorf("invalid plugin file extension. Expecting file %s, but got %s", expectedPluginFile, fileName)
 	}
 	return nil
 }

--- a/plugin/plugin.go
+++ b/plugin/plugin.go
@@ -228,7 +228,7 @@ func (c execCommander) Output(ctx context.Context, name string, command proto.Co
 // ExtractPluginNameFromFileName checks if fileName is a valid plugin file name
 // and gets plugin name from it based on spec: https://github.com/notaryproject/specifications/blob/main/specs/plugin-extensibility.md#installation
 func ExtractPluginNameFromFileName(fileName string) (string, error) {
-	fname := file.FileNameWithoutExtension(fileName)
+	fname := file.TrimFileExtension(fileName)
 	pluginName, found := strings.CutPrefix(fname, proto.Prefix)
 	if !found {
 		return "", fmt.Errorf("invalid plugin executable file name. Plugin file name requires format notation-{plugin-name}, but got %s", fname)

--- a/plugin/plugin.go
+++ b/plugin/plugin.go
@@ -264,16 +264,3 @@ func validate(metadata *proto.GetMetadataResponse) error {
 	}
 	return nil
 }
-
-// validatePluginFileExtensionAgainstOS validates if plugin executable file
-// extension aligns with the runtime OS.
-//
-// On windows, `.exe` extension is required.
-// On other OS, MUST not have the `.exe` extension.
-func validatePluginFileExtensionAgainstOS(fileName, pluginName string) error {
-	expectedPluginFile := binName(pluginName)
-	if filepath.Ext(fileName) != filepath.Ext(expectedPluginFile) {
-		return fmt.Errorf("invalid plugin file extension. Expecting file %s, but got %s", expectedPluginFile, fileName)
-	}
-	return nil
-}

--- a/plugin/plugin.go
+++ b/plugin/plugin.go
@@ -266,15 +266,14 @@ func validate(metadata *proto.GetMetadataResponse) error {
 }
 
 // validatePluginFileExtensionAgainstOS validates if plugin executable file
-// aligns with the runtime OS.
+// extension aligns with the runtime OS.
 //
 // On windows, `.exe` extension is required.
 // On other OS, MUST not have the `.exe` extension.
-func validatePluginFileExtensionAgainstOS(filePath string, pluginName string) error {
-	pluginFile := filepath.Base(filePath)
+func validatePluginFileExtensionAgainstOS(fileName string, pluginName string) error {
 	expectedPluginFile := binName(pluginName)
-	if filepath.Ext(pluginFile) != filepath.Ext(expectedPluginFile) {
-		return fmt.Errorf("invalid plugin file name extension. Expecting file %s, but got %s", expectedPluginFile, pluginFile)
+	if filepath.Ext(fileName) != filepath.Ext(expectedPluginFile) {
+		return fmt.Errorf("invalid plugin file name extension. Expecting file %s, but got %s", expectedPluginFile, fileName)
 	}
 	return nil
 }

--- a/plugin/plugin_test.go
+++ b/plugin/plugin_test.go
@@ -273,7 +273,7 @@ func TestNewCLIPlugin_ValidError(t *testing.T) {
 }
 
 func TestExtractPluginNameFromExecutableFileName(t *testing.T) {
-	pluginName, err := ExtractPluginNameFromFileName("notation-my-plugin")
+	pluginName, err := ParsePluginName("notation-my-plugin")
 	if err != nil {
 		t.Fatalf("expected nil err, got %v", err)
 	}
@@ -281,7 +281,7 @@ func TestExtractPluginNameFromExecutableFileName(t *testing.T) {
 		t.Fatalf("expected plugin name my-plugin, but got %s", pluginName)
 	}
 
-	pluginName, err = ExtractPluginNameFromFileName("notation-my-plugin.exe")
+	pluginName, err = ParsePluginName("notation-my-plugin.exe")
 	if err != nil {
 		t.Fatalf("expected nil err, got %v", err)
 	}
@@ -289,13 +289,13 @@ func TestExtractPluginNameFromExecutableFileName(t *testing.T) {
 		t.Fatalf("expected plugin name my-plugin, but got %s", pluginName)
 	}
 
-	_, err = ExtractPluginNameFromFileName("myPlugin")
+	_, err = ParsePluginName("myPlugin")
 	expectedErrorMsg := "invalid plugin executable file name. Plugin file name requires format notation-{plugin-name}, but got myPlugin"
 	if err == nil || err.Error() != expectedErrorMsg {
 		t.Fatalf("expected %s, got %v", expectedErrorMsg, err)
 	}
 
-	_, err = ExtractPluginNameFromFileName("my-plugin")
+	_, err = ParsePluginName("my-plugin")
 	expectedErrorMsg = "invalid plugin executable file name. Plugin file name requires format notation-{plugin-name}, but got my-plugin"
 	if err == nil || err.Error() != expectedErrorMsg {
 		t.Fatalf("expected %s, got %v", expectedErrorMsg, err)

--- a/plugin/plugin_test.go
+++ b/plugin/plugin_test.go
@@ -270,3 +270,33 @@ func TestNewCLIPlugin_ValidError(t *testing.T) {
 		}
 	})
 }
+
+func TestExtractPluginNameFromExecutableFileName(t *testing.T) {
+	pluginName, err := ExtractPluginNameFromFileName("notation-my-plugin")
+	if err != nil {
+		t.Fatalf("expected nil err, got %v", err)
+	}
+	if pluginName != "my-plugin" {
+		t.Fatalf("expected plugin name my-plugin, but got %s", pluginName)
+	}
+
+	pluginName, err = ExtractPluginNameFromFileName("notation-my-plugin.exe")
+	if err != nil {
+		t.Fatalf("expected nil err, got %v", err)
+	}
+	if pluginName != "my-plugin" {
+		t.Fatalf("expected plugin name my-plugin, but got %s", pluginName)
+	}
+
+	_, err = ExtractPluginNameFromFileName("myPlugin")
+	expectedErrorMsg := "invalid plugin executable file name. Plugin file name requires format notation-{plugin-name}, but got myPlugin"
+	if err == nil || err.Error() != expectedErrorMsg {
+		t.Fatalf("expected %s, got %v", expectedErrorMsg, err)
+	}
+
+	_, err = ExtractPluginNameFromFileName("my-plugin")
+	expectedErrorMsg = "invalid plugin executable file name. Plugin file name requires format notation-{plugin-name}, but got my-plugin"
+	if err == nil || err.Error() != expectedErrorMsg {
+		t.Fatalf("expected %s, got %v", expectedErrorMsg, err)
+	}
+}

--- a/plugin/plugin_test.go
+++ b/plugin/plugin_test.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"os"
 	"reflect"
+	"runtime"
 	"strconv"
 	"strings"
 	"testing"
@@ -298,5 +299,31 @@ func TestExtractPluginNameFromExecutableFileName(t *testing.T) {
 	expectedErrorMsg = "invalid plugin executable file name. Plugin file name requires format notation-{plugin-name}, but got my-plugin"
 	if err == nil || err.Error() != expectedErrorMsg {
 		t.Fatalf("expected %s, got %v", expectedErrorMsg, err)
+	}
+}
+
+func TestValidatePluginFileExtensionAgainstOS(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		err := validatePluginFileExtensionAgainstOS("notation-foo.exe", "foo")
+		if err != nil {
+			t.Fatalf("expecting nil error, but got %s", err)
+		}
+
+		err = validatePluginFileExtensionAgainstOS("notation-foo", "foo")
+		expectedErrorMsg := "invalid plugin file extension. Expecting file notation-foo.exe, but got notation-foo"
+		if err == nil || err.Error() != expectedErrorMsg {
+			t.Fatalf("expecting error %s, but got %v", expectedErrorMsg, err)
+		}
+		return
+	}
+	err := validatePluginFileExtensionAgainstOS("notation-foo", "foo")
+	if err != nil {
+		t.Fatalf("expecting nil error, but got %s", err)
+	}
+
+	err = validatePluginFileExtensionAgainstOS("notation-foo.exe", "foo")
+	expectedErrorMsg := "invalid plugin file extension. Expecting file notation-foo, but got notation-foo.exe"
+	if err == nil || err.Error() != expectedErrorMsg {
+		t.Fatalf("expecting error %s, but got %v", expectedErrorMsg, err)
 	}
 }

--- a/plugin/plugin_test.go
+++ b/plugin/plugin_test.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"os"
 	"reflect"
+	"runtime"
 	"strconv"
 	"strings"
 	"testing"
@@ -298,5 +299,31 @@ func TestExtractPluginNameFromExecutableFileName(t *testing.T) {
 	expectedErrorMsg = "invalid plugin executable file name. Plugin file name requires format notation-{plugin-name}, but got my-plugin"
 	if err == nil || err.Error() != expectedErrorMsg {
 		t.Fatalf("expected %s, got %v", expectedErrorMsg, err)
+	}
+}
+
+func TestValidatePluginFileExtensionAgainstOS(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		err := validatePluginFileExtensionAgainstOS("notation-foo.exe", "foo")
+		if err != nil {
+			t.Fatalf("expecting nil error, but got %s", err)
+		}
+
+		err = validatePluginFileExtensionAgainstOS("notation-foo", "foo")
+		expectedErrorMsg := "invalid plugin file name extension. Expecting file notation-foo.exe, but got notation-foo"
+		if err == nil || err.Error() != expectedErrorMsg {
+			t.Fatalf("expecting error %s, but got %v", expectedErrorMsg, err)
+		}
+		return
+	}
+	err := validatePluginFileExtensionAgainstOS("notation-foo", "foo")
+	if err != nil {
+		t.Fatalf("expecting nil error, but got %s", err)
+	}
+
+	err = validatePluginFileExtensionAgainstOS("notation-foo.exe", "foo")
+	expectedErrorMsg := "invalid plugin file name extension. Expecting file notation-foo, but got notation-foo.exe"
+	if err == nil || err.Error() != expectedErrorMsg {
+		t.Fatalf("expecting error %s, but got %v", expectedErrorMsg, err)
 	}
 }

--- a/plugin/plugin_test.go
+++ b/plugin/plugin_test.go
@@ -310,7 +310,7 @@ func TestValidatePluginFileExtensionAgainstOS(t *testing.T) {
 		}
 
 		err = validatePluginFileExtensionAgainstOS("notation-foo", "foo")
-		expectedErrorMsg := "invalid plugin file name extension. Expecting file notation-foo.exe, but got notation-foo"
+		expectedErrorMsg := "invalid plugin file extension. Expecting file notation-foo.exe, but got notation-foo"
 		if err == nil || err.Error() != expectedErrorMsg {
 			t.Fatalf("expecting error %s, but got %v", expectedErrorMsg, err)
 		}
@@ -322,7 +322,7 @@ func TestValidatePluginFileExtensionAgainstOS(t *testing.T) {
 	}
 
 	err = validatePluginFileExtensionAgainstOS("notation-foo.exe", "foo")
-	expectedErrorMsg := "invalid plugin file name extension. Expecting file notation-foo, but got notation-foo.exe"
+	expectedErrorMsg := "invalid plugin file extension. Expecting file notation-foo, but got notation-foo.exe"
 	if err == nil || err.Error() != expectedErrorMsg {
 		t.Fatalf("expecting error %s, but got %v", expectedErrorMsg, err)
 	}

--- a/plugin/plugin_test.go
+++ b/plugin/plugin_test.go
@@ -20,7 +20,6 @@ import (
 	"fmt"
 	"os"
 	"reflect"
-	"runtime"
 	"strconv"
 	"strings"
 	"testing"
@@ -299,31 +298,5 @@ func TestExtractPluginNameFromExecutableFileName(t *testing.T) {
 	expectedErrorMsg = "invalid plugin executable file name. Plugin file name requires format notation-{plugin-name}, but got my-plugin"
 	if err == nil || err.Error() != expectedErrorMsg {
 		t.Fatalf("expected %s, got %v", expectedErrorMsg, err)
-	}
-}
-
-func TestValidatePluginFileExtensionAgainstOS(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		err := validatePluginFileExtensionAgainstOS("notation-foo.exe", "foo")
-		if err != nil {
-			t.Fatalf("expecting nil error, but got %s", err)
-		}
-
-		err = validatePluginFileExtensionAgainstOS("notation-foo", "foo")
-		expectedErrorMsg := "invalid plugin file extension. Expecting file notation-foo.exe, but got notation-foo"
-		if err == nil || err.Error() != expectedErrorMsg {
-			t.Fatalf("expecting error %s, but got %v", expectedErrorMsg, err)
-		}
-		return
-	}
-	err := validatePluginFileExtensionAgainstOS("notation-foo", "foo")
-	if err != nil {
-		t.Fatalf("expecting nil error, but got %s", err)
-	}
-
-	err = validatePluginFileExtensionAgainstOS("notation-foo.exe", "foo")
-	expectedErrorMsg := "invalid plugin file extension. Expecting file notation-foo, but got notation-foo.exe"
-	if err == nil || err.Error() != expectedErrorMsg {
-		t.Fatalf("expecting error %s, but got %v", expectedErrorMsg, err)
 	}
 }

--- a/verifier/helpers.go
+++ b/verifier/helpers.go
@@ -149,7 +149,7 @@ func getVerificationPluginMinVersion(signerInfo *signature.SignerInfo) (string, 
 	if strings.TrimSpace(version) == "" {
 		return "", fmt.Errorf("%v from extended attribute is an empty string", HeaderVerificationPluginMinVersion)
 	}
-	if !notationsemver.IsSemverValid(version) {
+	if !notationsemver.IsValidSemver(version) {
 		return "", fmt.Errorf("%v from extended attribute is not a valid SemVer", HeaderVerificationPluginMinVersion)
 	}
 	return version, nil

--- a/verifier/helpers.go
+++ b/verifier/helpers.go
@@ -18,12 +18,12 @@ import (
 	"crypto/x509"
 	"errors"
 	"fmt"
-	"regexp"
 	"strings"
 
 	"github.com/notaryproject/notation-core-go/signature"
 	"github.com/notaryproject/notation-go"
 	set "github.com/notaryproject/notation-go/internal/container"
+	notationsemver "github.com/notaryproject/notation-go/internal/semver"
 	"github.com/notaryproject/notation-go/internal/slices"
 	"github.com/notaryproject/notation-go/verifier/trustpolicy"
 	"github.com/notaryproject/notation-go/verifier/truststore"
@@ -46,9 +46,6 @@ var VerificationPluginHeaders = []string{
 }
 
 var errExtendedAttributeNotExist = errors.New("extended attribute not exist")
-
-// semVerRegEx is takenfrom https://semver.org/#is-there-a-suggested-regular-expression-regex-to-check-a-semver-string
-var semVerRegEx = regexp.MustCompile(`^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$`)
 
 func loadX509TrustStores(ctx context.Context, scheme signature.SigningScheme, policy *trustpolicy.TrustPolicy, x509TrustStore truststore.X509TrustStore) ([]*x509.Certificate, error) {
 	var typeToLoad truststore.Type
@@ -152,12 +149,8 @@ func getVerificationPluginMinVersion(signerInfo *signature.SignerInfo) (string, 
 	if strings.TrimSpace(version) == "" {
 		return "", fmt.Errorf("%v from extended attribute is an empty string", HeaderVerificationPluginMinVersion)
 	}
-	if !isVersionSemverValid(version) {
+	if !notationsemver.IsVersionSemverValid(version) {
 		return "", fmt.Errorf("%v from extended attribute is not a valid SemVer", HeaderVerificationPluginMinVersion)
 	}
 	return version, nil
-}
-
-func isVersionSemverValid(version string) bool {
-	return semVerRegEx.MatchString(version)
 }

--- a/verifier/helpers.go
+++ b/verifier/helpers.go
@@ -149,7 +149,7 @@ func getVerificationPluginMinVersion(signerInfo *signature.SignerInfo) (string, 
 	if strings.TrimSpace(version) == "" {
 		return "", fmt.Errorf("%v from extended attribute is an empty string", HeaderVerificationPluginMinVersion)
 	}
-	if !notationsemver.IsVersionSemverValid(version) {
+	if !notationsemver.IsSemverValid(version) {
 		return "", fmt.Errorf("%v from extended attribute is not a valid SemVer", HeaderVerificationPluginMinVersion)
 	}
 	return version, nil

--- a/verifier/helpers.go
+++ b/verifier/helpers.go
@@ -149,7 +149,7 @@ func getVerificationPluginMinVersion(signerInfo *signature.SignerInfo) (string, 
 	if strings.TrimSpace(version) == "" {
 		return "", fmt.Errorf("%v from extended attribute is an empty string", HeaderVerificationPluginMinVersion)
 	}
-	if !notationsemver.IsValidSemver(version) {
+	if !notationsemver.IsValid(version) {
 		return "", fmt.Errorf("%v from extended attribute is not a valid SemVer", HeaderVerificationPluginMinVersion)
 	}
 	return version, nil

--- a/verifier/verifier.go
+++ b/verifier/verifier.go
@@ -232,7 +232,7 @@ func (v *verifier) processSignature(ctx context.Context, sigBlob []byte, envelop
 		pluginVersion := metadata.Version
 
 		//checking if the plugin version is in valid semver format
-		if !notationsemver.IsVersionSemverValid(pluginVersion) {
+		if !notationsemver.IsSemverValid(pluginVersion) {
 			return notation.ErrorVerificationInconclusive{Msg: fmt.Sprintf("plugin %s has pluginVersion %s which is not in valid semver format", verificationPluginName, pluginVersion)}
 		}
 

--- a/verifier/verifier.go
+++ b/verifier/verifier.go
@@ -232,7 +232,7 @@ func (v *verifier) processSignature(ctx context.Context, sigBlob []byte, envelop
 		pluginVersion := metadata.Version
 
 		//checking if the plugin version is in valid semver format
-		if !notationsemver.IsValidSemver(pluginVersion) {
+		if !notationsemver.IsValid(pluginVersion) {
 			return notation.ErrorVerificationInconclusive{Msg: fmt.Sprintf("plugin %s has pluginVersion %s which is not in valid semver format", verificationPluginName, pluginVersion)}
 		}
 

--- a/verifier/verifier.go
+++ b/verifier/verifier.go
@@ -32,6 +32,7 @@ import (
 	"github.com/notaryproject/notation-go/dir"
 	"github.com/notaryproject/notation-go/internal/envelope"
 	"github.com/notaryproject/notation-go/internal/pkix"
+	notationsemver "github.com/notaryproject/notation-go/internal/semver"
 	"github.com/notaryproject/notation-go/internal/slices"
 	trustpolicyInternal "github.com/notaryproject/notation-go/internal/trustpolicy"
 	"github.com/notaryproject/notation-go/log"
@@ -231,7 +232,7 @@ func (v *verifier) processSignature(ctx context.Context, sigBlob []byte, envelop
 		pluginVersion := metadata.Version
 
 		//checking if the plugin version is in valid semver format
-		if !isVersionSemverValid(pluginVersion) {
+		if !notationsemver.IsVersionSemverValid(pluginVersion) {
 			return notation.ErrorVerificationInconclusive{Msg: fmt.Sprintf("plugin %s has pluginVersion %s which is not in valid semver format", verificationPluginName, pluginVersion)}
 		}
 

--- a/verifier/verifier.go
+++ b/verifier/verifier.go
@@ -232,7 +232,7 @@ func (v *verifier) processSignature(ctx context.Context, sigBlob []byte, envelop
 		pluginVersion := metadata.Version
 
 		//checking if the plugin version is in valid semver format
-		if !notationsemver.IsSemverValid(pluginVersion) {
+		if !notationsemver.IsValidSemver(pluginVersion) {
 			return notation.ErrorVerificationInconclusive{Msg: fmt.Sprintf("plugin %s has pluginVersion %s which is not in valid semver format", verificationPluginName, pluginVersion)}
 		}
 


### PR DESCRIPTION
This PR adds the `Install` method to `plugin.CLIManager`.

As suggested by @shizhMSFT: 
when plugin path is a dir which contains a plugin executable file and extra files such as lib files and LICENSE files, all these files will be installed. A dir is considered a valid input if and only if `it contains one and only one valid plugin executable file named with format notaiton-{plugin-name}`. 
Note: only regular files under the dir will be installed, sub-directories are ignored.

If the input plugin path is just a single executable file, this file will be installed.

When plugin already exists:
1. If `overwrite` is set, version check is skipped. If the existing plugin is malfunctioning, directly overwrite it. If the existing plugin is valid, its plugin metadata is also returned for callers to consume.
3. If `overwrite` is not set, existing plugin MUST be valid, version check requires new plugin version MUST be higher than existing plugin version.

When plugin does not exist:
1. Directly install the new plugin from file path.