### PR TITLE
fix: improve plugin error message

### DIFF
--- a/plugin/errors.go
+++ b/plugin/errors.go
@@ -47,3 +47,79 @@ func (e InstallEqualVersionError) Error() string {
 	}
 	return "installing plugin with version equal to the existing plugin version"
 }
+
+// PluginLibraryInternalError is used when there is an issue executing a plugin
+type PluginLibraryInternalError struct {
+	Msg        string
+	InnerError error
+}
+
+func (e PluginLibraryInternalError) Error() string {
+	if e.Msg != "" {
+		return e.Msg
+	}
+	if e.InnerError != nil {
+		return e.InnerError.Error()
+	}
+	return "plugin library internal error"
+}
+
+func (e PluginLibraryInternalError) Unwrap() error {
+	return e.InnerError
+}
+
+// PluginMetadataValidationError is used when there is an issue with plugin metadata validation
+type PluginMetadataValidationError struct {
+	Msg        string
+	InnerError error
+}
+
+func (e PluginMetadataValidationError) Error() string {
+	if e.Msg != "" {
+		return e.Msg
+	}
+	if e.InnerError != nil {
+		return e.InnerError.Error()
+	}
+	return "metadata validation error"
+}
+
+func (e PluginMetadataValidationError) Unwrap() error {
+	return e.InnerError
+}
+
+// PluginProtocolError is used when there is an issue with JSON serialization/deserialization
+type PluginProtocolError struct {
+	Msg        string
+	InnerError error
+}
+
+func (e PluginProtocolError) Error() string {
+	if e.Msg != "" {
+		return e.Msg
+	}
+	if e.InnerError != nil {
+		return e.InnerError.Error()
+	}
+	return "plugin protocol error"
+}
+
+func (e PluginProtocolError) Unwrap() error {
+	return e.InnerError
+}
+
+// PluginListError is used when there is an issue with listing plugins
+type PluginListError struct {
+	Err error
+}
+
+func (e PluginListError) Error() string {
+	if e.Err != nil {
+		return e.Err.Error()
+	}
+	return "plugin list error"
+}
+
+func (e PluginListError) Unwrap() error {
+	return errors.Unwrap(e.Err)
+}

--- a/plugin/errors.go
+++ b/plugin/errors.go
@@ -20,7 +20,7 @@ import "errors"
 var ErrNotCompliant = errors.New("plugin not compliant")
 
 // ErrNotRegularFile is returned when the plugin file is not an regular file.
-var ErrNotRegularFile = errors.New("not regular file")
+var ErrNotRegularFile = errors.New("plugin executable file is not regular file")
 
 // PluginDowngradeError is returned when installing a plugin with version
 // lower than the exisiting plugin version.

--- a/plugin/errors.go
+++ b/plugin/errors.go
@@ -50,26 +50,6 @@ func (e InstallEqualVersionError) Error() string {
 	return "installing plugin with version equal to the existing plugin version"
 }
 
