### PR TITLE
bump: release v1.3.1

### DIFF
--- a/signer/signer.go
+++ b/signer/signer.go
@@ -34,7 +34,7 @@ import (
 )
 
 // signingAgent is the unprotected header field used by signature.
-const signingAgent = "notation-go/1.3.0"
+const signingAgent = "notation-go/1.3.1"
 
 // GenericSigner implements notation.Signer and embeds signature.Signer
 type GenericSigner struct {


### PR DESCRIPTION
## Release

This would mean tagging 961cef1f72d86e8f564bf7790fe04b23af53f02e as `v1.3.1` to release.

## Vote

We need at least `4` approvals from `6` maintainers to release `notation-go v1.3.1`.

- [x] Junjie Gao (@JeyJeyGao)
- [ ] Rakesh Gariganti (@rgnote)
- [ ] Milind Gokarn (@gokarnm)
- [x] Vani Rao (@vaninrao10)
- [x] Shiwei Zhang (@shizhMSFT)
- [x] Patrick Zheng (@Two-Hearts)

## What's Changed
* bump: release v1.3.0 by @Two-Hearts in https://github.com/notaryproject/notation-go/pull/507
* fix: remove signing time check during authenticTimestamp by @Two-Hearts in https://github.com/notaryproject/notation-go/pull/514
* bump: bump up dependencies for release-1.3 branch by @Two-Hearts in https://github.com/notaryproject/notation-go/pull/516

**Full Changelog**:
https://github.com/notaryproject/notation-go/compare/v1.3.0...961cef1f72d86e8f564bf7790fe04b23af53f02e

## Actions

Please review the PR and vote by approving.