### PR TITLE
refactor: updated verifier constructor

### DIFF
--- a/example_verifyBlob_test.go
+++ b/example_verifyBlob_test.go
@@ -61,7 +61,9 @@ func Example_verifyBlob() {
 	}
 
 	// exampleVerifier implements [notation.Verify] and [notation.VerifyBlob].
-	exampleVerifier, err := verifier.NewVerifier(nil, &exampleBlobPolicyDocument, truststore.NewX509TrustStore(dir.ConfigFS()), nil)
+	exampleVerifier, err := verifier.NewVerifierWithOptions(truststore.NewX509TrustStore(dir.ConfigFS()), verifier.VerifierOptions{
+		BlobTrustPolicy: &exampleBlobPolicyDocument,
+	})
 	if err != nil {
 		panic(err) // Handle error
 	}

--- a/verifier/verifier.go
+++ b/verifier/verifier.go
@@ -147,7 +147,6 @@ func NewWithOptions(ociTrustPolicy *trustpolicy.OCIDocument, trustStore truststo
 func NewVerifierWithOptions(trustStore truststore.X509TrustStore, verifierOptions VerifierOptions) (*verifier, error) {
 	ociTrustPolicy := verifierOptions.OCITrustPolicy
 	blobTrustPolicy := verifierOptions.BlobTrustPolicy
-	pluginManager := verifierOptions.PluginManager
 	if trustStore == nil {
 		return nil, errors.New("trustStore cannot be nil")
 	}
@@ -168,7 +167,7 @@ func NewVerifierWithOptions(trustStore truststore.X509TrustStore, verifierOption
 		ociTrustPolicyDoc:  ociTrustPolicy,
 		blobTrustPolicyDoc: blobTrustPolicy,
 		trustStore:         trustStore,
-		pluginManager:      pluginManager,
+		pluginManager:      verifierOptions.PluginManager,
 	}
 
 	if err := v.setRevocation(verifierOptions); err != nil {

--- a/verifier/verifier_test.go
+++ b/verifier/verifier_test.go
@@ -728,9 +728,13 @@ func TestNewVerifierWithOptions(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error while creating revocation object: %v", err)
 	}
-	opts := VerifierOptions{RevocationClient: r}
 
-	v, err := NewVerifierWithOptions(&ociPolicy, &blobPolicy, store, pm, opts)
+	v, err := NewVerifierWithOptions(store, VerifierOptions{
+		RevocationClient: r,
+		OCITrustPolicy:   &ociPolicy,
+		BlobTrustPolicy:  &blobPolicy,
+		PluginManager:    pm,
+	})
 	if err != nil {
 		t.Fatalf("expected NewVerifierWithOptions constructor to succeed, but got %v", err)
 	}
@@ -750,18 +754,28 @@ func TestNewVerifierWithOptions(t *testing.T) {
 		t.Fatal("expected nil revocationCodeSigningValidator")
 	}
 
-	_, err = NewVerifierWithOptions(nil, &blobPolicy, store, pm, opts)
+	_, err = NewVerifierWithOptions(store, VerifierOptions{
+		RevocationClient: r,
+		BlobTrustPolicy:  &blobPolicy,
+		PluginManager:    pm,
+	})
 	if err != nil {
 		t.Fatalf("expected NewVerifierWithOptions constructor to succeed, but got %v", err)
 	}
 
-	_, err = NewVerifierWithOptions(&ociPolicy, nil, store, pm, opts)
+	_, err = NewVerifierWithOptions(store, VerifierOptions{
+		RevocationClient: r,
+		OCITrustPolicy:   &ociPolicy,
+		PluginManager:    pm,
+	})
 	if err != nil {
 		t.Fatalf("expected NewVerifierWithOptions constructor to succeed, but got %v", err)
 	}
 
-	opts.RevocationClient = nil
-	_, err = NewVerifierWithOptions(&ociPolicy, nil, store, pm, opts)
+	_, err = NewVerifierWithOptions(store, VerifierOptions{
+		OCITrustPolicy: &ociPolicy,
+		PluginManager:  pm,
+	})
 	if err != nil {
 		t.Fatalf("expected NewVerifierWithOptions constructor to succeed, but got %v", err)
 	}
@@ -770,19 +784,11 @@ func TestNewVerifierWithOptions(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	opts = VerifierOptions{
+	v, err = NewVerifierWithOptions(store, VerifierOptions{
 		RevocationCodeSigningValidator: csValidator,
-	}
-	v, err = NewVerifierWithOptions(&ociPolicy, nil, store, pm, opts)
-	if err != nil {
-		t.Fatalf("expected NewVerifierWithOptions constructor to succeed, but got %v", err)
-	}
-	if v.revocationCodeSigningValidator == nil {
-		t.Fatal("expected v.revocationCodeSigningValidator to be non-nil")
-	}
-
-	opts = VerifierOptions{}
-	v, err = NewVerifierWithOptions(&ociPolicy, nil, store, pm, opts)
+		OCITrustPolicy:                 &ociPolicy,
+		PluginManager:                  pm,
+	})
 	if err != nil {
 		t.Fatalf("expected NewVerifierWithOptions constructor to succeed, but got %v", err)
 	}
@@ -803,17 +809,23 @@ func TestNewVerifierWithOptionsError(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error while creating revocation timestamp object: %v", err)
 	}
-	opts := VerifierOptions{
+
+	_, err = NewVerifierWithOptions(store, VerifierOptions{
 		RevocationClient:                r,
 		RevocationTimestampingValidator: rt,
-	}
-
-	_, err = NewVerifierWithOptions(nil, nil, store, pm, opts)
+		PluginManager:                   pm,
+	})
 	if err == nil || err.Error() != "ociTrustPolicy and blobTrustPolicy both cannot be nil" {
 		t.Errorf("expected err but not found.")
 	}
 
-	_, err = NewVerifierWithOptions(&ociPolicy, &blobPolicy, nil, pm, opts)
+	_, err = NewVerifierWithOptions(nil, VerifierOptions{
+		RevocationClient:                r,
+		RevocationTimestampingValidator: rt,
+		OCITrustPolicy:                  &ociPolicy,
+		BlobTrustPolicy:                 &blobPolicy,
+		PluginManager:                   pm,
+	})
 	if err == nil || err.Error() != "trustStore cannot be nil" {
 		t.Errorf("expected err but not found.")
 	}
@@ -831,7 +843,10 @@ func TestVerifyBlob(t *testing.T) {
 			},
 		},
 	}
-	v, err := NewVerifier(nil, policy, &testTrustStore{}, pm)
+	v, err := NewVerifierWithOptions(&testTrustStore{}, VerifierOptions{
+		BlobTrustPolicy: policy,
+		PluginManager:   pm,
+	})
 	if err != nil {
 		t.Fatalf("unexpected error while creating verifier: %v", err)
 	}
@@ -877,7 +892,10 @@ func TestVerifyBlob_Error(t *testing.T) {
 			},
 		},
 	}
