### PR TITLE
fix: remove signing time check during authenticTimestamp

### DIFF
--- a/verifier/timestamp_test.go
+++ b/verifier/timestamp_test.go
@@ -287,29 +287,6 @@ func TestAuthenticTimestamp(t *testing.T) {
 		}
 	})
 
-	t.Run("verify Authentic Timestamp failed due to signing time after timestamp value", func(t *testing.T) {
-		signedToken, err := os.ReadFile("testdata/timestamp/countersignature/TimeStampToken.p7s")
-		if err != nil {
-			t.Fatalf("failed to get signedToken: %v", err)
-		}
-		envContent, err := parseEnvContent("testdata/timestamp/sigEnv/withoutTimestamp.sig", jws.MediaTypeEnvelope)
-		if err != nil {
-			t.Fatalf("failed to get signature envelope content: %v", err)
-		}
-		envContent.SignerInfo.UnsignedAttributes.TimestampSignature = signedToken
-		envContent.SignerInfo.Signature = []byte("notation")
-		envContent.SignerInfo.SignedAttributes.SigningTime = time.Date(3000, time.November, 10, 23, 0, 0, 0, time.UTC)
-		outcome := &notation.VerificationOutcome{
-			EnvelopeContent:   envContent,
-			VerificationLevel: trustpolicy.LevelStrict,
-		}
-		authenticTimestampResult := verifyAuthenticTimestamp(context.Background(), dummyTrustPolicy.Name, dummyTrustPolicy.TrustStores, dummyTrustPolicy.SignatureVerification, trustStore, revocationTimestampingValidator, outcome)
-		expectedErrMsg := "timestamp [2021-09-17T14:09:09Z, 2021-09-17T14:09:11Z] is not bounded after the signing time \"3000-11-10 23:00:00 +0000 UTC\""
-		if err := authenticTimestampResult.Error; err == nil || err.Error() != expectedErrMsg {
-			t.Fatalf("expected %s, but got %s", expectedErrMsg, err)
-		}
-	})
-
 	t.Run("verify Authentic Timestamp failed due to trust store does not exist", func(t *testing.T) {
 		dummyTrustPolicy := &trustpolicy.TrustPolicy{
 			Name:           "test-timestamp",

--- a/verifier/verifier.go
+++ b/verifier/verifier.go
@@ -928,9 +928,6 @@ func verifyTimestamp(ctx context.Context, policyName string, trustStores []strin
 	if err != nil {
 		return fmt.Errorf("failed to verify the timestamp countersignature with error: %w", err)
 	}
-	if !timestamp.BoundedAfter(signerInfo.SignedAttributes.SigningTime) {
-		return fmt.Errorf("timestamp %s is not bounded after the signing time %q", timestamp.Format(time.RFC3339), signerInfo.SignedAttributes.SigningTime)
-	}
 
 	// 3. Validate timestamping certificate chain
 	logger.Debug("Validating timestamping certificate chain...")


### PR DESCRIPTION
This PR removes the signing time check against timestamp during authentic timestamp verification. The possibility of time skew requires further discussion on the check.

Resolves: #513 