### PR TITLE
bump: release v1.3.0-rc.1

### DIFF
--- a/signer/signer.go
+++ b/signer/signer.go
@@ -34,7 +34,7 @@ import (
 )
 
 // signingAgent is the unprotected header field used by signature.
-const signingAgent = "notation-go/1.3.0+unreleased"
+const signingAgent = "notation-go/1.3.0-rc.1"
 
 // GenericSigner implements notation.Signer and embeds signature.Signer
 type GenericSigner struct {


### PR DESCRIPTION
## Release

This would mean tagging 26f491ea7d4455753c2d6b941177906e39145141 as `v1.3.0-rc.1` to release.

## Vote

We need at least `4` approvals from `6` maintainers to release `notation-go v1.3.0-rc.1`.

- [x] Pritesh Bandi (@priteshbandi)
- [ ] Rakesh Gariganti (@rgnote)
- [ ] Milind Gokarn (@gokarnm)
- [x] Yi Zha (@yizha1)
- [x] Shiwei Zhang (@shizhMSFT)
- [x] Patrick Zheng (@Two-Hearts)

## What's Changed
* build(deps): bump golang.org/x/mod from 0.19.0 to 0.20.0 by @dependabot in https://github.com/notaryproject/notation-go/pull/433
* build(deps): bump golang.org/x/crypto from 0.25.0 to 0.26.0 by @dependabot in https://github.com/notaryproject/notation-go/pull/434
* bump: upgrade golang to v1.22 by @Two-Hearts in https://github.com/notaryproject/notation-go/pull/440
* docs: create release checklist on main by @Two-Hearts in https://github.com/notaryproject/notation-go/pull/443
* bump: bump up notation-core-go and signingAgent by @Two-Hearts in https://github.com/notaryproject/notation-go/pull/444
* fix: dir no longer panics when HOME and XDG_CONFIG_HOME are not set by @JasonTheDeveloper in https://github.com/notaryproject/notation-go/pull/449
* bump: update golang version to v1.22.0 by @Two-Hearts in https://github.com/notaryproject/notation-go/pull/457
* feat: crl support by @JeyJeyGao in https://github.com/notaryproject/notation-go/pull/458
* build(deps): bump golang.org/x/crypto from 0.26.0 to 0.27.0 by @dependabot in https://github.com/notaryproject/notation-go/pull/455
* feat: crl cache by @Two-Hearts in https://github.com/notaryproject/notation-go/pull/462
* refactor!: remove blob sign/verify for v1.3.0-rc.1 release by @Two-Hearts in https://github.com/notaryproject/notation-go/pull/464


**Full Changelog**:
https://github.com/notaryproject/notation-go/compare/v1.2.1...26f491ea7d4455753c2d6b941177906e39145141

## Actions

Please review the PR and vote by approving.