### PR TITLE
revert: "feat: add support for signing blob (#379)"

### DIFF
--- a/example_localSign_test.go
+++ b/example_localSign_test.go
@@ -47,8 +47,8 @@ func Example_localSign() {
 	// Users should replace `exampleCertTuple.PrivateKey` with their own private
 	// key and replace `exampleCerts` with the corresponding full certificate
 	// chain, following the Notary certificate requirements:
-	// https://github.com/notaryproject/notaryproject/blob/v1.0.0/specs/signature-specification.md#certificate-requirements
-	exampleSigner, err := signer.NewGenericSigner(exampleCertTuple.PrivateKey, exampleCerts)
+	// https://github.com/notaryproject/notaryproject/blob/v1.0.0-rc.1/specs/signature-specification.md#certificate-requirements
+	exampleSigner, err := signer.New(exampleCertTuple.PrivateKey, exampleCerts)
 	if err != nil {
 		panic(err) // Handle error
 	}

--- a/example_remoteSign_test.go
+++ b/example_remoteSign_test.go
@@ -18,13 +18,12 @@ import (
 	"crypto/x509"
 	"fmt"
 
-	"oras.land/oras-go/v2/registry/remote"
-
 	"github.com/notaryproject/notation-core-go/signature/cose"
 	"github.com/notaryproject/notation-core-go/testhelper"
 	"github.com/notaryproject/notation-go"
 	"github.com/notaryproject/notation-go/registry"
 	"github.com/notaryproject/notation-go/signer"
+	"oras.land/oras-go/v2/registry/remote"
 )
 
 // Both COSE ("application/cose") and JWS ("application/jose+json")
@@ -46,8 +45,8 @@ func Example_remoteSign() {
 	// Users should replace `exampleCertTuple.PrivateKey` with their own private
 	// key and replace `exampleCerts` with the corresponding full certificate
 	// chain, following the Notary certificate requirements:
-	// https://github.com/notaryproject/notaryproject/blob/v1.0.0/specs/signature-specification.md#certificate-requirements
-	exampleSigner, err := signer.NewGenericSigner(exampleCertTuple.PrivateKey, exampleCerts)
+	// https://github.com/notaryproject/notaryproject/blob/v1.0.0-rc.1/specs/signature-specification.md#certificate-requirements
+	exampleSigner, err := signer.New(exampleCertTuple.PrivateKey, exampleCerts)
 	if err != nil {
 		panic(err) // Handle error
 	}

--- a/log/log_test.go
+++ b/log/log_test.go
@@ -39,3 +39,115 @@ func TestGetLoggerWithNoLogger(t *testing.T) {
 		t.Errorf("GetLogger() = %v, want Discard", got)
 	}
 }
+
+func TestDiscardLogger(t *testing.T) {
+	logger := &discardLogger{}
+
+	t.Run("Debug", func(t *testing.T) {
+		defer func() {
+			if r := recover(); r != nil {
+				t.Errorf("method panicked")
+			}
+		}()
+		logger.Debug("test")
+	})
+
+	t.Run("Debugf", func(t *testing.T) {
+		defer func() {
+			if r := recover(); r != nil {
+				t.Errorf("method panicked")
+			}
+		}()
+		logger.Debugf("test %s", "format")
+	})
+
+	t.Run("Debugln", func(t *testing.T) {
+		defer func() {
+			if r := recover(); r != nil {
+				t.Errorf("method panicked")
+			}
+		}()
+		logger.Debugln("test")
+	})
+
+	t.Run("Info", func(t *testing.T) {
+		defer func() {
+			if r := recover(); r != nil {
+				t.Errorf("method panicked")
+			}
+		}()
+		logger.Info("test")
+	})
+
+	t.Run("Infof", func(t *testing.T) {
+		defer func() {
+			if r := recover(); r != nil {
+				t.Errorf("method panicked")
+			}
+		}()
+		logger.Infof("test %s", "format")
+	})
+
+	t.Run("Infoln", func(t *testing.T) {
+		defer func() {
+			if r := recover(); r != nil {
+				t.Errorf("method panicked")
+			}
+		}()
+		logger.Infoln("test")
+	})
+
+	t.Run("Warn", func(t *testing.T) {
+		defer func() {
+			if r := recover(); r != nil {
+				t.Errorf("method panicked")
+			}
+		}()
+		logger.Warn("test")
+	})
+
+	t.Run("Warnf", func(t *testing.T) {
+		defer func() {
+			if r := recover(); r != nil {
+				t.Errorf("method panicked")
+			}
+		}()
+		logger.Warnf("test %s", "format")
+	})
+
+	t.Run("Warnln", func(t *testing.T) {
+		defer func() {
+			if r := recover(); r != nil {
+				t.Errorf("method panicked")
+			}
+		}()
+		logger.Warnln("test")
+	})
+
+	t.Run("Error", func(t *testing.T) {
+		defer func() {
+			if r := recover(); r != nil {
+				t.Errorf("method panicked")
+			}
+		}()
+		logger.Error("test")
+	})
+
+	t.Run("Errorf", func(t *testing.T) {
+		defer func() {
+			if r := recover(); r != nil {
+				t.Errorf("method panicked")
+			}
+		}()
+		logger.Errorf("test %s", "format")
+	})
+
+	t.Run("Errorln", func(t *testing.T) {
+		defer func() {
+			if r := recover(); r != nil {
+				t.Errorf("method panicked")
+			}
+		}()
+		logger.Errorln("test")
+	})
+}

--- a/notation_test.go
+++ b/notation_test.go
@@ -188,37 +188,6 @@ func TestSignWithInvalidUserMetadata(t *testing.T) {
 	}
 }
 
