### PR TITLE
feat: add `SignOCI` function to return both artifact and signature manifest descriptor

### DIFF
--- a/example_remoteSign_test.go
+++ b/example_remoteSign_test.go
@@ -70,13 +70,16 @@ func Example_remoteSign() {
 	// remote sign core process
 	// upon successful signing, descriptor of the sign content is returned and
 	// the generated signature is pushed into remote registry.
-	targetDesc, err := notation.Sign(context.Background(), exampleSigner, exampleRepo, exampleSignOptions)
+	targetManifestDesc, sigManifestDesc, err := notation.SignOCI(context.Background(), exampleSigner, exampleRepo, exampleSignOptions)
 	if err != nil {
 		panic(err) // Handle error
 	}
 
 	fmt.Println("Successfully signed")
-	fmt.Println("targetDesc MediaType:", targetDesc.MediaType)
-	fmt.Println("targetDesc Digest:", targetDesc.Digest)
-	fmt.Println("targetDesc Size:", targetDesc.Size)
+	fmt.Println("targetManifestDesc.MediaType:", targetManifestDesc.MediaType)
+	fmt.Println("targetManifestDesc.Digest:", targetManifestDesc.Digest)
+	fmt.Println("targetManifestDesc.Size:", targetManifestDesc.Size)
+	fmt.Println("sigManifestDesc.MediaType:", sigManifestDesc.MediaType)
+	fmt.Println("sigManifestDesc.Digest:", sigManifestDesc.Digest)
+	fmt.Println("sigManifestDesc.Size:", sigManifestDesc.Size)
 }

--- a/example_signWithTimestmap_test.go
+++ b/example_signWithTimestmap_test.go
@@ -98,13 +98,16 @@ func Example_signWithTimestamp() {
 		ArtifactReference: exampleArtifactReference,
 	}
 
-	targetDesc, err := notation.Sign(context.Background(), exampleSigner, exampleRepo, exampleSignOptions)
+	targetManifestDesc, sigManifestDesc, err := notation.SignOCI(context.Background(), exampleSigner, exampleRepo, exampleSignOptions)
 	if err != nil {
 		panic(err) // Handle error
 	}
 
 	fmt.Println("Successfully signed")
-	fmt.Println("targetDesc MediaType:", targetDesc.MediaType)
-	fmt.Println("targetDesc Digest:", targetDesc.Digest)
-	fmt.Println("targetDesc Size:", targetDesc.Size)
+	fmt.Println("targetManifestDesc.MediaType:", targetManifestDesc.MediaType)
+	fmt.Println("targetManifestDesc.Digest:", targetManifestDesc.Digest)
+	fmt.Println("targetManifestDesc.Size:", targetManifestDesc.Size)
+	fmt.Println("sigManifestDesc.MediaType:", sigManifestDesc.MediaType)
+	fmt.Println("sigManifestDesc.Digest:", sigManifestDesc.Digest)
+	fmt.Println("sigManifestDesc.Size:", sigManifestDesc.Size)
 }

--- a/notation.go
+++ b/notation.go
@@ -152,7 +152,7 @@ func Sign(ctx context.Context, signer Signer, repo registry.Repository, signOpts
 // Both artifact and signature manifest descriptors are returned upon successful
 // signing.
 //
-// Note: If the error type is remote.ReferrersError and
+// Note: If the error type is [remote.ReferrersError] and
 // referrerError.IsReferrersIndexDelete() returns true, the signature is
 // successfully pushed to the repository, but the referrers index deletion
 // failed. In this case, the artifact and signature manifest descriptors are

--- a/notation.go
+++ b/notation.go
@@ -141,7 +141,7 @@ type SignOptions struct {
 // Sign signs the OCI artifact and push the signature to the Repository.
 // The descriptor of the sign content is returned upon successful signing.
 //
-// Deprecated: Use SignOCI instead.
+// Deprecated: use SignOCI instead.
 func Sign(ctx context.Context, signer Signer, repo registry.Repository, signOpts SignOptions) (ocispec.Descriptor, error) {
 	artifactMenifestDesc, _, err := SignOCI(ctx, signer, repo, signOpts)
 	return artifactMenifestDesc, err

--- a/notation.go
+++ b/notation.go
@@ -149,7 +149,7 @@ func Sign(ctx context.Context, signer Signer, repo registry.Repository, signOpts
 //
 // Both artifact and signature manifest descriptors are returned upon successful
 // signing.
-func SignOCI(ctx context.Context, signer Signer, repo registry.Repository, signOpts SignOptions) (artifactManifestDesc ocispec.Descriptor, sigManifestDesc ocispec.Descriptor, err error) {
+func SignOCI(ctx context.Context, signer Signer, repo registry.Repository, signOpts SignOptions) (artifactManifestDesc, sigManifestDesc ocispec.Descriptor, err error) {
 	// sanity check
 	if err := validateSignArguments(signer, signOpts.SignerSignOptions); err != nil {
 		return ocispec.Descriptor{}, ocispec.Descriptor{}, err

--- a/notation.go
+++ b/notation.go
@@ -212,7 +212,6 @@ func SignOCI(ctx context.Context, signer Signer, repo registry.Repository, signO
 			logger.Warn("Removal of outdated referrers index from remote registry failed. Garbage collection may be required.")
 			return artifactManifestDesc, sigManifestDesc, nil
 		}
-
 		logger.Error("Failed to push the signature")
 		return ocispec.Descriptor{}, ocispec.Descriptor{}, ErrorPushSignatureFailed{Msg: err.Error()}
 	}

--- a/notation_test.go
+++ b/notation_test.go
@@ -171,8 +171,8 @@ func TestSignWithDanglingReferrersIndex(t *testing.T) {
 	opts.SignatureMediaType = jws.MediaTypeEnvelope
 
 	_, err := Sign(context.Background(), &dummySigner{}, repo, opts)
-	if err == nil {
-		t.Fatalf("no error occurred, expected error")
+	if err != nil {
+		t.Fatalf("expected no error as the error has been handled as a warning, got %s", err)
 	}
 }
 

--- a/notation_test.go
+++ b/notation_test.go
@@ -171,8 +171,8 @@ func TestSignWithDanglingReferrersIndex(t *testing.T) {
 	opts.SignatureMediaType = jws.MediaTypeEnvelope
 
 	_, err := Sign(context.Background(), &dummySigner{}, repo, opts)
-	if err != nil {
-		t.Fatalf("expected no error as the error has been handled as a warning, got %s", err)
+	if err == nil {
+		t.Fatalf("no error occurred, expected error")
 	}
 }
 


### PR DESCRIPTION
Feat:
- added `SignOCI` function and **deprecated** the `Sign` function to return both artifact and signature manifest descriptor.

Fix:
- handled referrer index deletion error as a warning to avoid confusion about the final signing status.

Resolve part of https://github.com/notaryproject/notation/issues/695