### PR TITLE
test: add trustpolicy fuzzer

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/notaryproject/notation-go
 go 1.22.0
 
 require (
+	github.com/AdaLogics/go-fuzz-headers v0.0.0-20240806141605-e8a1dd7889d6
 	github.com/go-ldap/ldap/v3 v3.4.8
 	github.com/notaryproject/notation-core-go v1.1.1-0.20240920045731-0786f51de737
 	github.com/notaryproject/notation-plugin-framework-go v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/AdaLogics/go-fuzz-headers v0.0.0-20240806141605-e8a1dd7889d6 h1:He8afgbRMd7mFxO99hRNu+6tazq8nFF9lIwo9JFroBk=
+github.com/AdaLogics/go-fuzz-headers v0.0.0-20240806141605-e8a1dd7889d6/go.mod h1:8o94RPi1/7XTJvwPpRSzSUedZrtlirdB3r9Z20bi2f8=
 github.com/Azure/go-ntlmssp v0.0.0-20221128193559-754e69321358 h1:mFRzDkZVAjdal+s7s0MwaRv9igoPqLRdzOLzw/8Xvq8=
 github.com/Azure/go-ntlmssp v0.0.0-20221128193559-754e69321358/go.mod h1:chxPXzSsl7ZWRAuOIE23GDNzjWuZquvFlgA8xmpunjU=
 github.com/alexbrainman/sspi v0.0.0-20231016080023-1a75b4708caa h1:LHTHcTQiSGT7VVbI0o4wBRNQIgn917usHWOd6VAffYI=

--- a/verifier/trustpolicy/fuzz_test.go
+++ b/verifier/trustpolicy/fuzz_test.go
@@ -1,0 +1,29 @@
+// Copyright The Notary Project Authors.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package trustpolicy
+
+import (
+	"testing"
+
+	fuzz "github.com/AdaLogics/go-fuzz-headers"
+)
+
+func FuzzDocumentValidate(f *testing.F) {
+	f.Fuzz(func(t *testing.T, documentData []byte) {
+		ff := fuzz.NewConsumer(documentData)
+		policyDoc := &Document{}
+		ff.GenerateStruct(policyDoc)
+		policyDoc.Validate()
+	})
+}


### PR DESCRIPTION
Moves [this fuzzer](https://github.com/cncf/cncf-fuzzing/blob/main/projects/notary/fuzz_trustpolicy.go) upstream from cncf-fuzzing. Adds a dependency to randomize structs.