### PR TITLE
test: add fuzz test

### DIFF
--- a/internal/pkix/fuzz_test.go
+++ b/internal/pkix/fuzz_test.go
@@ -1,0 +1,24 @@
+// Copyright The Notary Project Authors.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pkix
+
+import (
+	"testing"
+)
+
+func FuzzParseDistinguishedName(f *testing.F) {
+	f.Fuzz(func(t *testing.T, name string) {
+		_, _ = ParseDistinguishedName(name)
+	})
+}


### PR DESCRIPTION
Adds a fuzz test from cncf-fuzzing: https://github.com/cncf/cncf-fuzzing/blob/main/projects/notary/fuzz_pkix_test.go