### PR TITLE
bump: release v1.3.0-rc.2

### DIFF
--- a/signer/signer.go
+++ b/signer/signer.go
@@ -34,7 +34,7 @@ import (
 )
 
 // signingAgent is the unprotected header field used by signature.
-const signingAgent = "notation-go/1.3.0-rc.1"
+const signingAgent = "notation-go/1.3.0-rc.2"
 
 // GenericSigner implements notation.Signer and embeds signature.Signer
 type GenericSigner struct {


### PR DESCRIPTION
## Release

This would mean tagging c3c9bcdcf3db56c9a920188639006f340551e737 as `v1.3.0-rc.2` to release.

## Vote

We need at least `4` approvals from `6` maintainers to release `notation-go v1.3.0-rc.2`.

- [ ] Pritesh Bandi (@priteshbandi)
- [x] Junjie Gao (@JeyJeyGao)
- [ ] Milind Gokarn (@gokarnm)
- [x] Vani Rao (@vaninrao10)
- [x] Shiwei Zhang (@shizhMSFT)
- [x] Patrick Zheng (@Two-Hearts)

## What's Changed
* bump: release v1.3.0-rc.1 by @Two-Hearts in https://github.com/notaryproject/notation-go/pull/465
* chore: cherry pick fixes from `main` by @Two-Hearts in https://github.com/notaryproject/notation-go/pull/487
* chore: backport #469 for updating logs by @Two-Hearts in https://github.com/notaryproject/notation-go/pull/489
* bump: bump up notation-core-go for `release-1.3` branch by @Two-Hearts in https://github.com/notaryproject/notation-go/pull/490
* bump: bump up crypto for release-1.3 branch by @Two-Hearts in https://github.com/notaryproject/notation-go/pull/493
* fix: cherry pick fix of plugin output size (#484) to release-1.3 branch by @Two-Hearts in https://github.com/notaryproject/notation-go/pull/494

**Full Changelog**:
https://github.com/notaryproject/notation-go/compare/v1.3.0-rc.1...c3c9bcdcf3db56c9a920188639006f340551e737

## Actions

Please review the PR and vote by approving.