-// PluginUnknownError is used when there is an issue executing a plugin
-// and should be reported to Notation developers.
-type PluginUnknownError struct {
-	Msg        string
-	InnerError error
-}
-
-// Error returns the error message.
-func (e PluginUnknownError) Error() string {
-	if e.Msg != "" {
-		return e.Msg
-	}
-	return e.InnerError.Error()
-}
-
-// Unwrap returns the inner error.
-func (e PluginUnknownError) Unwrap() error {
-	return e.InnerError
-}
-
 // PluginMalformedError is used when there is an issue with plugin and
 // should be fixed by plugin developers.
 type PluginMalformedError struct {

--- a/plugin/errors.go
+++ b/plugin/errors.go
@@ -103,7 +103,7 @@ func (e PluginDirectryWalkError) Error() string {
 
 // Unwrap returns the inner error.
 func (e PluginDirectryWalkError) Unwrap() error {
-	return errors.Unwrap(e.Err)
+	return e.Err
 }
 
 // PluginExectableFileError is used when there is an issue with plugin
@@ -120,5 +120,5 @@ func (e PluginExectableFileError) Error() string {
 
 // Unwrap returns the inner error.
 func (e PluginExectableFileError) Unwrap() error {
-	return errors.Unwrap(e.Err)
+	return e.Err
 }

--- a/plugin/errors.go
+++ b/plugin/errors.go
@@ -59,50 +59,41 @@ func (e PluginUnknownError) Error() string {
 	if e.Msg != "" {
 		return e.Msg
 	}
-	if e.InnerError != nil {
-		return e.InnerError.Error()
-	}
-	return "plugin unknown error"
+	return e.InnerError.Error()
 }
 
 func (e PluginUnknownError) Unwrap() error {
 	return e.InnerError
 }
 
-// PluginValidityError is used when there is an issue with plugin validity and
+// PluginMalformedError is used when there is an issue with plugin and
 // should be fixed by plugin developers.
-type PluginValidityError struct {
+type PluginMalformedError struct {
 	Msg        string
 	InnerError error
 }
 
-func (e PluginValidityError) Error() string {
+func (e PluginMalformedError) Error() string {
 	if e.Msg != "" {
 		return e.Msg
 	}
-	if e.InnerError != nil {
-		return e.InnerError.Error()
-	}
-	return "plugin validity error"
+	return e.InnerError.Error()
 }
 
-func (e PluginValidityError) Unwrap() error {
+func (e PluginMalformedError) Unwrap() error {
 	return e.InnerError
 }
 
-// PluginDirectoryError is used when there is an issue with plugins directory
-// and should suggest user to check the plugin directory.
-type PluginDirectoryError struct {
+// PluginDirectryWalkError is used when there is an issue with plugins directory
+// and should suggest user to check the permission of plugin directory.
+type PluginDirectryWalkError struct {
 	Err error
 }
 
-func (e PluginDirectoryError) Error() string {
-	if e.Err != nil {
-		return e.Err.Error()
-	}
-	return "plugin directory error"
+func (e PluginDirectryWalkError) Error() string {
+	return e.Err.Error()
 }
 
-func (e PluginDirectoryError) Unwrap() error {
+func (e PluginDirectryWalkError) Unwrap() error {
 	return errors.Unwrap(e.Err)
 }

--- a/plugin/errors.go
+++ b/plugin/errors.go
@@ -90,19 +90,19 @@ func (e PluginValidityError) Unwrap() error {
 	return e.InnerError
 }
 
-// PluginListError is used when there is an issue with listing plugins
+// PluginDirectoryError is used when there is an issue with plugins directory
 // and should suggest user to check the plugin directory.
-type PluginListError struct {
+type PluginDirectoryError struct {
 	Err error
 }
 
-func (e PluginListError) Error() string {
+func (e PluginDirectoryError) Error() string {
 	if e.Err != nil {
 		return e.Err.Error()
 	}
-	return "plugin list error"
+	return "plugin directory error"
 }
 
-func (e PluginListError) Unwrap() error {
+func (e PluginDirectoryError) Unwrap() error {
 	return errors.Unwrap(e.Err)
 }

--- a/plugin/errors.go
+++ b/plugin/errors.go
@@ -20,7 +20,7 @@ import "errors"
 var ErrNotCompliant = errors.New("plugin not compliant")
 
 // ErrNotRegularFile is returned when the plugin file is not an regular file.
-var ErrNotRegularFile = errors.New("plugin executable file is not regular file")
+var ErrNotRegularFile = errors.New("plugin executable file is not a regular file")
 
 // PluginDowngradeError is returned when installing a plugin with version
 // lower than the exisiting plugin version.

--- a/plugin/errors.go
+++ b/plugin/errors.go
@@ -90,9 +90,9 @@ func (e PluginMalformedError) Unwrap() error {
 	return e.InnerError
 }
 
-// PluginDirectryWalkError is used when there is an issue with plugins directory
+// PluginDirectoryWalkError is used when there is an issue with plugins directory
 // and should suggest user to check the permission of plugin directory.
-type PluginDirectryWalkError error
+type PluginDirectoryWalkError error
 
 // PluginExecutableFileError is used when there is an issue with plugin
 // executable file and should suggest user to check the existence, permission

--- a/plugin/errors.go
+++ b/plugin/errors.go
@@ -48,67 +48,50 @@ func (e InstallEqualVersionError) Error() string {
 	return "installing plugin with version equal to the existing plugin version"
 }
 
-// PluginLibraryInternalError is used when there is an issue executing a plugin
-type PluginLibraryInternalError struct {
+// PluginUnknownError is used when there is an issue executing a plugin
+// and should be reported to Notation developers.
+type PluginUnknownError struct {
 	Msg        string
 	InnerError error
 }
 
-func (e PluginLibraryInternalError) Error() string {
+func (e PluginUnknownError) Error() string {
 	if e.Msg != "" {
 		return e.Msg
 	}
 	if e.InnerError != nil {
 		return e.InnerError.Error()
 	}
-	return "plugin library internal error"
+	return "plugin unknown error"
 }
 
-func (e PluginLibraryInternalError) Unwrap() error {
+func (e PluginUnknownError) Unwrap() error {
 	return e.InnerError
 }
 
-// PluginMetadataValidationError is used when there is an issue with plugin metadata validation
-type PluginMetadataValidationError struct {
+// PluginValidityError is used when there is an issue with plugin validity and
+// should be fixed by plugin developers.
+type PluginValidityError struct {
 	Msg        string
 	InnerError error
 }
 
-func (e PluginMetadataValidationError) Error() string {
+func (e PluginValidityError) Error() string {
 	if e.Msg != "" {
 		return e.Msg
 	}
 	if e.InnerError != nil {
 		return e.InnerError.Error()
 	}
-	return "metadata validation error"
+	return "plugin validity error"
 }
 
-func (e PluginMetadataValidationError) Unwrap() error {
-	return e.InnerError
-}
-
-// PluginProtocolError is used when there is an issue with JSON serialization/deserialization
-type PluginProtocolError struct {
-	Msg        string
-	InnerError error
-}
-
-func (e PluginProtocolError) Error() string {
-	if e.Msg != "" {
-		return e.Msg
-	}
-	if e.InnerError != nil {
-		return e.InnerError.Error()
-	}
-	return "plugin protocol error"
-}
-
-func (e PluginProtocolError) Unwrap() error {
+func (e PluginValidityError) Unwrap() error {
 	return e.InnerError
 }
 
 // PluginListError is used when there is an issue with listing plugins
+// and should suggest user to check the plugin directory.
 type PluginListError struct {
 	Err error
 }

--- a/plugin/errors.go
+++ b/plugin/errors.go
@@ -92,33 +92,9 @@ func (e PluginMalformedError) Unwrap() error {
 
 // PluginDirectryWalkError is used when there is an issue with plugins directory
 // and should suggest user to check the permission of plugin directory.
-type PluginDirectryWalkError struct {
-	Err error
-}
+type PluginDirectryWalkError error
 
-// Error returns the error message.
-func (e PluginDirectryWalkError) Error() string {
-	return e.Err.Error()
-}
-
-// Unwrap returns the inner error.
-func (e PluginDirectryWalkError) Unwrap() error {
-	return e.Err
-}
-
-// PluginExectableFileError is used when there is an issue with plugin
+// PluginExecutableFileError is used when there is an issue with plugin
 // executable file and should suggest user to check the existence, permission
 // and platform/arch compatibility of plugin.
-type PluginExectableFileError struct {
-	Err error
-}
-
-// Error returns the error message.
-func (e PluginExectableFileError) Error() string {
-	return e.Err.Error()
-}
-
-// Unwrap returns the inner error.
-func (e PluginExectableFileError) Unwrap() error {
-	return e.Err
-}
+type PluginExecutableFileError error

--- a/plugin/errors.go
+++ b/plugin/errors.go
@@ -28,6 +28,7 @@ type PluginDowngradeError struct {
 	Msg string
 }
 
+// Error returns the error message.
 func (e PluginDowngradeError) Error() string {
 	if e.Msg != "" {
 		return e.Msg
@@ -41,6 +42,7 @@ type InstallEqualVersionError struct {
 	Msg string
 }
 
+// Error returns the error message.
 func (e InstallEqualVersionError) Error() string {
 	if e.Msg != "" {
 		return e.Msg
@@ -55,6 +57,7 @@ type PluginUnknownError struct {
 	InnerError error
 }
 
+// Error returns the error message.
 func (e PluginUnknownError) Error() string {
 	if e.Msg != "" {
 		return e.Msg
@@ -62,6 +65,7 @@ func (e PluginUnknownError) Error() string {
 	return e.InnerError.Error()
 }
 
+// Unwrap returns the inner error.
 func (e PluginUnknownError) Unwrap() error {
 	return e.InnerError
 }
@@ -73,6 +77,7 @@ type PluginMalformedError struct {
 	InnerError error
 }
 
+// Error returns the error message.
 func (e PluginMalformedError) Error() string {
 	if e.Msg != "" {
 		return e.Msg
@@ -80,6 +85,7 @@ func (e PluginMalformedError) Error() string {
 	return e.InnerError.Error()
 }
 
+// Unwrap returns the inner error.
 func (e PluginMalformedError) Unwrap() error {
 	return e.InnerError
 }
@@ -90,10 +96,29 @@ type PluginDirectryWalkError struct {
 	Err error
 }
 
+// Error returns the error message.
 func (e PluginDirectryWalkError) Error() string {
 	return e.Err.Error()
 }
 
+// Unwrap returns the inner error.
 func (e PluginDirectryWalkError) Unwrap() error {
+	return errors.Unwrap(e.Err)
+}
+
+// PluginExectableFileError is used when there is an issue with plugin
+// executable file and should suggest user to check the existence, permission
+// and platform/arch compatibility of plugin.
+type PluginExectableFileError struct {
+	Err error
+}
+
+// Error returns the error message.
+func (e PluginExectableFileError) Error() string {
+	return e.Err.Error()
+}
+
+// Unwrap returns the inner error.
+func (e PluginExectableFileError) Unwrap() error {
 	return errors.Unwrap(e.Err)
 }

--- a/plugin/manager.go
+++ b/plugin/manager.go
@@ -64,7 +64,7 @@ func (m *CLIManager) List(ctx context.Context) ([]string, error) {
 	var plugins []string
 	fs.WalkDir(m.pluginFS, ".", func(dir string, d fs.DirEntry, err error) error {
 		if err != nil {
-			return err
+			return &PluginListError{fmt.Errorf("failed to list plugin: %w", err)}
 		}
 		if dir == "." {
 			// Ignore root dir.

--- a/plugin/manager.go
+++ b/plugin/manager.go
@@ -62,6 +62,11 @@ func (m *CLIManager) Get(ctx context.Context, name string) (Plugin, error) {
 // List produces a list of the plugin names on the system.
 func (m *CLIManager) List(ctx context.Context) ([]string, error) {
 	var plugins []string
+	// check plugin directory exsitence
+	if _, err := fs.Stat(m.pluginFS, "."); errors.Is(err, os.ErrNotExist) {
+		return plugins, nil
+	}
+
 	if err := fs.WalkDir(m.pluginFS, ".", func(dir string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return err

--- a/plugin/manager.go
+++ b/plugin/manager.go
@@ -80,7 +80,7 @@ func (m *CLIManager) List(ctx context.Context) ([]string, error) {
 		plugins = append(plugins, d.Name())
 		return fs.SkipDir
 	}); err != nil {
-		return nil, &PluginDirectryWalkError{Err: fmt.Errorf("failed to list plugin: %w", err)}
+		return nil, PluginDirectryWalkError(fmt.Errorf("failed to list plugin: %w", err))
 	}
 	return plugins, nil
 }

--- a/plugin/manager.go
+++ b/plugin/manager.go
@@ -80,7 +80,7 @@ func (m *CLIManager) List(ctx context.Context) ([]string, error) {
 		plugins = append(plugins, d.Name())
 		return fs.SkipDir
 	}); err != nil {
-		return nil, &PluginDirectoryError{Err: fmt.Errorf("failed to list plugin: %w", err)}
+		return nil, &PluginDirectryWalkError{Err: fmt.Errorf("failed to list plugin: %w", err)}
 	}
 	return plugins, nil
 }

--- a/plugin/manager.go
+++ b/plugin/manager.go
@@ -80,7 +80,7 @@ func (m *CLIManager) List(ctx context.Context) ([]string, error) {
 		plugins = append(plugins, d.Name())
 		return fs.SkipDir
 	}); err != nil {
-		return nil, &PluginListError{Err: fmt.Errorf("failed to list plugin: %w", err)}
+		return nil, &PluginDirectoryError{Err: fmt.Errorf("failed to list plugin: %w", err)}
 	}
 	return plugins, nil
 }

--- a/plugin/manager.go
+++ b/plugin/manager.go
@@ -146,11 +146,11 @@ func (m *CLIManager) Install(ctx context.Context, installOpts CLIInstallOptions)
 	// validate and get new plugin metadata
 	newPlugin, err := NewCLIPlugin(ctx, pluginName, pluginExecutableFile)
 	if err != nil {
-		return nil, nil, fmt.Errorf("failed to create new CLI plugin: %w", err)
+		return nil, nil, err
 	}
 	newPluginMetadata, err := newPlugin.GetMetadata(ctx, &proto.GetMetadataRequest{})
 	if err != nil {
-		return nil, nil, fmt.Errorf("failed to get metadata of new plugin: %w", err)
+		return nil, nil, err
 	}
 	// check plugin existence and get existing plugin metadata
 	var existingPluginMetadata *proto.GetMetadataResponse
@@ -163,7 +163,7 @@ func (m *CLIManager) Install(ctx context.Context, installOpts CLIInstallOptions)
 	} else { // plugin already exists
 		existingPluginMetadata, err = existingPlugin.GetMetadata(ctx, &proto.GetMetadataRequest{})
 		if err != nil && !overwrite { // fail only if overwrite is not set
-			return nil, nil, fmt.Errorf("failed to get metadata of existing plugin: %w", err)
+			return nil, nil, err
 		}
 		// existing plugin is valid, and overwrite is not set, check version
 		if !overwrite {

--- a/plugin/manager.go
+++ b/plugin/manager.go
@@ -62,9 +62,9 @@ func (m *CLIManager) Get(ctx context.Context, name string) (Plugin, error) {
 // List produces a list of the plugin names on the system.
 func (m *CLIManager) List(ctx context.Context) ([]string, error) {
 	var plugins []string
-	fs.WalkDir(m.pluginFS, ".", func(dir string, d fs.DirEntry, err error) error {
+	if err := fs.WalkDir(m.pluginFS, ".", func(dir string, d fs.DirEntry, err error) error {
 		if err != nil {
-			return &PluginListError{fmt.Errorf("failed to list plugin: %w", err)}
+			return err
 		}
 		if dir == "." {
 			// Ignore root dir.
@@ -79,7 +79,9 @@ func (m *CLIManager) List(ctx context.Context) ([]string, error) {
 		// add plugin name
 		plugins = append(plugins, d.Name())
 		return fs.SkipDir
-	})
+	}); err != nil {
+		return nil, &PluginListError{Err: fmt.Errorf("failed to list plugin: %w", err)}
+	}
 	return plugins, nil
 }
 

--- a/plugin/manager_test.go
+++ b/plugin/manager_test.go
@@ -388,7 +388,7 @@ func TestManager_Install(t *testing.T) {
 		installOpts := CLIInstallOptions{
 			PluginPath: newPluginFilePath,
 		}
-		expectedErrorMsg := "plugin executable name must be \"notation-foobar\" instead of \"notation-bar\""
+		expectedErrorMsg := "plugin executable file name must be \"notation-foobar\" instead of \"notation-bar\""
 		_, _, err := mgr.Install(context.Background(), installOpts)
 		if err == nil || err.Error() != expectedErrorMsg {
 			t.Fatalf("expecting error %s, but got %v", expectedErrorMsg, err)
@@ -405,7 +405,7 @@ func TestManager_Install(t *testing.T) {
 		installOpts := CLIInstallOptions{
 			PluginPath: newPluginFilePath,
 		}
-		expectedErrorMsg := "plugin executable name must be \"notation-bar\" instead of \"notation-foo\""
+		expectedErrorMsg := "plugin executable file name must be \"notation-bar\" instead of \"notation-foo\""
 		_, _, err := mgr.Install(context.Background(), installOpts)
 		if err == nil || err.Error() != expectedErrorMsg {
 			t.Fatalf("expecting error %s, but got %v", expectedErrorMsg, err)

--- a/plugin/manager_test.go
+++ b/plugin/manager_test.go
@@ -388,7 +388,7 @@ func TestManager_Install(t *testing.T) {
 		installOpts := CLIInstallOptions{
 			PluginPath: newPluginFilePath,
 		}
-		expectedErrorMsg := "plugin executable file name must be \"notation-foobar\" instead of \"notation-bar\""
+		expectedErrorMsg := "failed to get metadata of new plugin: plugin executable file name must be \"notation-foobar\" instead of \"notation-bar\""
 		_, _, err := mgr.Install(context.Background(), installOpts)
 		if err == nil || err.Error() != expectedErrorMsg {
 			t.Fatalf("expecting error %s, but got %v", expectedErrorMsg, err)
@@ -405,7 +405,7 @@ func TestManager_Install(t *testing.T) {
 		installOpts := CLIInstallOptions{
 			PluginPath: newPluginFilePath,
 		}
-		expectedErrorMsg := "plugin executable file name must be \"notation-bar\" instead of \"notation-foo\""
+		expectedErrorMsg := "failed to get metadata of existing plugin: plugin executable file name must be \"notation-bar\" instead of \"notation-foo\""
 		_, _, err := mgr.Install(context.Background(), installOpts)
 		if err == nil || err.Error() != expectedErrorMsg {
 			t.Fatalf("expecting error %s, but got %v", expectedErrorMsg, err)

--- a/plugin/manager_test.go
+++ b/plugin/manager_test.go
@@ -388,7 +388,7 @@ func TestManager_Install(t *testing.T) {
 		installOpts := CLIInstallOptions{
 			PluginPath: newPluginFilePath,
 		}
-		expectedErrorMsg := "failed to get metadata of new plugin: executable name must be \"notation-foobar\" instead of \"notation-bar\""
+		expectedErrorMsg := "plugin executable name must be \"notation-foobar\" instead of \"notation-bar\""
 		_, _, err := mgr.Install(context.Background(), installOpts)
 		if err == nil || err.Error() != expectedErrorMsg {
 			t.Fatalf("expecting error %s, but got %v", expectedErrorMsg, err)
@@ -405,7 +405,7 @@ func TestManager_Install(t *testing.T) {
 		installOpts := CLIInstallOptions{
 			PluginPath: newPluginFilePath,
 		}
-		expectedErrorMsg := "failed to get metadata of existing plugin: executable name must be \"notation-bar\" instead of \"notation-foo\""
+		expectedErrorMsg := "plugin executable name must be \"notation-bar\" instead of \"notation-foo\""
 		_, _, err := mgr.Install(context.Background(), installOpts)
 		if err == nil || err.Error() != expectedErrorMsg {
 			t.Fatalf("expecting error %s, but got %v", expectedErrorMsg, err)

--- a/plugin/plugin.go
+++ b/plugin/plugin.go
@@ -85,7 +85,7 @@ func NewCLIPlugin(ctx context.Context, name, path string) (*CLIPlugin, error) {
 	}
 	if !fi.Mode().IsRegular() {
 		// Ignore non-regular files.
-		return nil, fmt.Errorf("plugin instantiation failed because the executable file %s is not a regular file", path)
+		return nil, fmt.Errorf("plugin instantiation failed for the executable file %s: %w", path, ErrNotRegularFile)
 	}
 
 	// generate plugin
@@ -175,7 +175,7 @@ func run(ctx context.Context, pluginName string, pluginPath string, req proto.Re
 	data, err := json.Marshal(req)
 	if err != nil {
 		logger.Errorf("failed to marshal request: %+v", req)
-		return PluginUnknownError{
+		return &PluginUnknownError{
 			Msg:        fmt.Sprintf("failed to execute the %s command for %s plugin", req.Command(), pluginName),
 			InnerError: fmt.Errorf("failed to marshal request: %w", err)}
 	}

--- a/plugin/plugin.go
+++ b/plugin/plugin.go
@@ -189,7 +189,7 @@ func run(ctx context.Context, pluginName string, pluginPath string, req proto.Re
 
 		if len(stderr) == 0 {
 			return &PluginMalformedError{
-				Msg:        fmt.Sprintf("failed to execute the %s command for %s plugin: %s", req.Command(), pluginName, string(stderr)),
+				Msg:        fmt.Sprintf("failed to execute the %s command for %s plugin: %s", req.Command(), pluginName, err),
 				InnerError: err,
 			}
 		} else {

--- a/plugin/plugin.go
+++ b/plugin/plugin.go
@@ -177,7 +177,7 @@ func run(ctx context.Context, pluginName string, pluginPath string, req proto.Re
 		logger.Errorf("failed to marshal request: %+v", req)
 		return PluginUnknownError{
 			Msg:        fmt.Sprintf("failed to execute the %s command for %s plugin", req.Command(), pluginName),
-			InnerError: err}
+			InnerError: fmt.Errorf("failed to marshal request: %w", err)}
 	}
 
 	logger.Debugf("Plugin %s request: %s", req.Command(), string(data))

--- a/plugin/plugin.go
+++ b/plugin/plugin.go
@@ -188,7 +188,10 @@ func run(ctx context.Context, pluginName string, pluginPath string, req proto.Re
 		logger.Errorf("Plugin %s returned error: %s", req.Command(), string(stderr))
 
 		if len(stderr) == 0 {
-			return fmt.Errorf("failed to execute the %s command for %s plugin: %w", req.Command(), pluginName, err)
+			return &PluginMalformedError{
+				Msg:        fmt.Sprintf("failed to execute the %s command for %s plugin: %s", req.Command(), pluginName, string(stderr)),
+				InnerError: err,
+			}
 		} else {
 			var re proto.RequestError
 			jsonErr := json.Unmarshal(stderr, &re)

--- a/plugin/plugin.go
+++ b/plugin/plugin.go
@@ -81,11 +81,11 @@ func NewCLIPlugin(ctx context.Context, name, path string) (*CLIPlugin, error) {
 	if err != nil {
 		// Ignore any file which we cannot Stat
 		// (e.g. due to permissions or anything else).
-		return nil, fmt.Errorf("plugin instantiation failed because the executable file is either not found or inaccessible: %w", err)
+		return nil, fmt.Errorf("plugin executable file is either not found or inaccessible: %w", err)
 	}
 	if !fi.Mode().IsRegular() {
 		// Ignore non-regular files.
-		return nil, fmt.Errorf("plugin instantiation failed for the executable file %s: %w", path, ErrNotRegularFile)
+		return nil, ErrNotRegularFile
 	}
 
 	// generate plugin

--- a/plugin/plugin.go
+++ b/plugin/plugin.go
@@ -81,11 +81,11 @@ func NewCLIPlugin(ctx context.Context, name, path string) (*CLIPlugin, error) {
 	if err != nil {
 		// Ignore any file which we cannot Stat
 		// (e.g. due to permissions or anything else).
-		return nil, fmt.Errorf("failed to create new CLI plugin: the plugin executable file is not found or inaccessible: %w", err)
+		return nil, fmt.Errorf("failed to instantiate the plugin: the executable file is not found or inaccessible: %w", err)
 	}
 	if !fi.Mode().IsRegular() {
 		// Ignore non-regular files.
-		return nil, fmt.Errorf("failed to create new CLI plugin: the plugin executable file %q is not a regular file", path)
+		return nil, fmt.Errorf("failed to instantiate the plugin: the executable file %q is not a regular file", path)
 	}
 
 	// generate plugin

--- a/plugin/plugin.go
+++ b/plugin/plugin.go
@@ -175,10 +175,8 @@ func run(ctx context.Context, pluginName string, pluginPath string, req proto.Re
 	// serialize request
 	data, err := json.Marshal(req)
 	if err != nil {
-		logger.Errorf("Failed to marshal request: %+v", req)
-		return &PluginUnknownError{
-			Msg:        fmt.Sprintf("failed to execute the %s command for plugin %s", req.Command(), pluginName),
-			InnerError: fmt.Errorf("failed to marshal request: %w", err)}
+		logger.Errorf("Failed to marshal request object: %+v", req)
+		return fmt.Errorf("failed to marshal request object: %w", err)
 	}
 
 	logger.Debugf("Plugin %s request: %s", req.Command(), string(data))

--- a/plugin/plugin.go
+++ b/plugin/plugin.go
@@ -25,6 +25,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 
 	"github.com/notaryproject/notation-go/internal/slices"
 	"github.com/notaryproject/notation-go/log"
@@ -195,7 +196,7 @@ func run(ctx context.Context, pluginName string, pluginPath string, req proto.Re
 			jsonErr := json.Unmarshal(stderr, &re)
 			if jsonErr != nil {
 				return &PluginMalformedError{
-					Msg:        fmt.Sprintf("failed to execute the %s command for plugin %s: the plugin isn't compliant with Notation plugin requirement: %s", req.Command(), pluginName, string(stderr)),
+					Msg:        fmt.Sprintf("failed to execute the %s command for plugin %s: %s", req.Command(), pluginName, strings.TrimSuffix(string(stderr), "\n")),
 					InnerError: jsonErr,
 				}
 			}

--- a/plugin/plugin_test.go
+++ b/plugin/plugin_test.go
@@ -194,7 +194,7 @@ func TestNewCLIPlugin_PathError(t *testing.T) {
 	})
 
 	t.Run("plugin is not a regular file", func(t *testing.T) {
-		expectedErrMsg := `plugin instantiation failed for the executable file ./testdata/plugins/badplugin/notation-badplugin: not regular file`
+		expectedErrMsg := "plugin executable file is not regular file"
 		p, err := NewCLIPlugin(ctx, "badplugin", "./testdata/plugins/badplugin/notation-badplugin")
 		if err.Error() != expectedErrMsg {
 			t.Errorf("NewCLIPlugin() error = %v, want %v", err, expectedErrMsg)

--- a/plugin/plugin_test.go
+++ b/plugin/plugin_test.go
@@ -194,7 +194,7 @@ func TestNewCLIPlugin_PathError(t *testing.T) {
 	})
 
 	t.Run("plugin is not a regular file", func(t *testing.T) {
-		expectedErrMsg := `plugin instantiation failed because the executable file ./testdata/plugins/badplugin/notation-badplugin is not a regular file`
+		expectedErrMsg := `plugin instantiation failed for the executable file ./testdata/plugins/badplugin/notation-badplugin: not regular file`
 		p, err := NewCLIPlugin(ctx, "badplugin", "./testdata/plugins/badplugin/notation-badplugin")
 		if err.Error() != expectedErrMsg {
 			t.Errorf("NewCLIPlugin() error = %v, want %v", err, expectedErrMsg)

--- a/plugin/plugin_test.go
+++ b/plugin/plugin_test.go
@@ -194,7 +194,7 @@ func TestNewCLIPlugin_PathError(t *testing.T) {
 	})
 
 	t.Run("plugin is not a regular file", func(t *testing.T) {
-		expectedErrMsg := `failed to instantiate the plugin: the executable file "./testdata/plugins/badplugin/notation-badplugin" is not a regular file`
+		expectedErrMsg := `plugin instantiation failed because the executable file ./testdata/plugins/badplugin/notation-badplugin is not a regular file`
 		p, err := NewCLIPlugin(ctx, "badplugin", "./testdata/plugins/badplugin/notation-badplugin")
 		if err.Error() != expectedErrMsg {
 			t.Errorf("NewCLIPlugin() error = %v, want %v", err, expectedErrMsg)
@@ -214,7 +214,7 @@ func TestNewCLIPlugin_ValidError(t *testing.T) {
 	t.Run("command no response", func(t *testing.T) {
 		executor = testCommander{}
 		_, err := p.GetMetadata(ctx, &proto.GetMetadataRequest{})
-		if _, ok := err.(*PluginValidityError); !ok {
+		if _, ok := err.(*PluginMalformedError); !ok {
 			t.Fatal("should return plugin validity error")
 		}
 	})
@@ -222,7 +222,7 @@ func TestNewCLIPlugin_ValidError(t *testing.T) {
 	t.Run("invalid json", func(t *testing.T) {
 		executor = testCommander{stdout: []byte("content")}
 		_, err := p.GetMetadata(ctx, &proto.GetMetadataRequest{})
-		if _, ok := err.(*PluginValidityError); !ok {
+		if _, ok := err.(*PluginMalformedError); !ok {
 			t.Fatal("should return plugin validity error")
 		}
 	})
@@ -238,7 +238,7 @@ func TestNewCLIPlugin_ValidError(t *testing.T) {
 	t.Run("invalid metadata content", func(t *testing.T) {
 		executor = testCommander{stdout: metadataJSON(proto.GetMetadataResponse{Name: "foo"})}
 		_, err := p.GetMetadata(ctx, &proto.GetMetadataRequest{})
-		if _, ok := err.(*PluginValidityError); !ok {
+		if _, ok := err.(*PluginMalformedError); !ok {
 			t.Fatal("should be plugin validity error.")
 		}
 	})

--- a/plugin/plugin_test.go
+++ b/plugin/plugin_test.go
@@ -30,7 +30,7 @@ func TestGetMetadata(t *testing.T) {
 	t.Run("plugin error is in invalid json format", func(t *testing.T) {
 		exitErr := errors.New("unknown error")
 		stderr := []byte("sad")
-		expectedErrMsg := "failed to execute the get-plugin-metadata command for plugin test-plugin: the plugin isn't compliant with Notation plugin requirement: sad"
+		expectedErrMsg := "failed to execute the get-plugin-metadata command for plugin test-plugin: sad"
 		plugin := CLIPlugin{name: "test-plugin"}
 		executor = testCommander{stdout: nil, stderr: stderr, err: exitErr}
 		_, err := plugin.GetMetadata(context.Background(), &proto.GetMetadataRequest{})

--- a/plugin/plugin_test.go
+++ b/plugin/plugin_test.go
@@ -30,7 +30,7 @@ func TestGetMetadata(t *testing.T) {
 	t.Run("plugin error is in invalid json format", func(t *testing.T) {
 		exitErr := errors.New("unknown error")
 		stderr := []byte("sad")
-		expectedErrMsg := "failed to execute the get-plugin-metadata command for test-plugin plugin: the error response isn't compliant with Notation plugin requirement: sad"
+		expectedErrMsg := "failed to execute the get-plugin-metadata command for plugin test-plugin: the plugin isn't compliant with Notation plugin requirement: sad"
 		plugin := CLIPlugin{name: "test-plugin"}
 		executor = testCommander{stdout: nil, stderr: stderr, err: exitErr}
 		_, err := plugin.GetMetadata(context.Background(), &proto.GetMetadataRequest{})
@@ -55,7 +55,7 @@ func TestGetMetadata(t *testing.T) {
 	t.Run("plugin cause system error", func(t *testing.T) {
 		exitErr := errors.New("system error")
 		stderr := []byte("")
-		expectedErrMsg := "failed to execute the get-plugin-metadata command for test-plugin plugin: system error"
+		expectedErrMsg := "failed to execute the get-plugin-metadata command for plugin test-plugin: system error"
 		plugin := CLIPlugin{name: "test-plugin"}
 		executor = testCommander{stdout: nil, stderr: stderr, err: exitErr}
 		_, err := plugin.GetMetadata(context.Background(), &proto.GetMetadataRequest{})
@@ -230,7 +230,7 @@ func TestNewCLIPlugin_ValidError(t *testing.T) {
 	t.Run("invalid metadata name", func(t *testing.T) {
 		executor = testCommander{stdout: metadataJSON(invalidMetadataName)}
 		_, err := p.GetMetadata(ctx, &proto.GetMetadataRequest{})
-		if !strings.Contains(err.Error(), "executable name must be") {
+		if !strings.Contains(err.Error(), "executable file name must be") {
 			t.Fatal("should fail the operation.")
 		}
 	})

--- a/plugin/plugin_test.go
+++ b/plugin/plugin_test.go
@@ -30,7 +30,7 @@ func TestGetMetadata(t *testing.T) {
 	t.Run("plugin error is in invalid json format", func(t *testing.T) {
 		exitErr := errors.New("unknown error")
 		stderr := []byte("sad")
-		expectedErrMsg := "failed to execute the get-plugin-metadata command for test-plugin plugin: the error response isn't compliant with Notation plugin protocol: sad"
+		expectedErrMsg := "failed to execute the get-plugin-metadata command for test-plugin plugin: the error response isn't compliant with Notation plugin requirement: sad"
 		plugin := CLIPlugin{name: "test-plugin"}
 		executor = testCommander{stdout: nil, stderr: stderr, err: exitErr}
 		_, err := plugin.GetMetadata(context.Background(), &proto.GetMetadataRequest{})

--- a/plugin/plugin_test.go
+++ b/plugin/plugin_test.go
@@ -194,7 +194,7 @@ func TestNewCLIPlugin_PathError(t *testing.T) {
 	})
 
 	t.Run("plugin is not a regular file", func(t *testing.T) {
-		expectedErrMsg := "plugin executable file is not regular file"
+		expectedErrMsg := "plugin executable file is not a regular file"
 		p, err := NewCLIPlugin(ctx, "badplugin", "./testdata/plugins/badplugin/notation-badplugin")
 		if err.Error() != expectedErrMsg {
 			t.Errorf("NewCLIPlugin() error = %v, want %v", err, expectedErrMsg)


### PR DESCRIPTION
- added `PluginUnknownError`, `PluginValidityError`, `PluginDirectoryError`. For each error types, Notation CLI should provide a recommanded suggestion to solve them.
- improved error message

Resolve part of: https://github.com/notaryproject/notation/issues/824
Resolve part of: https://github.com/notaryproject/notation/issues/867

Signed-off-by: Junjie Gao <junjiegao@microsoft.com>