### PR TITLE
fix: dir no longer panics when HOME and XDG_CONFIG_HOME are not set

### DIFF
--- a/dir/fs.go
+++ b/dir/fs.go
@@ -51,10 +51,10 @@ func NewSysFS(root string) SysFS {
 
 // ConfigFS is the config SysFS
 func ConfigFS() SysFS {
-	return NewSysFS(UserConfigDir)
+	return NewSysFS(userConfigDirPath())
 }
 
 // PluginFS is the plugin SysFS
 func PluginFS() SysFS {
-	return NewSysFS(filepath.Join(UserLibexecDir, PathPlugins))
+	return NewSysFS(filepath.Join(userLibexecDirPath(), PathPlugins))
 }

--- a/dir/fs_test.go
+++ b/dir/fs_test.go
@@ -67,7 +67,7 @@ func TestPluginFS(t *testing.T) {
 	if err != nil {
 		t.Fatalf("SysPath() failed. err = %v", err)
 	}
-	if path != filepath.Join(UserLibexecDir, PathPlugins, "plugin") {
-		t.Fatalf(`SysPath() failed. got: %q, want: %q`, path, filepath.Join(UserLibexecDir, PathPlugins, "plugin"))
+	if path != filepath.Join(userLibexecDirPath(), PathPlugins, "plugin") {
+		t.Fatalf(`SysPath() failed. got: %q, want: %q`, path, filepath.Join(userLibexecDirPath(), PathPlugins, "plugin"))
 	}
 }

--- a/dir/path.go
+++ b/dir/path.go
@@ -73,21 +73,28 @@ const (
 
 var userConfigDir = os.UserConfigDir // for unit test
 
-func init() {
-	loadUserPath()
+// userConfigDirPath returns the user level {NOTATION_CONFIG} path.
+func userConfigDirPath() string {
+	if UserConfigDir == "" {
+		userDir, err := userConfigDir()
+		if err != nil {
+			// fallback to current directory
+			UserConfigDir = "." + notation
+			return UserConfigDir
+		}
+		// set user config
+		UserConfigDir = filepath.Join(userDir, notation)
+	}
+	return UserConfigDir
 }
 
-// loadUserPath function defines UserConfigDir and UserLibexecDir.
-func loadUserPath() {
-	// set user config
-	userDir, err := userConfigDir()
-	if err != nil {
-		panic(err)
+// userLibexecDirPath returns the user level {NOTATION_LIBEXEC} path.
+func userLibexecDirPath() string {
+	if UserLibexecDir == "" {
+		// set user libexec
+		UserLibexecDir = userConfigDirPath()
 	}
-	UserConfigDir = filepath.Join(userDir, notation)
-
-	// set user libexec
-	UserLibexecDir = UserConfigDir
+	return UserLibexecDir
 }
 
 // LocalKeyPath returns the local key and local cert relative paths.


### PR DESCRIPTION
This PR is for `release-1.2` branch only.

This PR cherry picks the fix of issue #446 from main.

The fix:
- Removed the `init()` function from `dir/path`
- When `userConfigDir()` returns an error, instead of `panic(err)`, default to the current directory instead
- Split `loadUserPath()` into two new functions used to setup and return the values for `UserConfigDir` and `UserLibexecDir`
- Added additional unit tests for the two new functions and to test the default directory is used when `HOME` is set to `""`
