### PR TITLE
bump: release v1.2.0

### DIFF
--- a/signer/signer.go
+++ b/signer/signer.go
@@ -34,7 +34,7 @@ import (
 )
 
 // signingAgent is the unprotected header field used by signature.
-const signingAgent = "notation-go/1.2.0-rc.1"
+const signingAgent = "notation-go/1.2.0"
 
 // GenericSigner implements notation.Signer and embeds signature.Signer
 type GenericSigner struct {


### PR DESCRIPTION
## Release

This would mean tagging a6ca9ee64a8e13bd4a45439c3d389d9fb59bdd19 as `v1.2.0` to release.

## Vote

We need at least `4` approvals from `6` maintainers to release `notation-go v1.2.0`.

- [x] Pritesh Bandi (@priteshbandi)
- [x] Junjie Gao (@JeyJeyGao)
- [ ] Rakesh Gariganti (@rgnote)
- [ ] Milind Gokarn (@gokarnm)
- [x] Shiwei Zhang (@shizhMSFT)
- [x] Patrick Zheng (@Two-Hearts)

## What's Changed
* bump: bump up for v1.2.0 release by @Two-Hearts in https://github.com/notaryproject/notation-go/pull/442


**Full Changelog**:
https://github.com/notaryproject/notation-go/compare/v1.2.0-rc.1...a6ca9ee64a8e13bd4a45439c3d389d9fb59bdd19

## Actions

Please review the PR and vote by approving.