-	v, err := NewVerifier(nil, policy, &testTrustStore{}, pm)
+	v, err := NewVerifierWithOptions(&testTrustStore{}, VerifierOptions{
+		BlobTrustPolicy: policy,
+		PluginManager:   pm,
+	})
 	if err != nil {
 		t.Fatalf("unexpected error while creating verifier: %v", err)
 	}

--- a/verifier/verifier_test.go
+++ b/verifier/verifier_test.go
@@ -17,10 +17,12 @@ import (
 	"context"
 	"crypto/x509"
 	"crypto/x509/pkix"
+	"encoding/json"
 	"encoding/pem"
 	"errors"
 	"fmt"
 	"net/http"
+	"os"
 	"path/filepath"
 	"reflect"
 	"strconv"
@@ -828,6 +830,46 @@ func TestNewVerifierWithOptionsError(t *testing.T) {
 	})
 	if err == nil || err.Error() != "trustStore cannot be nil" {
 		t.Errorf("expected err but not found.")
+	}
+}
+
+func TestNewOCIVerifierFromConfig(t *testing.T) {
+	defer func(oldUserConfigDir string) {
+		dir.UserConfigDir = oldUserConfigDir
+	}(dir.UserConfigDir)
+
+	tempRoot := t.TempDir()
+	dir.UserConfigDir = tempRoot
+	path := filepath.Join(tempRoot, "trustpolicy.oci.json")
+	policyJson, _ := json.Marshal(dummyOCIPolicyDocument())
+	if err := os.WriteFile(path, policyJson, 0600); err != nil {
+		t.Fatalf("TestLoadOCIDocument write policy file failed. Error: %v", err)
+	}
+	t.Cleanup(func() { os.RemoveAll(tempRoot) })
+
+	_, err := NewOCIVerifierFromConfig()
+	if err != nil {
+		t.Fatalf("expected NewOCIVerifierFromConfig constructor to succeed, but got %v", err)
+	}
+}
+
+func TestNewBlobVerifierFromConfig(t *testing.T) {
+	defer func(oldUserConfigDir string) {
+		dir.UserConfigDir = oldUserConfigDir
+	}(dir.UserConfigDir)
+
+	tempRoot := t.TempDir()
+	dir.UserConfigDir = tempRoot
+	path := filepath.Join(tempRoot, "trustpolicy.blob.json")
+	policyJson, _ := json.Marshal(dummyBlobPolicyDocument())
+	if err := os.WriteFile(path, policyJson, 0600); err != nil {
+		t.Fatalf("TestLoadBlobDocument write policy file failed. Error: %v", err)
+	}
+	t.Cleanup(func() { os.RemoveAll(tempRoot) })
+
+	_, err := NewBlobVerifierFromConfig()
+	if err != nil {
+		t.Fatalf("expected NewBlobVerifierFromConfig constructor to succeed, but got %v", err)
 	}
 }
 


### PR DESCRIPTION
This PR moves optional parameters of the verifier constructor into `VerifierOptions`.