### PR TITLE
bump: release v1.3.0

### DIFF
--- a/signer/signer.go
+++ b/signer/signer.go
@@ -34,7 +34,7 @@ import (
 )
 
 // signingAgent is the unprotected header field used by signature.
-const signingAgent = "notation-go/1.3.0-rc.2"
+const signingAgent = "notation-go/1.3.0"
 
 // GenericSigner implements notation.Signer and embeds signature.Signer
 type GenericSigner struct {


### PR DESCRIPTION
## Release

This would mean tagging 31ee0d664a21dccc77175f4b1e736d3a90231fe4 as `v1.3.0` to release.

## Vote

We need at least `4` approvals from `6` maintainers to release `notation-go v1.3.0`.

- [x] Pritesh Bandi (@priteshbandi)
- [x] Junjie Gao (@JeyJeyGao)
- [ ] Milind Gokarn (@gokarnm)
- [ ] Vani Rao (@vaninrao10)
- [x] Shiwei Zhang (@shizhMSFT)
- [x] Patrick Zheng (@Two-Hearts)

## What's Changed
* bump: release v1.3.0-rc.2 by @Two-Hearts in https://github.com/notaryproject/notation-go/pull/495
* cherry-pick: cherry pick from main to release-1.3 branch by @Two-Hearts in https://github.com/notaryproject/notation-go/pull/505
* bump: bump up dependencies for release-1.3 branch by @Two-Hearts in https://github.com/notaryproject/notation-go/pull/506

**Full Changelog**:
https://github.com/notaryproject/notation-go/compare/v1.3.0-rc.2...31ee0d664a21dccc77175f4b1e736d3a90231fe4

## Actions

Please review the PR and vote by approving.