### PR TITLE
ci: enable ci for release branch

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,9 +15,13 @@ name: build
 
 on:
   push:
-    branches: main
+    branches: 
+      - main
+      - release-*
   pull_request:
-    branches: main
+    branches:
+      - main
+      - release-*
 
 jobs:
   build:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -15,9 +15,13 @@ name: "CodeQL"
 
 on:
   push:
-    branches: main
+    branches: 
+      - main
+      - release-*
   pull_request:
-    branches: main
+    branches:
+      - main
+      - release-*
   schedule:
     - cron: '29 2 * * 5'
 

--- a/.github/workflows/license-checker.yml
+++ b/.github/workflows/license-checker.yml
@@ -23,7 +23,6 @@ on:
       - main
       - release-*
 
-
 permissions:
   contents: write
   pull-requests: write

--- a/.github/workflows/license-checker.yml
+++ b/.github/workflows/license-checker.yml
@@ -15,9 +15,14 @@ name: License Checker
 
 on:
   push:
-    branches: main
+    branches: 
+      - main
+      - release-*
   pull_request:
-    branches: main
+    branches:
+      - main
+      - release-*
+
 
 permissions:
   contents: write


### PR DESCRIPTION
To enable a safe way to create a release branch, we need to enable CI for the release branch as proposed in #408 

Signed-off-by: Junjie Gao <junjiegao@microsoft.com>