### PR TITLE
bump: release v1.3.0-rc.2

### DIFF
--- a/signer/signer.go
+++ b/signer/signer.go
@@ -34,7 +34,7 @@ import (
 )
 
 // signingAgent is the unprotected header field used by signature.
-const signingAgent = "notation-go/1.3.0-rc.1"
+const signingAgent = "notation-go/1.3.0-rc.2"
 
 // GenericSigner implements notation.Signer and embeds signature.Signer
 type GenericSigner struct {


### PR DESCRIPTION
## Release

This would mean tagging f63defd138f83e5b86e2bc9c4dc65972af9d19fc as `v1.3.0-rc.2` to release.

## Vote

We need at least `4` approvals from `6` maintainers to release `notation-go v1.3.0-rc.2`.

- [ ] Pritesh Bandi (@priteshbandi)
- [ ] Junjie Gao (@JeyJeyGao)
- [ ] Milind Gokarn (@gokarnm)
- [ ] Vani Rao (@vaninrao10)
- [ ] Shiwei Zhang (@shizhMSFT)
- [ ] Patrick Zheng (@Two-Hearts)

## What's Changed
* bump: release v1.3.0-rc.1 by @Two-Hearts in https://github.com/notaryproject/notation-go/pull/465
* test: add fuzz test by @AdamKorcz in https://github.com/notaryproject/notation-go/pull/459
* build(deps): bump github.com/veraison/go-cose from 1.1.0 to 1.3.0 by @dependabot in https://github.com/notaryproject/notation-go/pull/467
* fix: added tsa trust store root cert validation by @Two-Hearts in https://github.com/notaryproject/notation-go/pull/471
* chore: add crl cache debug logs by @Two-Hearts in https://github.com/notaryproject/notation-go/pull/473
* build(deps): bump golang.org/x/crypto from 0.27.0 to 0.28.0 by @dependabot in https://github.com/notaryproject/notation-go/pull/468
* build(deps): bump github.com/golang-jwt/jwt/v4 from 4.5.0 to 4.5.1 by @dependabot in https://github.com/notaryproject/notation-go/pull/474
* build(deps): bump golang.org/x/crypto from 0.28.0 to 0.29.0 by @dependabot in https://github.com/notaryproject/notation-go/pull/476
* fix: crl cache log and err msg by @Two-Hearts in https://github.com/notaryproject/notation-go/pull/475
* build(deps): bump golang.org/x/mod from 0.21.0 to 0.22.0 by @dependabot in https://github.com/notaryproject/notation-go/pull/477
* chore: Improve error message in case of plugin timeout by @priteshbandi in https://github.com/notaryproject/notation-go/pull/472
* fix: timestamping by @Two-Hearts in https://github.com/notaryproject/notation-go/pull/478
* fix: add warning message for non-revokable certificate by @JeyJeyGao in https://github.com/notaryproject/notation-go/pull/479
* fix: enable timestamping cert chain revocation check during signing by @Two-Hearts in https://github.com/notaryproject/notation-go/pull/482
* perf(log): encode objects only when logged by @JeyJeyGao in https://github.com/notaryproject/notation-go/pull/481
* chore: cherry pick fixes from `main` by @Two-Hearts in https://github.com/notaryproject/notation-go/pull/487
* chore: backport #469 for updating logs by @Two-Hearts in https://github.com/notaryproject/notation-go/pull/489
* bump: bump up notation-core-go for `release-1.3` branch by @Two-Hearts in https://github.com/notaryproject/notation-go/pull/490


**Full Changelog**:
https://github.com/notaryproject/notation-go/compare/v1.3.0-rc.1...f63defd138f83e5b86e2bc9c4dc65972af9d19fc

## Actions

Please review the PR and vote by approving.