### PR TITLE
Fix build on 32bit platforms

### DIFF
--- a/notation_test.go
+++ b/notation_test.go
@@ -760,7 +760,7 @@ func TestLocalContent(t *testing.T) {
 		// verify the artifact
 		verifyOpts := VerifyOptions{
 			ArtifactReference:    artifactReference,
-			MaxSignatureAttempts: math.MaxInt64,
+			MaxSignatureAttempts: math.MaxInt,
 		}
 		policyDocument := dummyPolicyDocument()
 		verifier := dummyVerifier{&policyDocument, mock.PluginManager{}, false, *trustpolicy.LevelStrict, false}


### PR DESCRIPTION
Reproduce with:

$ GOARCH=386 go test -v github.com/notaryproject/notation-go
./notation_test.go:763:26: cannot use math.MaxInt64 (untyped int constant 9223372036854775807) as int value in struct literal (overflows)
FAIL    github.com/notaryproject/notation-go [build failed]
FAIL

Signed-off-by: Reinhard Tartler <siretart@gmail.com>