### PR TITLE
bump: bump up notation-core-go

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.21
 
 require (
 	github.com/go-ldap/ldap/v3 v3.4.8
-	github.com/notaryproject/notation-core-go v1.0.4-0.20240716001320-f45197cbd53b
+	github.com/notaryproject/notation-core-go v1.1.0-beta.1
 	github.com/notaryproject/notation-plugin-framework-go v1.0.0
 	github.com/notaryproject/tspclient-go v0.1.1-0.20240715235637-df25ef8d2172
 	github.com/opencontainers/go-digest v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -32,8 +32,8 @@ github.com/jcmturner/gokrb5/v8 v8.4.4 h1:x1Sv4HaTpepFkXbt2IkL29DXRf8sOfZXo8eRKh6
 github.com/jcmturner/gokrb5/v8 v8.4.4/go.mod h1:1btQEpgT6k+unzCwX1KdWMEwPPkkgBtP+F6aCACiMrs=
 github.com/jcmturner/rpc/v2 v2.0.3 h1:7FXXj8Ti1IaVFpSAziCZWNzbNuZmnvw/i6CqLNdWfZY=
 github.com/jcmturner/rpc/v2 v2.0.3/go.mod h1:VUJYCIDm3PVOEHw8sgt091/20OJjskO/YJki3ELg/Hc=
-github.com/notaryproject/notation-core-go v1.0.4-0.20240716001320-f45197cbd53b h1:uJ4bmNieZRkPj3UgmKr3bZr8vs7UJ2MdlJMeB0oOaZw=
-github.com/notaryproject/notation-core-go v1.0.4-0.20240716001320-f45197cbd53b/go.mod h1:MdxSbL9F5h63EmtXWfYMWy7hEmGmOmsfN4B6KM2WyhY=
+github.com/notaryproject/notation-core-go v1.1.0-beta.1 h1:Rpg8qhoEo4nIdiAWz597lbEcvEmjKwJLUtvJqXa8M4c=
+github.com/notaryproject/notation-core-go v1.1.0-beta.1/go.mod h1:MdxSbL9F5h63EmtXWfYMWy7hEmGmOmsfN4B6KM2WyhY=
 github.com/notaryproject/notation-plugin-framework-go v1.0.0 h1:6Qzr7DGXoCgXEQN+1gTZWuJAZvxh3p8Lryjn5FaLzi4=
 github.com/notaryproject/notation-plugin-framework-go v1.0.0/go.mod h1:RqWSrTOtEASCrGOEffq0n8pSg2KOgKYiWqFWczRSics=
 github.com/notaryproject/tspclient-go v0.1.1-0.20240715235637-df25ef8d2172 h1:Q8UsmeFMzyFuMMq4dlbIRJUi7khEKXKUe2H2Hm3W92Y=


### PR DESCRIPTION
Bumping up notation-core-go to `v1.1.0-beta.1`.