### PR TITLE
bump: release v1.2.1

### DIFF
--- a/signer/signer.go
+++ b/signer/signer.go
@@ -34,7 +34,7 @@ import (
 )
 
 // signingAgent is the unprotected header field used by signature.
-const signingAgent = "notation-go/1.2.0"
+const signingAgent = "notation-go/1.2.1"
 
 // GenericSigner implements notation.Signer and embeds signature.Signer
 type GenericSigner struct {


### PR DESCRIPTION
## Release

This would mean tagging e6dde2dc5f0b04ccbdaa241e5ab6f716ff7e1944 as `v1.2.1` to release.

## Vote

We need at least `4` approvals from `6` maintainers to release `notation-go v1.2.1`.

- [x] Pritesh Bandi (@priteshbandi)
- [x] Junjie Gao (@JeyJeyGao)
- [ ] Rakesh Gariganti (@rgnote)
- [ ] Milind Gokarn (@gokarnm)
- [x] Shiwei Zhang (@shizhMSFT)
- [x] Patrick Zheng (@Two-Hearts)

## What's Changed
* bump: release v1.2.0 by @Two-Hearts in https://github.com/notaryproject/notation-go/pull/445
* fix: dir no longer panics when HOME and XDG_CONFIG_HOME are not set by @Two-Hearts in https://github.com/notaryproject/notation-go/pull/451


**Full Changelog**:
https://github.com/notaryproject/notation-go/compare/v1.2.0...e6dde2dc5f0b04ccbdaa241e5ab6f716ff7e1944

## Actions

Please review the PR and vote by approving.