### PR TITLE
fix: update error message

### DIFF
--- a/signer/plugin.go
+++ b/signer/plugin.go
@@ -200,7 +200,7 @@ func (s *pluginSigner) describeKey(ctx context.Context, config map[string]string
 	}
 	resp, err := s.plugin.DescribeKey(ctx, req)
 	if err != nil {
-		return nil, fmt.Errorf("describe-key command failed: %w", err)
+		return nil, err
 	}
 
 	return resp, nil
@@ -301,7 +301,7 @@ func (s *pluginPrimitiveSigner) Sign(payload []byte) ([]byte, []*x509.Certificat
 
 	resp, err := s.plugin.GenerateSignature(s.ctx, req)
 	if err != nil {
-		return nil, nil, fmt.Errorf("generate-signature command failed: %w", err)
+		return nil, nil, err
 	}
 
 	// Check keyID is honored.


### PR DESCRIPTION
Previous:
```
Warning: Always sign the artifact using digest(@sha256:...) rather than a tag(:v2) because tags are mutable and a tag reference can point to a different artifact than the one signed.
Error: describe-key command failed: failed to execute the describe-key command for plugin azure-kv: CertificateNotFound: A certificate with (name/id) self-signed-pkcs13/versions/70747b2064c0488e936eba7a29acc4c6 was not found in this key vault. If you recently deleted this certificate you may be able to recover it using the correct recovery command. For help resolving this issue, please see https://go.microsoft.com/fwlink/?linkid=2125182
```

Current:
```
Warning: Always sign the artifact using digest(@sha256:...) rather than a tag(:v2) because tags are mutable and a tag reference can point to a different artifact than the one signed.
Error: failed to execute the describe-key command for plugin azure-kv: CertificateNotFound: A certificate with (name/id) self-signed-pkcs13/versions/70747b2064c0488e936eba7a29acc4c6 was not found in this key vault. If you recently deleted this certificate you may be able to recover it using the correct recovery command. For help resolving this issue, please see https://go.microsoft.com/fwlink/?linkid=2125182
```
Signed-off-by: Junjie Gao <junjiegao@microsoft.com>