### PR TITLE
feat: plugin install iteration 2

### DIFF
--- a/plugin/manager.go
+++ b/plugin/manager.go
@@ -247,8 +247,7 @@ func parsePluginFromDir(ctx context.Context, path string) (string, string, error
 		}
 		// only take regular files
 		if info.Mode().IsRegular() {
-			candidatePluginName, err := parsePluginName(d.Name())
-			if err != nil {
+			if candidatePluginName, err = parsePluginName(d.Name()); err != nil {
 				// file name does not follow the notation-{plugin-name} format,
 				// continue
 				return nil

--- a/plugin/manager.go
+++ b/plugin/manager.go
@@ -246,7 +246,8 @@ func parsePluginFromDir(path string) (string, string, error) {
 		}
 		// only take regular files
 		if info.Mode().IsRegular() {
-			if pluginName, err = parsePluginName(d.Name()); err != nil {
+			pName, err := parsePluginName(d.Name())
+			if err != nil {
 				// file name does not follow the notation-{plugin-name} format,
 				// continue
 				return nil
@@ -264,13 +265,13 @@ func parsePluginFromDir(path string) (string, string, error) {
 			}
 			foundPluginExecutableFile = true
 			pluginExecutableFile = p
+			pluginName = pName
 		}
 		return nil
 	}); err != nil {
 		return "", "", err
 	}
 	if !foundPluginExecutableFile {
-		fmt.Println("no plugin executable file", filesWithValidNameFormat)
 		// if no executable file was found, but there's one and only one
 		// potential candidate, try install the candidate
 		if len(filesWithValidNameFormat) == 1 {

--- a/plugin/manager.go
+++ b/plugin/manager.go
@@ -127,7 +127,7 @@ func (m *CLIManager) Install(ctx context.Context, installOpts CLIInstallOptions)
 		// input is not a dir, check if it's a single plugin executable file
 		installFromNonDir = true
 		pluginExecutableFile = installOpts.PluginPath
-		pluginName, err = ParsePluginName(filepath.Base(pluginExecutableFile))
+		pluginName, err = parsePluginName(filepath.Base(pluginExecutableFile))
 		if err != nil {
 			return nil, nil, fmt.Errorf("failed to read plugin name from file path %s: %w", pluginExecutableFile, err)
 		}
@@ -140,7 +140,7 @@ func (m *CLIManager) Install(ctx context.Context, installOpts CLIInstallOptions)
 		}
 	}
 	// validate and get new plugin metadata
-	if err := validatePluginFileExtensionAgainstOS(filepath.Base(pluginExecutableFile), pluginName); err != nil {
+	if err := validatePluginFilenameAgainstOS(filepath.Base(pluginExecutableFile), pluginName); err != nil {
 		return nil, nil, err
 	}
 	newPlugin, err := NewCLIPlugin(ctx, pluginName, pluginExecutableFile)
@@ -246,7 +246,7 @@ func parsePluginFromDir(path string) (string, string, error) {
 		}
 		// only take regular files
 		if info.Mode().IsRegular() {
-			if pluginName, err = ParsePluginName(d.Name()); err != nil {
+			if pluginName, err = parsePluginName(d.Name()); err != nil {
 				// file name does not follow the notation-{plugin-name} format,
 				// continue
 				return nil

--- a/plugin/manager.go
+++ b/plugin/manager.go
@@ -270,6 +270,7 @@ func parsePluginFromDir(path string) (string, string, error) {
 		return "", "", err
 	}
 	if !foundPluginExecutableFile {
+		fmt.Println("no plugin executable file", filesWithValidNameFormat)
 		// if no executable file was found, but there's one and only one
 		// potential candidate, try install the candidate
 		if len(filesWithValidNameFormat) == 1 {

--- a/plugin/manager.go
+++ b/plugin/manager.go
@@ -279,7 +279,7 @@ func parsePluginFromDir(ctx context.Context, path string) (string, string, error
 			if err := setExecutable(candidate); err != nil {
 				return "", "", fmt.Errorf("no plugin executable file was found: %w", err)
 			}
-			logger.Warnf("Found candidate plugin executable file %q without executable permission. Setting user executable bit and try install.", filepath.Base(candidate))
+			logger.Warnf("Found candidate plugin executable file %q without executable permission. Setting user executable bit and trying to install.", filepath.Base(candidate))
 			return candidate, candidatePluginName, nil
 		}
 		return "", "", errors.New("no plugin executable file was found")

--- a/plugin/manager.go
+++ b/plugin/manager.go
@@ -122,21 +122,21 @@ func (m *CLIManager) Install(ctx context.Context, installOpts CLIInstallOptions)
 	pluginExecutableFile, pluginName, err := parsePluginFromDir(installOpts.PluginPath)
 	if err != nil {
 		if !errors.Is(err, file.ErrNotDirectory) {
-			return nil, nil, fmt.Errorf("failed to read plugin from directory %s: %w", installOpts.PluginPath, err)
+			return nil, nil, fmt.Errorf("failed to read plugin from input directory: %w", err)
 		}
 		// input is not a dir, check if it's a single plugin executable file
 		installFromNonDir = true
 		pluginExecutableFile = installOpts.PluginPath
 		pluginName, err = parsePluginName(filepath.Base(pluginExecutableFile))
 		if err != nil {
-			return nil, nil, fmt.Errorf("failed to read plugin name from file path %s: %w", pluginExecutableFile, err)
+			return nil, nil, fmt.Errorf("failed to read plugin name from input file: %w", err)
 		}
 		isExec, err := isExecutableFile(pluginExecutableFile)
 		if err != nil {
-			return nil, nil, fmt.Errorf("failed to check if file %s is executable: %w", pluginExecutableFile, err)
+			return nil, nil, fmt.Errorf("failed to check if input file is executable: %w", err)
 		}
 		if !isExec {
-			return nil, nil, fmt.Errorf("file %s is not executable", pluginExecutableFile)
+			return nil, nil, errors.New("input file is not executable")
 		}
 	}
 	// validate and get new plugin metadata

--- a/plugin/manager.go
+++ b/plugin/manager.go
@@ -130,16 +130,17 @@ func (m *CLIManager) Install(ctx context.Context, installOpts CLIInstallOptions)
 		// input is not a dir, check if it's a single plugin executable file
 		installFromNonDir = true
 		pluginExecutableFile = installOpts.PluginPath
-		pluginName, err = parsePluginName(filepath.Base(pluginExecutableFile))
+		pluginExecutableFileName := filepath.Base(pluginExecutableFile)
+		pluginName, err = parsePluginName(pluginExecutableFileName)
 		if err != nil {
-			return nil, nil, fmt.Errorf("failed to read plugin name from input file: %w", err)
+			return nil, nil, fmt.Errorf("failed to read plugin name from input file %s: %w", pluginExecutableFileName, err)
 		}
 		isExec, err := isExecutableFile(pluginExecutableFile)
 		if err != nil {
-			return nil, nil, fmt.Errorf("failed to check if input file is executable: %w", err)
+			return nil, nil, fmt.Errorf("failed to check if input file %s is executable: %w", pluginExecutableFileName, err)
 		}
 		if !isExec {
-			return nil, nil, errors.New("input file is not executable")
+			return nil, nil, fmt.Errorf("input file %s is not executable", pluginExecutableFileName)
 		}
 	}
 	// validate and get new plugin metadata

--- a/plugin/manager.go
+++ b/plugin/manager.go
@@ -140,6 +140,7 @@ func (m *CLIManager) Install(ctx context.Context, installOpts CLIInstallOptions)
 		}
 	}
 	// validate and get new plugin metadata
+	fmt.Println(pluginExecutableFile, pluginName)
 	newPlugin, err := NewCLIPlugin(ctx, pluginName, pluginExecutableFile)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to create new CLI plugin: %w", err)

--- a/plugin/manager.go
+++ b/plugin/manager.go
@@ -140,7 +140,7 @@ func (m *CLIManager) Install(ctx context.Context, installOpts CLIInstallOptions)
 		}
 	}
 	// validate and get new plugin metadata
-	if err := validatePluginFilenameAgainstOS(filepath.Base(pluginExecutableFile), pluginName); err != nil {
+	if err := validatePluginFileExtensionAgainstOS(filepath.Base(pluginExecutableFile)); err != nil {
 		return nil, nil, err
 	}
 	newPlugin, err := NewCLIPlugin(ctx, pluginName, pluginExecutableFile)

--- a/plugin/manager.go
+++ b/plugin/manager.go
@@ -279,7 +279,7 @@ func parsePluginFromDir(ctx context.Context, path string) (string, string, error
 			if err := setExecutable(candidate); err != nil {
 				return "", "", fmt.Errorf("no plugin executable file was found: %w", err)
 			}
-			logger.Warnf("Found candidate plugin executable file %q without executable permission. Setting user executable bit and try install.", candidate)
+			logger.Warnf("Found candidate plugin executable file %q without executable permission. Setting user executable bit and try install.", filepath.Base(candidate))
 			return candidate, candidatePluginName, nil
 		}
 		return "", "", errors.New("no plugin executable file was found")

--- a/plugin/manager.go
+++ b/plugin/manager.go
@@ -276,11 +276,7 @@ func parsePluginFromDir(ctx context.Context, path string) (string, string, error
 		// potential candidate, try install the candidate
 		if len(filesWithValidNameFormat) == 1 {
 			candidate := filesWithValidNameFormat[0]
-			candidateInfo, err := os.Stat(candidate)
-			if err != nil {
-				return "", "", fmt.Errorf("no plugin executable file was found: %w", err)
-			}
-			if err := os.Chmod(candidate, candidateInfo.Mode()|os.FileMode(0100)); err != nil {
+			if err := setExecutable(candidate); err != nil {
 				return "", "", fmt.Errorf("no plugin executable file was found: %w", err)
 			}
 			logger.Warnf("Found candidate plugin executable file %q without executable permission. Setting user executable bit and try install.", candidate)

--- a/plugin/manager.go
+++ b/plugin/manager.go
@@ -115,10 +115,12 @@ type CLIInstallOptions struct {
 // plugin is malfunctioning, it will be overwritten.
 func (m *CLIManager) Install(ctx context.Context, installOpts CLIInstallOptions) (*proto.GetMetadataResponse, *proto.GetMetadataResponse, error) {
 	// initialization
+	logger := log.GetLogger(ctx)
 	overwrite := installOpts.Overwrite
 	if installOpts.PluginPath == "" {
 		return nil, nil, errors.New("plugin source path cannot be empty")
 	}
+	logger.Debugf("Installing plugin from plugin path %s", installOpts.PluginPath)
 	var installFromNonDir bool
 	pluginExecutableFile, pluginName, err := parsePluginFromDir(ctx, installOpts.PluginPath)
 	if err != nil {

--- a/plugin/manager_test.go
+++ b/plugin/manager_test.go
@@ -265,7 +265,7 @@ func TestManager_Install(t *testing.T) {
 		installOpts := CLIInstallOptions{
 			PluginPath: newPluginFilePath,
 		}
-		expectedErrorMsg := "failed to read plugin name from file path testdata/bar/bar: invalid plugin executable file name. Plugin file name requires format notation-{plugin-name}, but got bar"
+		expectedErrorMsg := "failed to read plugin name from file input file: invalid plugin executable file name. Plugin file name requires format notation-{plugin-name}, but got bar"
 		_, _, err := mgr.Install(context.Background(), installOpts)
 		if err == nil || err.Error() != expectedErrorMsg {
 			t.Fatalf("expecting error %s, but got %v", expectedErrorMsg, err)
@@ -289,7 +289,7 @@ func TestManager_Install(t *testing.T) {
 		installOpts := CLIInstallOptions{
 			PluginPath: newPluginFilePath,
 		}
-		expectedErrorMsg := "file testdata/bar/notation-bar is not executable"
+		expectedErrorMsg := "input file is not executable"
 		_, _, err := mgr.Install(context.Background(), installOpts)
 		if err == nil || err.Error() != expectedErrorMsg {
 			t.Fatalf("expecting error %s, but got %v", expectedErrorMsg, err)
@@ -313,7 +313,7 @@ func TestManager_Install(t *testing.T) {
 		installOpts := CLIInstallOptions{
 			PluginPath: newPluginFilePath,
 		}
-		expectedErrorMsg := "invalid plugin file extension. On OS other than windows, plugin executable file cannot have '.exe' file extension"
+		expectedErrorMsg := "invalid plugin file extension. On OS other than Windows, plugin executable file cannot have '.exe' file extension"
 		_, _, err := mgr.Install(context.Background(), installOpts)
 		if err == nil || err.Error() != expectedErrorMsg {
 			t.Fatalf("expecting error %s, but got %v", expectedErrorMsg, err)
@@ -329,7 +329,7 @@ func TestManager_Install(t *testing.T) {
 		installOpts := CLIInstallOptions{
 			PluginPath: newPluginFilePath,
 		}
-		expectedErrorMsg := "failed to read plugin from directory testdata/bar/notation-bar: stat testdata/bar/notation-bar: no such file or directory"
+		expectedErrorMsg := "failed to read plugin from input directory: stat testdata/bar/notation-bar: no such file or directory"
 		_, _, err := mgr.Install(context.Background(), installOpts)
 		if err == nil || err.Error() != expectedErrorMsg {
 			t.Fatalf("expecting error %s, but got %v", expectedErrorMsg, err)
@@ -450,7 +450,7 @@ func TestManager_Install(t *testing.T) {
 		installOpts := CLIInstallOptions{
 			PluginPath: newPluginDir,
 		}
-		expectedErrorMsg := "failed to read plugin from directory testdata/foo: no plugin executable file was found"
+		expectedErrorMsg := "failed to read plugin from input directory: no plugin executable file was found"
 		_, _, err := mgr.Install(context.Background(), installOpts)
 		if err == nil || err.Error() != expectedErrorMsg {
 			t.Fatalf("expecting error %s, but got %v", expectedErrorMsg, err)
@@ -481,7 +481,7 @@ func TestManager_Install(t *testing.T) {
 		installOpts := CLIInstallOptions{
 			PluginPath: newPluginDir,
 		}
-		expectedErrorMsg := "failed to read plugin from directory testdata/foo: found more than one plugin executable files"
+		expectedErrorMsg := "failed to read plugin from input directory: found more than one plugin executable files"
 		_, _, err := mgr.Install(context.Background(), installOpts)
 		if err == nil || err.Error() != expectedErrorMsg {
 			t.Fatalf("expecting error %s, but got %v", expectedErrorMsg, err)
@@ -565,7 +565,7 @@ func TestValidatePluginFileExtensionAgainstOS(t *testing.T) {
 		}
 
 		err = validatePluginFileExtensionAgainstOS("notation-foo")
-		expectedErrorMsg := "invalid plugin file extension. On windows, plugin executable file MUST have '.exe' file extension"
+		expectedErrorMsg := "invalid plugin file extension. On Windows, plugin executable file MUST have '.exe' file extension"
 		if err == nil || err.Error() != expectedErrorMsg {
 			t.Fatalf("expecting error %s, but got %v", expectedErrorMsg, err)
 		}
@@ -576,7 +576,7 @@ func TestValidatePluginFileExtensionAgainstOS(t *testing.T) {
 		}
 
 		err = validatePluginFileExtensionAgainstOS("notation-foo.exe")
-		expectedErrorMsg := "invalid plugin file extension. On OS other than windows, plugin executable file cannot have '.exe' file extension"
+		expectedErrorMsg := "invalid plugin file extension. On OS other than Windows, plugin executable file cannot have '.exe' file extension"
 		if err == nil || err.Error() != expectedErrorMsg {
 			t.Fatalf("expecting error %s, but got %v", expectedErrorMsg, err)
 		}

--- a/plugin/manager_test.go
+++ b/plugin/manager_test.go
@@ -307,6 +307,30 @@ func TestManager_Install(t *testing.T) {
 		}
 	})
 
+	t.Run("fail to install due to plugin executable file name missing plugin name", func(t *testing.T) {
+		newPluginFilePath := "testdata/bar/notaiton-"
+		newPluginDir := filepath.Dir(newPluginFilePath)
+		if err := os.MkdirAll(newPluginDir, 0777); err != nil {
+			t.Fatalf("failed to create %s: %v", newPluginDir, err)
+		}
+		defer os.RemoveAll(newPluginDir)
+		if err := createFileAndChmod(newPluginFilePath, 0700); err != nil {
+			t.Fatal(err)
+		}
+		executor = testInstallCommander{
+			newPluginFilePath: newPluginFilePath,
+			newPluginStdout:   metadataJSON(validMetadataBar),
+		}
+		installOpts := CLIInstallOptions{
+			PluginPath: newPluginFilePath,
+		}
+		expectedErrorMsg := "invalid plugin executable file name. Plugin file name requires format notation-{plugin-name}, but got notation-"
+		_, _, err := mgr.Install(context.Background(), installOpts)
+		if err == nil || err.Error() != expectedErrorMsg {
+			t.Fatalf("expecting error %s, but got %v", expectedErrorMsg, err)
+		}
+	})
+
 	t.Run("fail to install due to wrong plugin file permission", func(t *testing.T) {
 		newPluginFilePath := "testdata/bar/notation-bar"
 		newPluginDir := filepath.Dir(newPluginFilePath)

--- a/plugin/manager_test.go
+++ b/plugin/manager_test.go
@@ -300,7 +300,7 @@ func TestManager_Install(t *testing.T) {
 		installOpts := CLIInstallOptions{
 			PluginPath: newPluginFilePath,
 		}
-		expectedErrorMsg := "failed to read plugin name from input file: invalid plugin executable file name. Plugin file name requires format notation-{plugin-name}, but got bar"
+		expectedErrorMsg := "failed to read plugin name from input file bar: invalid plugin executable file name. Plugin file name requires format notation-{plugin-name}, but got bar"
 		_, _, err := mgr.Install(context.Background(), installOpts)
 		if err == nil || err.Error() != expectedErrorMsg {
 			t.Fatalf("expecting error %s, but got %v", expectedErrorMsg, err)
@@ -324,7 +324,7 @@ func TestManager_Install(t *testing.T) {
 		installOpts := CLIInstallOptions{
 			PluginPath: newPluginFilePath,
 		}
-		expectedErrorMsg := "failed to read plugin name from input file: invalid plugin executable file name. Plugin file name requires format notation-{plugin-name}, but got notation-"
+		expectedErrorMsg := "failed to read plugin name from input file notation-: invalid plugin executable file name. Plugin file name requires format notation-{plugin-name}, but got notation-"
 		_, _, err := mgr.Install(context.Background(), installOpts)
 		if err == nil || err.Error() != expectedErrorMsg {
 			t.Fatalf("expecting error %s, but got %v", expectedErrorMsg, err)
@@ -348,7 +348,7 @@ func TestManager_Install(t *testing.T) {
 		installOpts := CLIInstallOptions{
 			PluginPath: newPluginFilePath,
 		}
-		expectedErrorMsg := "input file is not executable"
+		expectedErrorMsg := "input file notation-bar is not executable"
 		_, _, err := mgr.Install(context.Background(), installOpts)
 		if err == nil || err.Error() != expectedErrorMsg {
 			t.Fatalf("expecting error %s, but got %v", expectedErrorMsg, err)

--- a/plugin/manager_test.go
+++ b/plugin/manager_test.go
@@ -595,39 +595,65 @@ func TestManager_Uninstall(t *testing.T) {
 func TestParsePluginName(t *testing.T) {
 	pluginName, err := parsePluginName("notation-my-plugin")
 	if err != nil {
-		t.Fatalf("expected nil err, got %v", err)
+		t.Fatalf("expected nil err, but got %v", err)
 	}
 	if pluginName != "my-plugin" {
 		t.Fatalf("expected plugin name my-plugin, but got %s", pluginName)
 	}
 
-	_, err = parsePluginName("myPlugin")
-	expectedErrorMsg := "invalid plugin executable file name. Plugin file name requires format notation-{plugin-name}, but got myPlugin"
-	if err == nil || err.Error() != expectedErrorMsg {
-		t.Fatalf("expected %s, got %v", expectedErrorMsg, err)
-	}
-
-	_, err = parsePluginName("my-plugin")
-	expectedErrorMsg = "invalid plugin executable file name. Plugin file name requires format notation-{plugin-name}, but got my-plugin"
-	if err == nil || err.Error() != expectedErrorMsg {
-		t.Fatalf("expected %s, got %v", expectedErrorMsg, err)
-	}
-
 	if runtime.GOOS == "windows" {
 		pluginName, err = parsePluginName("notation-my-plugin.exe")
 		if err != nil {
-			t.Fatalf("expected nil err, got %v", err)
+			t.Fatalf("expected nil err, but got %v", err)
 		}
 		if pluginName != "my-plugin" {
 			t.Fatalf("expected plugin name my-plugin, but got %s", pluginName)
 		}
+
+		pluginName, err = parsePluginName("notation-com.plugin")
+		if err != nil {
+			t.Fatalf("expected nil err, but got %v", err)
+		}
+		if pluginName != "com.plugin" {
+			t.Fatalf("expected plugin name com.plugin, but got %s", pluginName)
+		}
+
+		expectedErrorMsg := "invalid plugin executable file name. Plugin file name requires format notation-{plugin-name}.exe, but got my-plugin.exe"
+		_, err = parsePluginName("my-plugin.exe")
+		if err == nil || err.Error() != expectedErrorMsg {
+			t.Fatalf("expected %s, but got %v", expectedErrorMsg, err)
+		}
+
+		expectedErrorMsg = "invalid plugin executable file name. Plugin file name requires format notation-{plugin-name}.exe, but got notation-.exe"
+		_, err = parsePluginName("notation-.exe")
+		if err == nil || err.Error() != expectedErrorMsg {
+			t.Fatalf("expected %s, but got %v", expectedErrorMsg, err)
+		}
 	} else {
 		pluginName, err = parsePluginName("notation-com.example.plugin")
 		if err != nil {
-			t.Fatalf("expected nil err, got %v", err)
+			t.Fatalf("expected nil err, but got %v", err)
 		}
 		if pluginName != "com.example.plugin" {
 			t.Fatalf("expected plugin name com.example.plugin, but got %s", pluginName)
+		}
+
+		expectedErrorMsg := "invalid plugin executable file name. Plugin file name requires format notation-{plugin-name}, but got myPlugin"
+		_, err = parsePluginName("myPlugin")
+		if err == nil || err.Error() != expectedErrorMsg {
+			t.Fatalf("expected %s, but got %v", expectedErrorMsg, err)
+		}
+
+		expectedErrorMsg = "invalid plugin executable file name. Plugin file name requires format notation-{plugin-name}, but got my-plugin"
+		_, err = parsePluginName("my-plugin")
+		if err == nil || err.Error() != expectedErrorMsg {
+			t.Fatalf("expected %s, but got %v", expectedErrorMsg, err)
+		}
+
+		expectedErrorMsg = "invalid plugin executable file name. Plugin file name requires format notation-{plugin-name}, but got notation-"
+		_, err = parsePluginName("notation-")
+		if err == nil || err.Error() != expectedErrorMsg {
+			t.Fatalf("expected %s, but got %v", expectedErrorMsg, err)
 		}
 	}
 }

--- a/plugin/manager_test.go
+++ b/plugin/manager_test.go
@@ -629,6 +629,12 @@ func TestParsePluginName(t *testing.T) {
 		if err == nil || err.Error() != expectedErrorMsg {
 			t.Fatalf("expected %s, but got %v", expectedErrorMsg, err)
 		}
+
+		expectedErrorMsg = "invalid plugin executable file name. Plugin file name requires format notation-{plugin-name}.exe, but got my-plugin"
+		_, err = parsePluginName("my-plugin")
+		if err == nil || err.Error() != expectedErrorMsg {
+			t.Fatalf("expected %s, but got %v", expectedErrorMsg, err)
+		}
 	} else {
 		pluginName, err = parsePluginName("notation-com.example.plugin")
 		if err != nil {

--- a/plugin/manager_test.go
+++ b/plugin/manager_test.go
@@ -432,7 +432,7 @@ func TestManager_Install(t *testing.T) {
 	t.Run("success to install from plugin dir", func(t *testing.T) {
 		existedPluginFilePath := "testdata/plugins/foo/notation-foo"
 		newPluginFilePath := "testdata/foo/notation-foo"
-		newPluginLibPath := "testdata/foo/notation-libfoo"
+		newPluginLibPath := "testdata/foo/libfoo"
 		newPluginDir := filepath.Dir(newPluginFilePath)
 		if err := os.MkdirAll(newPluginDir, 0777); err != nil {
 			t.Fatalf("failed to create %s: %v", newPluginDir, err)

--- a/plugin/manager_test.go
+++ b/plugin/manager_test.go
@@ -593,16 +593,8 @@ func TestManager_Uninstall(t *testing.T) {
 }
 
 func TestParsePluginName(t *testing.T) {
-	pluginName, err := parsePluginName("notation-my-plugin")
-	if err != nil {
-		t.Fatalf("expected nil err, but got %v", err)
-	}
-	if pluginName != "my-plugin" {
-		t.Fatalf("expected plugin name my-plugin, but got %s", pluginName)
-	}
-
 	if runtime.GOOS == "windows" {
-		pluginName, err = parsePluginName("notation-my-plugin.exe")
+		pluginName, err := parsePluginName("notation-my-plugin.exe")
 		if err != nil {
 			t.Fatalf("expected nil err, but got %v", err)
 		}
@@ -610,15 +602,13 @@ func TestParsePluginName(t *testing.T) {
 			t.Fatalf("expected plugin name my-plugin, but got %s", pluginName)
 		}
 
-		pluginName, err = parsePluginName("notation-com.plugin")
-		if err != nil {
-			t.Fatalf("expected nil err, but got %v", err)
-		}
-		if pluginName != "com.plugin" {
-			t.Fatalf("expected plugin name com.plugin, but got %s", pluginName)
+		expectedErrorMsg := "invalid plugin executable file name. Plugin file name requires format notation-{plugin-name}.exe, but got notation-com.plugin"
+		_, err = parsePluginName("notation-com.plugin")
+		if err == nil || err.Error() != expectedErrorMsg {
+			t.Fatalf("expected %s, but got %v", expectedErrorMsg, err)
 		}
 
-		expectedErrorMsg := "invalid plugin executable file name. Plugin file name requires format notation-{plugin-name}.exe, but got my-plugin.exe"
+		expectedErrorMsg = "invalid plugin executable file name. Plugin file name requires format notation-{plugin-name}.exe, but got my-plugin.exe"
 		_, err = parsePluginName("my-plugin.exe")
 		if err == nil || err.Error() != expectedErrorMsg {
 			t.Fatalf("expected %s, but got %v", expectedErrorMsg, err)
@@ -636,6 +626,14 @@ func TestParsePluginName(t *testing.T) {
 			t.Fatalf("expected %s, but got %v", expectedErrorMsg, err)
 		}
 	} else {
+		pluginName, err := parsePluginName("notation-my-plugin")
+		if err != nil {
+			t.Fatalf("expected nil err, but got %v", err)
+		}
+		if pluginName != "my-plugin" {
+			t.Fatalf("expected plugin name my-plugin, but got %s", pluginName)
+		}
+
 		pluginName, err = parsePluginName("notation-com.example.plugin")
 		if err != nil {
 			t.Fatalf("expected nil err, but got %v", err)

--- a/plugin/manager_test.go
+++ b/plugin/manager_test.go
@@ -265,7 +265,7 @@ func TestManager_Install(t *testing.T) {
 		installOpts := CLIInstallOptions{
 			PluginPath: newPluginFilePath,
 		}
-		expectedErrorMsg := "failed to read plugin name from file input file: invalid plugin executable file name. Plugin file name requires format notation-{plugin-name}, but got bar"
+		expectedErrorMsg := "failed to read plugin name from input file: invalid plugin executable file name. Plugin file name requires format notation-{plugin-name}, but got bar"
 		_, _, err := mgr.Install(context.Background(), installOpts)
 		if err == nil || err.Error() != expectedErrorMsg {
 			t.Fatalf("expecting error %s, but got %v", expectedErrorMsg, err)

--- a/plugin/manager_test.go
+++ b/plugin/manager_test.go
@@ -465,7 +465,7 @@ func TestManager_Install(t *testing.T) {
 		}
 	})
 
-	t.Run("success to install from plugin dir with one and only one valid candidate and no executable file", func(t *testing.T) {
+	t.Run("success to install from plugin dir with no executable file and one valid candidate file", func(t *testing.T) {
 		existedPluginFilePath := "testdata/plugins/foo/notation-foo"
 		newPluginFilePath := "testdata/foo/notation-foo"
 		newPluginLibPath := "testdata/foo/libfoo"
@@ -501,15 +501,19 @@ func TestManager_Install(t *testing.T) {
 		}
 	})
 
-	t.Run("fail to install from plugin dir due to no plugin executable file", func(t *testing.T) {
+	t.Run("fail to install from plugin dir due to more than one candidate plugin executable files", func(t *testing.T) {
 		existedPluginFilePath := "testdata/plugins/foo/notation-foo"
-		newPluginFilePath := "testdata/foo/foo"
+		newPluginFilePath := "testdata/foo/notation-foo1"
+		newPluginFilePath2 := "testdata/foo/notation-foo2"
 		newPluginDir := filepath.Dir(newPluginFilePath)
 		if err := os.MkdirAll(newPluginDir, 0777); err != nil {
 			t.Fatalf("failed to create %s: %v", newPluginDir, err)
 		}
 		defer os.RemoveAll(newPluginDir)
-		if err := createFileAndChmod(newPluginFilePath, 0700); err != nil {
+		if err := createFileAndChmod(newPluginFilePath, 0600); err != nil {
+			t.Fatal(err)
+		}
+		if err := createFileAndChmod(newPluginFilePath2, 0600); err != nil {
 			t.Fatal(err)
 		}
 		executor = testInstallCommander{

--- a/plugin/manager_test.go
+++ b/plugin/manager_test.go
@@ -432,7 +432,7 @@ func TestManager_Install(t *testing.T) {
 	t.Run("success to install from plugin dir", func(t *testing.T) {
 		existedPluginFilePath := "testdata/plugins/foo/notation-foo"
 		newPluginFilePath := "testdata/foo/notation-foo"
-		newPluginLibPath := "testdata/foo/libfoo"
+		newPluginLibPath := "testdata/foo/notation-libfoo"
 		newPluginDir := filepath.Dir(newPluginFilePath)
 		if err := os.MkdirAll(newPluginDir, 0777); err != nil {
 			t.Fatalf("failed to create %s: %v", newPluginDir, err)

--- a/plugin/manager_test.go
+++ b/plugin/manager_test.go
@@ -324,7 +324,7 @@ func TestManager_Install(t *testing.T) {
 		installOpts := CLIInstallOptions{
 			PluginPath: newPluginFilePath,
 		}
-		expectedErrorMsg := "invalid plugin executable file name. Plugin file name requires format notation-{plugin-name}, but got notation-"
+		expectedErrorMsg := "failed to read plugin name from input file: invalid plugin executable file name. Plugin file name requires format notation-{plugin-name}, but got notation-"
 		_, _, err := mgr.Install(context.Background(), installOpts)
 		if err == nil || err.Error() != expectedErrorMsg {
 			t.Fatalf("expecting error %s, but got %v", expectedErrorMsg, err)

--- a/plugin/manager_test.go
+++ b/plugin/manager_test.go
@@ -308,7 +308,7 @@ func TestManager_Install(t *testing.T) {
 	})
 
 	t.Run("fail to install due to plugin executable file name missing plugin name", func(t *testing.T) {
-		newPluginFilePath := "testdata/bar/notaiton-"
+		newPluginFilePath := "testdata/bar/notation-"
 		newPluginDir := filepath.Dir(newPluginFilePath)
 		if err := os.MkdirAll(newPluginDir, 0777); err != nil {
 			t.Fatalf("failed to create %s: %v", newPluginDir, err)

--- a/plugin/manager_test.go
+++ b/plugin/manager_test.go
@@ -355,30 +355,6 @@ func TestManager_Install(t *testing.T) {
 		}
 	})
 
-	t.Run("fail to install due to invalid new plugin file extension", func(t *testing.T) {
-		newPluginFilePath := "testdata/bar/notation-bar.exe"
-		newPluginDir := filepath.Dir(newPluginFilePath)
-		if err := os.MkdirAll(newPluginDir, 0777); err != nil {
-			t.Fatalf("failed to create %s: %v", newPluginDir, err)
-		}
-		defer os.RemoveAll(newPluginDir)
-		if err := createFileAndChmod(newPluginFilePath, 0700); err != nil {
-			t.Fatal(err)
-		}
-		executor = testInstallCommander{
-			newPluginFilePath: newPluginFilePath,
-			newPluginStdout:   metadataJSON(validMetadataBar),
-		}
-		installOpts := CLIInstallOptions{
-			PluginPath: newPluginFilePath,
-		}
-		expectedErrorMsg := "invalid plugin file extension. On OS other than Windows, plugin executable file cannot have '.exe' file extension"
-		_, _, err := mgr.Install(context.Background(), installOpts)
-		if err == nil || err.Error() != expectedErrorMsg {
-			t.Fatalf("expecting error %s, but got %v", expectedErrorMsg, err)
-		}
-	})
-
 	t.Run("fail to install due to new plugin executable file does not exist", func(t *testing.T) {
 		newPluginFilePath := "testdata/bar/notation-bar"
 		executor = testInstallCommander{
@@ -612,32 +588,6 @@ func TestParsePluginName(t *testing.T) {
 		}
 		if pluginName != "com.example.plugin" {
 			t.Fatalf("expected plugin name com.example.plugin, but got %s", pluginName)
-		}
-	}
-}
-
-func TestValidatePluginFileExtensionAgainstOS(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		err := validatePluginFileExtensionAgainstOS("notation-foo.exe")
-		if err != nil {
-			t.Fatalf("expecting nil error, but got %s", err)
-		}
-
-		err = validatePluginFileExtensionAgainstOS("notation-foo")
-		expectedErrorMsg := "invalid plugin file extension. On Windows, plugin executable file MUST have '.exe' file extension"
-		if err == nil || err.Error() != expectedErrorMsg {
-			t.Fatalf("expecting error %s, but got %v", expectedErrorMsg, err)
-		}
-	} else {
-		err := validatePluginFileExtensionAgainstOS("notation-foo")
-		if err != nil {
-			t.Fatalf("expecting nil error, but got %s", err)
-		}
-
-		err = validatePluginFileExtensionAgainstOS("notation-foo.exe")
-		expectedErrorMsg := "invalid plugin file extension. On OS other than Windows, plugin executable file cannot have '.exe' file extension"
-		if err == nil || err.Error() != expectedErrorMsg {
-			t.Fatalf("expecting error %s, but got %v", expectedErrorMsg, err)
 		}
 	}
 }

--- a/plugin/manager_unix.go
+++ b/plugin/manager_unix.go
@@ -47,7 +47,7 @@ func isExecutableFile(filePath string) (bool, error) {
 // and gets plugin name from it based on spec: https://github.com/notaryproject/specifications/blob/main/specs/plugin-extensibility.md#installation
 func parsePluginName(fileName string) (string, error) {
 	pluginName, found := strings.CutPrefix(fileName, proto.Prefix)
-	if !found {
+	if !found || pluginName == "" {
 		return "", fmt.Errorf("invalid plugin executable file name. Plugin file name requires format notation-{plugin-name}, but got %s", fileName)
 	}
 	return pluginName, nil

--- a/plugin/manager_unix.go
+++ b/plugin/manager_unix.go
@@ -17,7 +17,9 @@
 package plugin
 
 import (
+	"fmt"
 	"os"
+	"strings"
 
 	"github.com/notaryproject/notation-go/plugin/proto"
 )
@@ -37,4 +39,14 @@ func isExecutableFile(filePath string) (bool, error) {
 		return false, ErrNotRegularFile
 	}
 	return mode.Perm()&0100 != 0, nil
+}
+
+// parsePluginName checks if fileName is a valid plugin file name
+// and gets plugin name from it based on spec: https://github.com/notaryproject/specifications/blob/main/specs/plugin-extensibility.md#installation
+func parsePluginName(fileName string) (string, error) {
+	pluginName, found := strings.CutPrefix(fname, proto.Prefix)
+	if !found {
+		return "", fmt.Errorf("invalid plugin executable file name. Plugin file name requires format notation-{plugin-name}, but got %s", fname)
+	}
+	return pluginName, nil
 }

--- a/plugin/manager_unix.go
+++ b/plugin/manager_unix.go
@@ -17,10 +17,8 @@
 package plugin
 
 import (
-	"errors"
 	"fmt"
 	"os"
-	"path/filepath"
 	"strings"
 
 	"github.com/notaryproject/notation-go/plugin/proto"
@@ -51,16 +49,4 @@ func parsePluginName(fileName string) (string, error) {
 		return "", fmt.Errorf("invalid plugin executable file name. Plugin file name requires format notation-{plugin-name}, but got %s", fileName)
 	}
 	return pluginName, nil
-}
-
-// validatePluginFileExtensionAgainstOS validates if plugin executable file
-// name aligns with the runtime OS.
-//
-// On windows, `.exe` extension is required.
-// On other OS, MUST NOT have the `.exe` extension.
-func validatePluginFileExtensionAgainstOS(fileName string) error {
-	if strings.EqualFold(filepath.Ext(fileName), ".exe") {
-		return errors.New("invalid plugin file extension. On OS other than Windows, plugin executable file cannot have '.exe' file extension")
-	}
-	return nil
 }

--- a/plugin/manager_unix.go
+++ b/plugin/manager_unix.go
@@ -38,7 +38,6 @@ func isExecutableFile(filePath string) (bool, error) {
 	if !mode.IsRegular() {
 		return false, ErrNotRegularFile
 	}
-	fmt.Println(fi.Name(), mode.Perm())
 	return mode.Perm()&0100 != 0, nil
 }
 

--- a/plugin/manager_unix.go
+++ b/plugin/manager_unix.go
@@ -60,7 +60,7 @@ func parsePluginName(fileName string) (string, error) {
 // On other OS, MUST NOT have the `.exe` extension.
 func validatePluginFileExtensionAgainstOS(fileName string) error {
 	if strings.EqualFold(filepath.Ext(fileName), ".exe") {
-		return errors.New("invalid plugin file extension. On OS other than windows, plugin executable file cannot have '.exe' file extension")
+		return errors.New("invalid plugin file extension. On OS other than Windows, plugin executable file cannot have '.exe' file extension")
 	}
 	return nil
 }

--- a/plugin/manager_unix.go
+++ b/plugin/manager_unix.go
@@ -38,6 +38,7 @@ func isExecutableFile(filePath string) (bool, error) {
 	if !mode.IsRegular() {
 		return false, ErrNotRegularFile
 	}
+	fmt.Println(fi.Name(), mode.Perm())
 	return mode.Perm()&0100 != 0, nil
 }
 

--- a/plugin/manager_unix.go
+++ b/plugin/manager_unix.go
@@ -50,3 +50,12 @@ func parsePluginName(fileName string) (string, error) {
 	}
 	return pluginName, nil
 }
+
+// setExecutable sets file to be user executable
+func setExecutable(filePath string) error {
+	fileInfo, err := os.Stat(filePath)
+	if err != nil {
+		return err
+	}
+	return os.Chmod(filePath, fileInfo.Mode()|os.FileMode(0100))
+}

--- a/plugin/manager_unix.go
+++ b/plugin/manager_unix.go
@@ -17,8 +17,10 @@
 package plugin
 
 import (
+	"errors"
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/notaryproject/notation-go/plugin/proto"
@@ -49,4 +51,16 @@ func parsePluginName(fileName string) (string, error) {
 		return "", fmt.Errorf("invalid plugin executable file name. Plugin file name requires format notation-{plugin-name}, but got %s", fileName)
 	}
 	return pluginName, nil
+}
+
+// validatePluginFileExtensionAgainstOS validates if plugin executable file
+// name aligns with the runtime OS.
+//
+// On windows, `.exe` extension is required.
+// On other OS, MUST NOT have the `.exe` extension.
+func validatePluginFileExtensionAgainstOS(fileName string) error {
+	if strings.EqualFold(filepath.Ext(fileName), ".exe") {
+		return errors.New("invalid plugin file extension. On OS other than windows, plugin executable file cannot have '.exe' file extension")
+	}
+	return nil
 }

--- a/plugin/manager_unix.go
+++ b/plugin/manager_unix.go
@@ -44,9 +44,9 @@ func isExecutableFile(filePath string) (bool, error) {
 // parsePluginName checks if fileName is a valid plugin file name
 // and gets plugin name from it based on spec: https://github.com/notaryproject/specifications/blob/main/specs/plugin-extensibility.md#installation
 func parsePluginName(fileName string) (string, error) {
-	pluginName, found := strings.CutPrefix(fname, proto.Prefix)
+	pluginName, found := strings.CutPrefix(fileName, proto.Prefix)
 	if !found {
-		return "", fmt.Errorf("invalid plugin executable file name. Plugin file name requires format notation-{plugin-name}, but got %s", fname)
+		return "", fmt.Errorf("invalid plugin executable file name. Plugin file name requires format notation-{plugin-name}, but got %s", fileName)
 	}
 	return pluginName, nil
 }

--- a/plugin/manager_windows.go
+++ b/plugin/manager_windows.go
@@ -53,5 +53,5 @@ func parsePluginName(fileName string) (string, error) {
 // setExecutable returns error on Windows. User needs to install the correct
 // plugin file.
 func setExecutable(filePath string) error {
-	return fmt.Errorf("on Windows, plugin executable file must have file extension '.exe', but got %s", filePath)
+	return fmt.Errorf("on Windows, plugin executable file must have file extension '.exe', but got %s", filepath.Base(filePath))
 }

--- a/plugin/manager_windows.go
+++ b/plugin/manager_windows.go
@@ -50,9 +50,8 @@ func parsePluginName(fileName string) (string, error) {
 	return pluginName, nil
 }
 
-// setExecutable sets file to be executable by adding '.exe' file extension
+// setExecutable returns error on Windows. User needs to install the correct
+// plugin file.
 func setExecutable(filePath string) error {
-	fileDir := filepath.Dir(filePath)
-	fileName := filepath.Base(filePath)
-	return os.Rename(filePath, filepath.Join(fileDir, fileName+".exe"))
+	return fmt.Errorf("on Windows, plugin executable file must have file extension '.exe', but got %s", filePath)
 }

--- a/plugin/manager_windows.go
+++ b/plugin/manager_windows.go
@@ -58,7 +58,7 @@ func parsePluginName(fileName string) (string, error) {
 // On other OS, MUST NOT have the `.exe` extension.
 func validatePluginFileExtensionAgainstOS(fileName string) error {
 	if !strings.EqualFold(filepath.Ext(fileName), ".exe") {
-		return errors.New("invalid plugin file extension. On windows, plugin executable file MUST have '.exe' file extension")
+		return errors.New("invalid plugin file extension. On Windows, plugin executable file MUST have '.exe' file extension")
 	}
 	return nil
 }

--- a/plugin/manager_windows.go
+++ b/plugin/manager_windows.go
@@ -14,6 +14,7 @@
 package plugin
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -48,4 +49,16 @@ func parsePluginName(fileName string) (string, error) {
 		return "", fmt.Errorf("invalid plugin executable file name. Plugin file name requires format notation-{plugin-name}, but got %s", fname)
 	}
 	return pluginName, nil
+}
+
+// validatePluginFileExtensionAgainstOS validates if plugin executable file
+// name aligns with the runtime OS.
+//
+// On windows, `.exe` extension is required.
+// On other OS, MUST NOT have the `.exe` extension.
+func validatePluginFileExtensionAgainstOS(fileName string) error {
+	if !strings.EqualFold(filepath.Ext(fileName), ".exe") {
+		return errors.New("invalid plugin file extension. On windows, plugin executable file MUST have '.exe' file extension")
+	}
+	return nil
 }

--- a/plugin/manager_windows.go
+++ b/plugin/manager_windows.go
@@ -14,7 +14,6 @@
 package plugin
 
 import (
-	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -49,16 +48,4 @@ func parsePluginName(fileName string) (string, error) {
 		return "", fmt.Errorf("invalid plugin executable file name. Plugin file name requires format notation-{plugin-name}, but got %s", fname)
 	}
 	return pluginName, nil
-}
-
-// validatePluginFileExtensionAgainstOS validates if plugin executable file
-// name aligns with the runtime OS.
-//
-// On windows, `.exe` extension is required.
-// On other OS, MUST NOT have the `.exe` extension.
-func validatePluginFileExtensionAgainstOS(fileName string) error {
-	if !strings.EqualFold(filepath.Ext(fileName), ".exe") {
-		return errors.New("invalid plugin file extension. On Windows, plugin executable file MUST have '.exe' file extension")
-	}
-	return nil
 }

--- a/plugin/manager_windows.go
+++ b/plugin/manager_windows.go
@@ -14,10 +14,12 @@
 package plugin
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
 
+	"github.com/notaryproject/notation-go/internal/file"
 	"github.com/notaryproject/notation-go/plugin/proto"
 )
 
@@ -35,4 +37,15 @@ func isExecutableFile(filePath string) (bool, error) {
 		return false, ErrNotRegularFile
 	}
 	return strings.EqualFold(filepath.Ext(filepath.Base(filePath)), ".exe"), nil
+}
+
+// parsePluginName checks if fileName is a valid plugin file name
+// and gets plugin name from it based on spec: https://github.com/notaryproject/specifications/blob/main/specs/plugin-extensibility.md#installation
+func parsePluginName(fileName string) (string, error) {
+	fname := file.TrimFileExtension(fileName)
+	pluginName, found := strings.CutPrefix(fname, proto.Prefix)
+	if !found {
+		return "", fmt.Errorf("invalid plugin executable file name. Plugin file name requires format notation-{plugin-name}, but got %s", fname)
+	}
+	return pluginName, nil
 }

--- a/plugin/manager_windows.go
+++ b/plugin/manager_windows.go
@@ -42,10 +42,10 @@ func isExecutableFile(filePath string) (bool, error) {
 // parsePluginName checks if fileName is a valid plugin file name
 // and gets plugin name from it based on spec: https://github.com/notaryproject/specifications/blob/main/specs/plugin-extensibility.md#installation
 func parsePluginName(fileName string) (string, error) {
-	fname := fileName
-	if strings.EqualFold(filepath.Ext(fileName), ".exe") {
-		fname = file.TrimFileExtension(fileName)
+	if !strings.EqualFold(filepath.Ext(fileName), ".exe") {
+		return "", fmt.Errorf("invalid plugin executable file name. Plugin file name requires format notation-{plugin-name}.exe, but got %s", fileName)
 	}
+	fname := file.TrimFileExtension(fileName)
 	pluginName, found := strings.CutPrefix(fname, proto.Prefix)
 	if !found || pluginName == "" {
 		return "", fmt.Errorf("invalid plugin executable file name. Plugin file name requires format notation-{plugin-name}.exe, but got %s", fileName)

--- a/plugin/manager_windows.go
+++ b/plugin/manager_windows.go
@@ -49,3 +49,10 @@ func parsePluginName(fileName string) (string, error) {
 	}
 	return pluginName, nil
 }
+
+// setExecutable sets file to be executable by adding '.exe' file extension
+func setExecutable(filePath string) error {
+	fileDir := filepath.Dir(filePath)
+	fileName := filepath.Base(filePath)
+	return os.Rename(filePath, filepath.Join(fileDir, fileName+".exe"))
+}

--- a/plugin/manager_windows.go
+++ b/plugin/manager_windows.go
@@ -42,10 +42,13 @@ func isExecutableFile(filePath string) (bool, error) {
 // parsePluginName checks if fileName is a valid plugin file name
 // and gets plugin name from it based on spec: https://github.com/notaryproject/specifications/blob/main/specs/plugin-extensibility.md#installation
 func parsePluginName(fileName string) (string, error) {
-	fname := file.TrimFileExtension(fileName)
+	fname := fileName
+	if strings.EqualFold(filepath.Ext(fileName), ".exe") {
+		fname = file.TrimFileExtension(fileName)
+	}
 	pluginName, found := strings.CutPrefix(fname, proto.Prefix)
 	if !found || pluginName == "" {
-		return "", fmt.Errorf("invalid plugin executable file name. Plugin file name requires format notation-{plugin-name}, but got %s", fname)
+		return "", fmt.Errorf("invalid plugin executable file name. Plugin file name requires format notation-{plugin-name}.exe, but got %s", fileName)
 	}
 	return pluginName, nil
 }
@@ -53,5 +56,5 @@ func parsePluginName(fileName string) (string, error) {
 // setExecutable returns error on Windows. User needs to install the correct
 // plugin file.
 func setExecutable(filePath string) error {
-	return fmt.Errorf("on Windows, plugin executable file must have file extension '.exe', but got %s", filepath.Base(filePath))
+	return fmt.Errorf(`plugin executable file must have file extension ".exe", but got %q`, filepath.Base(filePath))
 }

--- a/plugin/manager_windows.go
+++ b/plugin/manager_windows.go
@@ -45,7 +45,7 @@ func isExecutableFile(filePath string) (bool, error) {
 func parsePluginName(fileName string) (string, error) {
 	fname := file.TrimFileExtension(fileName)
 	pluginName, found := strings.CutPrefix(fname, proto.Prefix)
-	if !found {
+	if !found || pluginName == "" {
 		return "", fmt.Errorf("invalid plugin executable file name. Plugin file name requires format notation-{plugin-name}, but got %s", fname)
 	}
 	return pluginName, nil

--- a/plugin/plugin.go
+++ b/plugin/plugin.go
@@ -25,9 +25,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"strings"
 
-	"github.com/notaryproject/notation-go/internal/file"
 	"github.com/notaryproject/notation-go/internal/slices"
 	"github.com/notaryproject/notation-go/log"
 	"github.com/notaryproject/notation-go/plugin/proto"
@@ -227,14 +225,14 @@ func (c execCommander) Output(ctx context.Context, name string, command proto.Co
 
 // ParsePluginName checks if fileName is a valid plugin file name
 // and gets plugin name from it based on spec: https://github.com/notaryproject/specifications/blob/main/specs/plugin-extensibility.md#installation
-func ParsePluginName(fileName string) (string, error) {
-	fname := file.TrimFileExtension(fileName)
-	pluginName, found := strings.CutPrefix(fname, proto.Prefix)
-	if !found {
-		return "", fmt.Errorf("invalid plugin executable file name. Plugin file name requires format notation-{plugin-name}, but got %s", fname)
-	}
-	return pluginName, nil
-}
+// func ParsePluginName(fileName string) (string, error) {
+// 	fname := file.TrimFileExtension(fileName)
+// 	pluginName, found := strings.CutPrefix(fname, proto.Prefix)
+// 	if !found {
+// 		return "", fmt.Errorf("invalid plugin executable file name. Plugin file name requires format notation-{plugin-name}, but got %s", fname)
+// 	}
+// 	return pluginName, nil
+// }
 
 // validate checks if the metadata is correctly populated.
 func validate(metadata *proto.GetMetadataResponse) error {
@@ -265,15 +263,15 @@ func validate(metadata *proto.GetMetadataResponse) error {
 	return nil
 }
 
-// validatePluginFileExtensionAgainstOS validates if plugin executable file
-// extension aligns with the runtime OS.
+// validatePluginFilenameAgainstOS validates if plugin executable file
+// name aligns with the runtime OS.
 //
 // On windows, `.exe` extension is required.
-// On other OS, MUST not have the `.exe` extension.
-func validatePluginFileExtensionAgainstOS(fileName, pluginName string) error {
+// On other OS, MUST NOT have the `.exe` extension.
+func validatePluginFilenameAgainstOS(fileName, pluginName string) error {
 	expectedPluginFile := binName(pluginName)
-	if filepath.Ext(fileName) != filepath.Ext(expectedPluginFile) {
-		return fmt.Errorf("invalid plugin file extension. Expecting file %s, but got %s", expectedPluginFile, fileName)
+	if fileName != expectedPluginFile {
+		return fmt.Errorf("invalid plugin file name. Expecting file %s, but got %s", expectedPluginFile, fileName)
 	}
 	return nil
 }

--- a/plugin/plugin.go
+++ b/plugin/plugin.go
@@ -223,17 +223,6 @@ func (c execCommander) Output(ctx context.Context, name string, command proto.Co
 	return stdout.Bytes(), nil, nil
 }
 
-// ParsePluginName checks if fileName is a valid plugin file name
-// and gets plugin name from it based on spec: https://github.com/notaryproject/specifications/blob/main/specs/plugin-extensibility.md#installation
-// func ParsePluginName(fileName string) (string, error) {
-// 	fname := file.TrimFileExtension(fileName)
-// 	pluginName, found := strings.CutPrefix(fname, proto.Prefix)
-// 	if !found {
-// 		return "", fmt.Errorf("invalid plugin executable file name. Plugin file name requires format notation-{plugin-name}, but got %s", fname)
-// 	}
-// 	return pluginName, nil
-// }
-
 // validate checks if the metadata is correctly populated.
 func validate(metadata *proto.GetMetadataResponse) error {
 	if metadata.Name == "" {
@@ -259,19 +248,6 @@ func validate(metadata *proto.GetMetadataResponse) error {
 			"contract version %q is not in the list of the plugin supported versions %v",
 			proto.ContractVersion, metadata.SupportedContractVersions,
 		)
-	}
-	return nil
-}
-
-// validatePluginFilenameAgainstOS validates if plugin executable file
-// name aligns with the runtime OS.
-//
-// On windows, `.exe` extension is required.
-// On other OS, MUST NOT have the `.exe` extension.
-func validatePluginFilenameAgainstOS(fileName, pluginName string) error {
-	expectedPluginFile := binName(pluginName)
-	if fileName != expectedPluginFile {
-		return fmt.Errorf("invalid plugin file name. Expecting file %s, but got %s", expectedPluginFile, fileName)
 	}
 	return nil
 }

--- a/plugin/plugin.go
+++ b/plugin/plugin.go
@@ -107,6 +107,7 @@ func (p *CLIPlugin) GetMetadata(ctx context.Context, req *proto.GetMetadataReque
 	if err = validate(&metadata); err != nil {
 		return nil, fmt.Errorf("invalid metadata: %w", err)
 	}
+	fmt.Println(metadata.Name, p.name)
 	if metadata.Name != p.name {
 		return nil, fmt.Errorf("executable name must be %q instead of %q", binName(metadata.Name), filepath.Base(p.path))
 	}

--- a/plugin/plugin.go
+++ b/plugin/plugin.go
@@ -107,7 +107,6 @@ func (p *CLIPlugin) GetMetadata(ctx context.Context, req *proto.GetMetadataReque
 	if err = validate(&metadata); err != nil {
 		return nil, fmt.Errorf("invalid metadata: %w", err)
 	}
-	fmt.Println(metadata.Name, p.name)
 	if metadata.Name != p.name {
 		return nil, fmt.Errorf("executable name must be %q instead of %q", binName(metadata.Name), filepath.Base(p.path))
 	}

--- a/plugin/plugin_test.go
+++ b/plugin/plugin_test.go
@@ -272,16 +272,8 @@ func TestNewCLIPlugin_ValidError(t *testing.T) {
 	})
 }
 
-func TestExtractPluginNameFromExecutableFileName(t *testing.T) {
+func TestParsePluginName(t *testing.T) {
 	pluginName, err := parsePluginName("notation-my-plugin")
-	if err != nil {
-		t.Fatalf("expected nil err, got %v", err)
-	}
-	if pluginName != "my-plugin" {
-		t.Fatalf("expected plugin name my-plugin, but got %s", pluginName)
-	}
-
-	pluginName, err = parsePluginName("notation-my-plugin.exe")
 	if err != nil {
 		t.Fatalf("expected nil err, got %v", err)
 	}
@@ -299,6 +291,24 @@ func TestExtractPluginNameFromExecutableFileName(t *testing.T) {
 	expectedErrorMsg = "invalid plugin executable file name. Plugin file name requires format notation-{plugin-name}, but got my-plugin"
 	if err == nil || err.Error() != expectedErrorMsg {
 		t.Fatalf("expected %s, got %v", expectedErrorMsg, err)
+	}
+
+	if runtime.GOOS == "windows" {
+		pluginName, err = parsePluginName("notation-my-plugin.exe")
+		if err != nil {
+			t.Fatalf("expected nil err, got %v", err)
+		}
+		if pluginName != "my-plugin" {
+			t.Fatalf("expected plugin name my-plugin, but got %s", pluginName)
+		}
+	} else {
+		pluginName, err = parsePluginName("notation-com.example.plugin")
+		if err != nil {
+			t.Fatalf("expected nil err, got %v", err)
+		}
+		if pluginName != "com.example.plugin" {
+			t.Fatalf("expected plugin name com.example.plugin, but got %s", pluginName)
+		}
 	}
 }
 

--- a/plugin/plugin_test.go
+++ b/plugin/plugin_test.go
@@ -273,7 +273,7 @@ func TestNewCLIPlugin_ValidError(t *testing.T) {
 }
 
 func TestExtractPluginNameFromExecutableFileName(t *testing.T) {
-	pluginName, err := ParsePluginName("notation-my-plugin")
+	pluginName, err := parsePluginName("notation-my-plugin")
 	if err != nil {
 		t.Fatalf("expected nil err, got %v", err)
 	}
@@ -281,7 +281,7 @@ func TestExtractPluginNameFromExecutableFileName(t *testing.T) {
 		t.Fatalf("expected plugin name my-plugin, but got %s", pluginName)
 	}
 
-	pluginName, err = ParsePluginName("notation-my-plugin.exe")
+	pluginName, err = parsePluginName("notation-my-plugin.exe")
 	if err != nil {
 		t.Fatalf("expected nil err, got %v", err)
 	}
@@ -289,13 +289,13 @@ func TestExtractPluginNameFromExecutableFileName(t *testing.T) {
 		t.Fatalf("expected plugin name my-plugin, but got %s", pluginName)
 	}
 
-	_, err = ParsePluginName("myPlugin")
+	_, err = parsePluginName("myPlugin")
 	expectedErrorMsg := "invalid plugin executable file name. Plugin file name requires format notation-{plugin-name}, but got myPlugin"
 	if err == nil || err.Error() != expectedErrorMsg {
 		t.Fatalf("expected %s, got %v", expectedErrorMsg, err)
 	}
 
-	_, err = ParsePluginName("my-plugin")
+	_, err = parsePluginName("my-plugin")
 	expectedErrorMsg = "invalid plugin executable file name. Plugin file name requires format notation-{plugin-name}, but got my-plugin"
 	if err == nil || err.Error() != expectedErrorMsg {
 		t.Fatalf("expected %s, got %v", expectedErrorMsg, err)
@@ -304,24 +304,24 @@ func TestExtractPluginNameFromExecutableFileName(t *testing.T) {
 
 func TestValidatePluginFileExtensionAgainstOS(t *testing.T) {
 	if runtime.GOOS == "windows" {
-		err := validatePluginFileExtensionAgainstOS("notation-foo.exe", "foo")
+		err := validatePluginFilenameAgainstOS("notation-foo.exe", "foo")
 		if err != nil {
 			t.Fatalf("expecting nil error, but got %s", err)
 		}
 
-		err = validatePluginFileExtensionAgainstOS("notation-foo", "foo")
+		err = validatePluginFilenameAgainstOS("notation-foo", "foo")
 		expectedErrorMsg := "invalid plugin file extension. Expecting file notation-foo.exe, but got notation-foo"
 		if err == nil || err.Error() != expectedErrorMsg {
 			t.Fatalf("expecting error %s, but got %v", expectedErrorMsg, err)
 		}
 		return
 	}
-	err := validatePluginFileExtensionAgainstOS("notation-foo", "foo")
+	err := validatePluginFilenameAgainstOS("notation-foo", "foo")
 	if err != nil {
 		t.Fatalf("expecting nil error, but got %s", err)
 	}
 
-	err = validatePluginFileExtensionAgainstOS("notation-foo.exe", "foo")
+	err = validatePluginFilenameAgainstOS("notation-foo.exe", "foo")
 	expectedErrorMsg := "invalid plugin file extension. Expecting file notation-foo, but got notation-foo.exe"
 	if err == nil || err.Error() != expectedErrorMsg {
 		t.Fatalf("expecting error %s, but got %v", expectedErrorMsg, err)

--- a/plugin/plugin_test.go
+++ b/plugin/plugin_test.go
@@ -20,7 +20,6 @@ import (
 	"fmt"
 	"os"
 	"reflect"
-	"runtime"
 	"strconv"
 	"strings"
 	"testing"
@@ -270,70 +269,4 @@ func TestNewCLIPlugin_ValidError(t *testing.T) {
 			t.Fatal("should have an invalid contract version error")
 		}
 	})
-}
-
-func TestParsePluginName(t *testing.T) {
-	pluginName, err := parsePluginName("notation-my-plugin")
-	if err != nil {
-		t.Fatalf("expected nil err, got %v", err)
-	}
-	if pluginName != "my-plugin" {
-		t.Fatalf("expected plugin name my-plugin, but got %s", pluginName)
-	}
-
-	_, err = parsePluginName("myPlugin")
-	expectedErrorMsg := "invalid plugin executable file name. Plugin file name requires format notation-{plugin-name}, but got myPlugin"
-	if err == nil || err.Error() != expectedErrorMsg {
-		t.Fatalf("expected %s, got %v", expectedErrorMsg, err)
-	}
-
-	_, err = parsePluginName("my-plugin")
-	expectedErrorMsg = "invalid plugin executable file name. Plugin file name requires format notation-{plugin-name}, but got my-plugin"
-	if err == nil || err.Error() != expectedErrorMsg {
-		t.Fatalf("expected %s, got %v", expectedErrorMsg, err)
-	}
-
-	if runtime.GOOS == "windows" {
-		pluginName, err = parsePluginName("notation-my-plugin.exe")
-		if err != nil {
-			t.Fatalf("expected nil err, got %v", err)
-		}
-		if pluginName != "my-plugin" {
-			t.Fatalf("expected plugin name my-plugin, but got %s", pluginName)
-		}
-	} else {
-		pluginName, err = parsePluginName("notation-com.example.plugin")
-		if err != nil {
-			t.Fatalf("expected nil err, got %v", err)
-		}
-		if pluginName != "com.example.plugin" {
-			t.Fatalf("expected plugin name com.example.plugin, but got %s", pluginName)
-		}
-	}
-}
-
-func TestValidatePluginFileExtensionAgainstOS(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		err := validatePluginFilenameAgainstOS("notation-foo.exe", "foo")
-		if err != nil {
-			t.Fatalf("expecting nil error, but got %s", err)
-		}
-
-		err = validatePluginFilenameAgainstOS("notation-foo", "foo")
-		expectedErrorMsg := "invalid plugin file extension. Expecting file notation-foo.exe, but got notation-foo"
-		if err == nil || err.Error() != expectedErrorMsg {
-			t.Fatalf("expecting error %s, but got %v", expectedErrorMsg, err)
-		}
-		return
-	}
-	err := validatePluginFilenameAgainstOS("notation-foo", "foo")
-	if err != nil {
-		t.Fatalf("expecting nil error, but got %s", err)
-	}
-
-	err = validatePluginFilenameAgainstOS("notation-foo.exe", "foo")
-	expectedErrorMsg := "invalid plugin file extension. Expecting file notation-foo, but got notation-foo.exe"
-	if err == nil || err.Error() != expectedErrorMsg {
-		t.Fatalf("expecting error %s, but got %v", expectedErrorMsg, err)
-	}
 }


### PR DESCRIPTION
This PR is the 2nd iteration of plugin install.
Installation SHOULD pass in any of the following scenario:
1. Installing a single valid plugin executable file on file system. An example can be `notation-com.example.plugin` on `Unix` and `notation-com.example.plugin.exe` on `Windows`.
2. Installing from a dir which contains `one and only one` executable file with file name in the `notation-{plugin-name}` format.
3. On `Unix`, install from a dir which contains `no executable file`, however, there's `one and only one` candidate file with file name in the `notation-{plugin-name}` format. (Notation would set it to executable and try install it with a warning alert to the user). On `Windows`, install would fail in this case since '.exe' file extension is required.


Corresponding tests are added as well.