-func TestSignOptsMissingSignatureMediaType(t *testing.T) {
-	repo := mock.NewRepository()
-	opts := SignOptions{
-		SignerSignOptions: SignerSignOptions{
-			SignatureMediaType: "",
-		},
-		ArtifactReference: mock.SampleArtifactUri,
-	}
-
-	_, err := Sign(context.Background(), &dummySigner{}, repo, opts)
-	if err == nil {
-		t.Fatalf("expected error but not found")
-	}
-}
-
-func TestSignOptsUnknownMediaType(t *testing.T) {
-	repo := mock.NewRepository()
-	opts := SignOptions{
-		SignerSignOptions: SignerSignOptions{
-			SignatureMediaType: "unknown",
-		},
-		ArtifactReference: mock.SampleArtifactUri,
-	}
-
-	_, err := Sign(context.Background(), &dummySigner{}, repo, opts)
-	if err == nil {
-		t.Fatalf("expected error but not found")
-	}
-
-}
-
 func TestRegistryResolveError(t *testing.T) {
 	policyDocument := dummyPolicyDocument()
 	repo := mock.NewRepository()

--- a/signer/plugin.go
+++ b/signer/plugin.go
@@ -15,7 +15,6 @@ package signer
 
 import (
 	"context"
-	"crypto"
 	"crypto/x509"
 	"encoding/json"
 	"errors"
@@ -30,38 +29,22 @@ import (
 	"github.com/notaryproject/notation-go/log"
 	"github.com/notaryproject/notation-go/plugin/proto"
 	"github.com/notaryproject/notation-plugin-framework-go/plugin"
-	"github.com/opencontainers/go-digest"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
-// PluginSigner signs artifacts and generates signatures.
+// pluginSigner signs artifacts and generates signatures.
 // It implements notation.Signer
-type PluginSigner struct {
+type pluginSigner struct {
 	plugin              plugin.SignPlugin
 	keyID               string
 	pluginConfig        map[string]string
 	manifestAnnotations map[string]string
 }
 
-var algorithms = map[crypto.Hash]digest.Algorithm{
-	crypto.SHA256: digest.SHA256,
-	crypto.SHA384: digest.SHA384,
-	crypto.SHA512: digest.SHA512,
-}
-
 // NewFromPlugin creates a notation.Signer that signs artifacts and generates
 // signatures by delegating the one or more operations to the named plugin,
 // as defined in https://github.com/notaryproject/notaryproject/blob/main/specs/plugin-extensibility.md#signing-interfaces.
-// Deprecated: NewFromPlugin function exists for historical compatibility and should not be used.
-// To create PluginSigner, use NewPluginSigner() function.
 func NewFromPlugin(plugin plugin.SignPlugin, keyID string, pluginConfig map[string]string) (notation.Signer, error) {
-	return NewPluginSigner(plugin, keyID, pluginConfig)
-}
-
-// NewPluginSigner creates a notation.Signer that signs artifacts and generates
-// signatures by delegating the one or more operations to the named plugin,
-// as defined in https://github.com/notaryproject/notaryproject/blob/main/specs/plugin-extensibility.md#signing-interfaces.
-func NewPluginSigner(plugin plugin.SignPlugin, keyID string, pluginConfig map[string]string) (*PluginSigner, error) {
 	if plugin == nil {
 		return nil, errors.New("nil plugin")
 	}
@@ -69,7 +52,7 @@ func NewPluginSigner(plugin plugin.SignPlugin, keyID string, pluginConfig map[st
 		return nil, errors.New("keyID not specified")
 	}
 
-	return &PluginSigner{
+	return &pluginSigner{
 		plugin:       plugin,
 		keyID:        keyID,
 		pluginConfig: pluginConfig,
@@ -77,91 +60,57 @@ func NewPluginSigner(plugin plugin.SignPlugin, keyID string, pluginConfig map[st
 }
 
 // PluginAnnotations returns signature manifest annotations returned from plugin
-func (s *PluginSigner) PluginAnnotations() map[string]string {
+func (s *pluginSigner) PluginAnnotations() map[string]string {
 	return s.manifestAnnotations
 }
 
 // Sign signs the artifact described by its descriptor and returns the
 // marshalled envelope.
-func (s *PluginSigner) Sign(ctx context.Context, desc ocispec.Descriptor, opts notation.SignerSignOptions) ([]byte, *signature.SignerInfo, error) {
+func (s *pluginSigner) Sign(ctx context.Context, desc ocispec.Descriptor, opts notation.SignerSignOptions) ([]byte, *signature.SignerInfo, error) {
 	logger := log.GetLogger(ctx)
-	mergedConfig := s.mergeConfig(opts.PluginConfig)
-
 	logger.Debug("Invoking plugin's get-plugin-metadata command")
-	metadata, err := s.plugin.GetMetadata(ctx, &plugin.GetMetadataRequest{PluginConfig: mergedConfig})
+	req := &plugin.GetMetadataRequest{
+		PluginConfig: s.mergeConfig(opts.PluginConfig),
+	}
+	metadata, err := s.plugin.GetMetadata(ctx, req)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	logger.Debugf("Using plugin %v with capabilities %v to sign oci artifact %v in signature media type %v", metadata.Name, metadata.Capabilities, desc.Digest, opts.SignatureMediaType)
+	logger.Debugf("Using plugin %v with capabilities %v to sign artifact %v in signature media type %v", metadata.Name, metadata.Capabilities, desc.Digest, opts.SignatureMediaType)
 	if metadata.HasCapability(plugin.CapabilitySignatureGenerator) {
-		ks, err := s.getKeySpec(ctx, mergedConfig)
-		if err != nil {
-			return nil, nil, err
-		}
-		return s.generateSignature(ctx, desc, opts, ks, metadata, mergedConfig)
+		return s.generateSignature(ctx, desc, opts, metadata)
 	} else if metadata.HasCapability(plugin.CapabilityEnvelopeGenerator) {
 		return s.generateSignatureEnvelope(ctx, desc, opts)
 	}
 	return nil, nil, fmt.Errorf("plugin does not have signing capabilities")
 }
 
-// SignBlob signs the arbitrary data and returns the marshalled envelope.
-func (s *PluginSigner) SignBlob(ctx context.Context, descGenFunc notation.BlobDescriptorGenerator, opts notation.SignerSignOptions) ([]byte, *signature.SignerInfo, error) {
-	logger := log.GetLogger(ctx)
-	mergedConfig := s.mergeConfig(opts.PluginConfig)
-
-	logger.Debug("Invoking plugin's get-plugin-metadata command")
-	metadata, err := s.plugin.GetMetadata(ctx, &plugin.GetMetadataRequest{PluginConfig: mergedConfig})
-	if err != nil {
-		return nil, nil, err
-	}
-
-	logger.Debug("Invoking plugin's describe-key command")
-	ks, err := s.getKeySpec(ctx, mergedConfig)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	// get descriptor to sign
-	desc, err := getDescriptor(ks, descGenFunc)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	logger.Debugf("Using plugin %v with capabilities %v to sign blob using descriptor %+v", metadata.Name, metadata.Capabilities, desc)
-	if metadata.HasCapability(plugin.CapabilitySignatureGenerator) {
-		return s.generateSignature(ctx, desc, opts, ks, metadata, mergedConfig)
-	} else if metadata.HasCapability(plugin.CapabilityEnvelopeGenerator) {
-		return s.generateSignatureEnvelope(ctx, desc, opts)
-	}
-	return nil, nil, fmt.Errorf("plugin does not have signing capabilities")
-}
-
-func (s *PluginSigner) getKeySpec(ctx context.Context, config map[string]string) (signature.KeySpec, error) {
-	logger := log.GetLogger(ctx)
-	logger.Debug("Invoking plugin's describe-key command")
-	descKeyResp, err := s.describeKey(ctx, config)
-	if err != nil {
-		return signature.KeySpec{}, err
-	}
-
-	if s.keyID != descKeyResp.KeyID {
-		return signature.KeySpec{}, fmt.Errorf("keyID in describeKey response %q does not match request %q", descKeyResp.KeyID, s.keyID)
-	}
-
-	return proto.DecodeKeySpec(descKeyResp.KeySpec)
-}
-
-func (s *PluginSigner) generateSignature(ctx context.Context, desc ocispec.Descriptor, opts notation.SignerSignOptions, ks signature.KeySpec, metadata *plugin.GetMetadataResponse, pluginConfig map[string]string) ([]byte, *signature.SignerInfo, error) {
+func (s *pluginSigner) generateSignature(ctx context.Context, desc ocispec.Descriptor, opts notation.SignerSignOptions, metadata *plugin.GetMetadataResponse) ([]byte, *signature.SignerInfo, error) {
 	logger := log.GetLogger(ctx)
 	logger.Debug("Generating signature by plugin")
-	genericSigner := GenericSigner{
-		signer: &pluginPrimitiveSigner{
+	config := s.mergeConfig(opts.PluginConfig)
+	// Get key info.
+	key, err := s.describeKey(ctx, config)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// Check keyID is honored.
+	if s.keyID != key.KeyID {
+		return nil, nil, fmt.Errorf("keyID in describeKey response %q does not match request %q", key.KeyID, s.keyID)
+	}
+	ks, err := proto.DecodeKeySpec(key.KeySpec)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	genericSigner := genericSigner{
+		Signer: &pluginPrimitiveSigner{
 			ctx:          ctx,
 			plugin:       s.plugin,
 			keyID:        s.keyID,
-			pluginConfig: pluginConfig,
+			pluginConfig: config,
 			keySpec:      ks,
 		},
 	}
@@ -170,7 +119,7 @@ func (s *PluginSigner) generateSignature(ctx context.Context, desc ocispec.Descr
 	return genericSigner.Sign(ctx, desc, opts)
 }
 
-func (s *PluginSigner) generateSignatureEnvelope(ctx context.Context, desc ocispec.Descriptor, opts notation.SignerSignOptions) ([]byte, *signature.SignerInfo, error) {
+func (s *pluginSigner) generateSignatureEnvelope(ctx context.Context, desc ocispec.Descriptor, opts notation.SignerSignOptions) ([]byte, *signature.SignerInfo, error) {
 	logger := log.GetLogger(ctx)
 	logger.Debug("Generating signature envelope by plugin")
 	payload := envelope.Payload{TargetArtifact: envelope.SanitizeTargetArtifact(desc)}
@@ -233,7 +182,7 @@ func (s *PluginSigner) generateSignatureEnvelope(ctx context.Context, desc ocisp
 	return resp.SignatureEnvelope, &envContent.SignerInfo, nil
 }
 
-func (s *PluginSigner) mergeConfig(config map[string]string) map[string]string {
+func (s *pluginSigner) mergeConfig(config map[string]string) map[string]string {
 	c := make(map[string]string, len(s.pluginConfig)+len(config))
 	// First clone s.PluginConfig.
 	for k, v := range s.pluginConfig {
@@ -246,7 +195,7 @@ func (s *PluginSigner) mergeConfig(config map[string]string) map[string]string {
 	return c
 }
 
-func (s *PluginSigner) describeKey(ctx context.Context, config map[string]string) (*plugin.DescribeKeyResponse, error) {
+func (s *pluginSigner) describeKey(ctx context.Context, config map[string]string) (*plugin.DescribeKeyResponse, error) {
 	req := &plugin.DescribeKeyRequest{
 		ContractVersion: plugin.ContractVersion,
 		KeyID:           s.keyID,

--- a/signer/signer.go
+++ b/signer/signer.go
@@ -13,7 +13,7 @@
 
 // Package signer provides notation signing functionality. It implements the
 // notation.Signer interface by providing builtinSigner for local signing and
-// PluginSigner for remote signing.
+// pluginSigner for remote signing.
 package signer
 
 import (
@@ -36,36 +36,24 @@ import (
 // signingAgent is the unprotected header field used by signature.
 const signingAgent = "Notation/1.0.0"
 
-// GenericSigner implements notation.Signer and embeds signature.Signer
-type GenericSigner struct {
-	signer signature.Signer
+// genericSigner implements notation.Signer and embeds signature.Signer
+type genericSigner struct {
+	signature.Signer
 }
 
 // New returns a builtinSigner given key and cert chain
-// Deprecated: New function exists for historical compatibility and should not be used.
-// To create GenericSigner, use NewGenericSigner() function.
 func New(key crypto.PrivateKey, certChain []*x509.Certificate) (notation.Signer, error) {
-	return NewGenericSigner(key, certChain)
-}
-
-// NewGenericSigner returns a builtinSigner given key and cert chain
-func NewGenericSigner(key crypto.PrivateKey, certChain []*x509.Certificate) (*GenericSigner, error) {
 	localSigner, err := signature.NewLocalSigner(certChain, key)
 	if err != nil {
 		return nil, err
 	}
-	return &GenericSigner{
-		signer: localSigner,
+	return &genericSigner{
+		Signer: localSigner,
 	}, nil
 }
 
 // NewFromFiles returns a builtinSigner given key and certChain paths.
 func NewFromFiles(keyPath, certChainPath string) (notation.Signer, error) {
-	return NewGenericSignerFromFiles(keyPath, certChainPath)
-}
-
-// NewGenericSignerFromFiles returns a builtinSigner given key and certChain paths.
-func NewGenericSignerFromFiles(keyPath, certChainPath string) (*GenericSigner, error) {
 	if keyPath == "" {
 		return nil, errors.New("key path not specified")
 	}
@@ -92,12 +80,12 @@ func NewGenericSignerFromFiles(keyPath, certChainPath string) (*GenericSigner, e
 	}
 
 	// create signer
-	return NewGenericSigner(cert.PrivateKey, certs)
+	return New(cert.PrivateKey, certs)
 }
 
 // Sign signs the artifact described by its descriptor and returns the
 // marshalled envelope.
-func (s *GenericSigner) Sign(ctx context.Context, desc ocispec.Descriptor, opts notation.SignerSignOptions) ([]byte, *signature.SignerInfo, error) {
+func (s *genericSigner) Sign(ctx context.Context, desc ocispec.Descriptor, opts notation.SignerSignOptions) ([]byte, *signature.SignerInfo, error) {
 	logger := log.GetLogger(ctx)
 	logger.Debugf("Generic signing for %v in signature media type %v", desc.Digest, opts.SignatureMediaType)
 	// Generate payload to be signed.
@@ -118,7 +106,7 @@ func (s *GenericSigner) Sign(ctx context.Context, desc ocispec.Descriptor, opts 
 			ContentType: envelope.MediaTypePayloadV1,
 			Content:     payloadBytes,
 		},
-		Signer:        s.signer,
+		Signer:        s.Signer,
 		SigningTime:   time.Now(),
 		SigningScheme: signature.SigningSchemeX509,
 		SigningAgent:  signingAgentId,
@@ -157,31 +145,4 @@ func (s *GenericSigner) Sign(ctx context.Context, desc ocispec.Descriptor, opts 
 
 	// TODO: re-enable timestamping https://github.com/notaryproject/notation-go/issues/78
 	return sig, &envContent.SignerInfo, nil
-}
-
-// SignBlob signs the descriptor returned by blobGen and returns the marshalled envelope
-func (s *GenericSigner) SignBlob(ctx context.Context, descGenFunc notation.BlobDescriptorGenerator, opts notation.SignerSignOptions) ([]byte, *signature.SignerInfo, error) {
-	logger := log.GetLogger(ctx)
-	logger.Debugf("Generic blob signing for signature media type %v", opts.SignatureMediaType)
-
-	ks, err := s.signer.KeySpec()
-	if err != nil {
-		return nil, nil, err
-	}
-
-	desc, err := getDescriptor(ks, descGenFunc)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	return s.Sign(ctx, desc, opts)
-}
-
-func getDescriptor(ks signature.KeySpec, descGenFunc notation.BlobDescriptorGenerator) (ocispec.Descriptor, error) {
-	digestAlg, ok := algorithms[ks.SignatureAlgorithm().Hash()]
-	if !ok {
-		return ocispec.Descriptor{}, fmt.Errorf("unknown hashing algo %v", ks.SignatureAlgorithm().Hash())
-	}
-
-	return descGenFunc(digestAlg)
 }

--- a/signer/signer_test.go
+++ b/signer/signer_test.go
@@ -168,72 +168,12 @@ func TestNewFromFiles(t *testing.T) {
 	}
 }
 
-func TestNewFromFilesError(t *testing.T) {
-	tests := map[string]struct {
-		keyPath  string
-		certPath string
-		errMsg   string
-	}{
-		"empty key path": {
-			keyPath:  "",
-			certPath: "someCert",
-			errMsg:   "key path not specified",
-		},
-		"empty cert path": {
-			keyPath:  "someKeyId",
-			certPath: "",
-			errMsg:   "certificate path not specified",
-		},
-	}
-	for name, tc := range tests {
-		t.Run(name, func(t *testing.T) {
-			_, err := NewFromFiles(tc.keyPath, tc.certPath)
-			if err == nil || err.Error() != tc.errMsg {
-				t.Fatalf("TestNewFromPluginFailed expects error %q, got %q", tc.errMsg, err.Error())
-			}
-		})
-	}
-}
-
-func TestNewError(t *testing.T) {
-	wantErr := "\"certs\" param is invalid. Error: empty certs"
-	_, err := New(nil, nil)
-	if err == nil || err.Error() != wantErr {
-		t.Fatalf("TestNewFromPluginFailed expects error %q, got %q", wantErr, err.Error())
-	}
-}
-
 func TestSignWithCertChain(t *testing.T) {
 	// sign with key
 	for _, envelopeType := range signature.RegisteredEnvelopeTypes() {
 		for _, keyCert := range keyCertPairCollections {
 			t.Run(fmt.Sprintf("envelopeType=%v_keySpec=%v", envelopeType, keyCert.keySpecName), func(t *testing.T) {
 				validateSignWithCerts(t, envelopeType, keyCert.key, keyCert.certs)
-			})
-		}
-	}
-}
-
-func TestSignBlobWithCertChain(t *testing.T) {
-	// sign with key
-	for _, envelopeType := range signature.RegisteredEnvelopeTypes() {
-		for _, keyCert := range keyCertPairCollections {
-			t.Run(fmt.Sprintf("envelopeType=%v_keySpec=%v", envelopeType, keyCert.keySpecName), func(t *testing.T) {
-				s, err := NewGenericSigner(keyCert.key, keyCert.certs)
-				if err != nil {
-					t.Fatalf("NewSigner() error = %v", err)
-				}
-
-				sOpts := notation.SignerSignOptions{
-					SignatureMediaType: envelopeType,
-				}
-				sig, _, err := s.SignBlob(context.Background(), getDescriptorFunc(false), sOpts)
-				if err != nil {
-					t.Fatalf("Sign() error = %v", err)
-				}
-
-				// basic verification
-				basicVerification(t, sig, envelopeType, keyCert.certs[len(keyCert.certs)-1], nil)
 			})
 		}
 	}


### PR DESCRIPTION
Revert:
- reverted #379 
- reverted test cases: `TestSignOptsMissingSignatureMediaType` and `TestSignOptsUnknownMediaType`, introduced in #405

Test:
- added test for `log` package to pass 80% coverage target

This reverts commit ec42378613e1e189da0e94f1c225dba0b06a0fed.


Resolves part of #412 
Signed-off-by: Junjie Gao <junjiegao@microsoft.com>