### PR TITLE
refactor: update error names to align with Go convention

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -15,6 +15,8 @@ package notation
 
 // ErrorPushSignatureFailed is used when failed to push signature to the
 // target registry.
+//
+// Deprecated: Use PushSignatureFailedError instead.
 type ErrorPushSignatureFailed struct {
 	Msg string
 }
@@ -26,8 +28,23 @@ func (e ErrorPushSignatureFailed) Error() string {
 	return "failed to push signature to registry"
 }
 
+// PushSignatureFailedError is used when failed to push signature to the
+// target registry.
+type PushSignatureFailedError struct {
+	Msg string
+}
+
+func (e PushSignatureFailedError) Error() string {
+	if e.Msg != "" {
+		return "failed to push signature to registry with error: " + e.Msg
+	}
+	return "failed to push signature to registry"
+}
+
 // ErrorVerificationInconclusive is used when signature verification fails due
 // to a runtime error (e.g. a network error)
+//
+// Deprecated: Use VerificationInconclusiveError instead.
 type ErrorVerificationInconclusive struct {
 	Msg string
 }
@@ -39,8 +56,23 @@ func (e ErrorVerificationInconclusive) Error() string {
 	return "signature verification was inclusive due to an unexpected error"
 }
 
+// VerificationInconclusiveError is used when signature verification fails due
+// to a runtime error (e.g. a network error)
+type VerificationInconclusiveError struct {
+	Msg string
+}
+
+func (e VerificationInconclusiveError) Error() string {
+	if e.Msg != "" {
+		return e.Msg
+	}
+	return "signature verification was inclusive due to an unexpected error"
+}
+
 // ErrorNoApplicableTrustPolicy is used when there is no trust policy that
 // applies to the given artifact
+//
+// Deprecated: Use NoApplicableTrustPolicyError instead.
 type ErrorNoApplicableTrustPolicy struct {
 	Msg string
 }
@@ -52,8 +84,23 @@ func (e ErrorNoApplicableTrustPolicy) Error() string {
 	return "there is no applicable trust policy for the given artifact"
 }
 
+// NoApplicableTrustPolicyError is used when there is no trust policy that
+// applies to the given artifact
+type NoApplicableTrustPolicyError struct {
+	Msg string
+}
+
+func (e NoApplicableTrustPolicyError) Error() string {
+	if e.Msg != "" {
+		return e.Msg
+	}
+	return "there is no applicable trust policy for the given artifact"
+}
+
 // ErrorSignatureRetrievalFailed is used when notation is unable to retrieve the
 // digital signature/s for the given artifact
+//
+// Deprecated: Use SignatureRetrievalFailedError instead.
 type ErrorSignatureRetrievalFailed struct {
 	Msg string
 }
@@ -65,8 +112,23 @@ func (e ErrorSignatureRetrievalFailed) Error() string {
 	return "unable to retrieve the digital signature from the registry"
 }
 
+// SignatureRetrievalFailedError is used when notation is unable to retrieve the
+// digital signature/s for the given artifact
+type SignatureRetrievalFailedError struct {
+	Msg string
+}
+
+func (e SignatureRetrievalFailedError) Error() string {
+	if e.Msg != "" {
+		return e.Msg
+	}
+	return "unable to retrieve the digital signature from the registry"
+}
+
 // ErrorVerificationFailed is used when it is determined that the digital
 // signature/s is not valid for the given artifact
+//
+// Deprecated: Use VerificationFailedError instead.
 type ErrorVerificationFailed struct {
 	Msg string
 }
@@ -78,13 +140,41 @@ func (e ErrorVerificationFailed) Error() string {
 	return "signature verification failed"
 }
 
+// VerificationFailedError is used when it is determined that the digital
+// signature/s is not valid for the given artifact
+type VerificationFailedError struct {
+	Msg string
+}
+
+func (e VerificationFailedError) Error() string {
+	if e.Msg != "" {
+		return e.Msg
+	}
+	return "signature verification failed"
+}
+
 // ErrorUserMetadataVerificationFailed is used when the signature does not
 // contain the user specified metadata
+//
+// Deprecated: Use UserMetadataVerificationFailedError instead.
 type ErrorUserMetadataVerificationFailed struct {
 	Msg string
 }
 
 func (e ErrorUserMetadataVerificationFailed) Error() string {
+	if e.Msg != "" {
+		return e.Msg
+	}
+	return "unable to find specified metadata in the signature"
+}
+
+// UserMetadataVerificationFailedError is used when the signature does not
+// contain the user specified metadata
+type UserMetadataVerificationFailedError struct {
+	Msg string
+}
+
+func (e UserMetadataVerificationFailedError) Error() string {
 	if e.Msg != "" {
 		return e.Msg
 	}

--- a/errors.go
+++ b/errors.go
@@ -16,19 +16,8 @@ package notation
 // ErrorPushSignatureFailed is used when failed to push signature to the
 // target registry.
 //
-// type ErrorPushSignatureFailed = PushSignatureFailedError
-//
 // Deprecated: Use PushSignatureFailedError instead.
-type ErrorPushSignatureFailed struct {
-	Msg string
-}
-
-func (e ErrorPushSignatureFailed) Error() string {
-	if e.Msg != "" {
-		return "failed to push signature to registry with error: " + e.Msg
-	}
-	return "failed to push signature to registry"
-}
+type ErrorPushSignatureFailed = PushSignatureFailedError
 
 // PushSignatureFailedError is used when failed to push signature to the
 // target registry.
@@ -46,19 +35,8 @@ func (e PushSignatureFailedError) Error() string {
 // ErrorVerificationInconclusive is used when signature verification fails due
 // to a runtime error (e.g. a network error)
 //
-// type ErrorVerificationInconclusive = VerificationInconclusiveError
-//
 // Deprecated: Use VerificationInconclusiveError instead.
-type ErrorVerificationInconclusive struct {
-	Msg string
-}
-
-func (e ErrorVerificationInconclusive) Error() string {
-	if e.Msg != "" {
-		return e.Msg
-	}
-	return "signature verification was inclusive due to an unexpected error"
-}
+type ErrorVerificationInconclusive = VerificationInconclusiveError
 
 // VerificationInconclusiveError is used when signature verification fails due
 // to a runtime error (e.g. a network error)
@@ -76,19 +54,8 @@ func (e VerificationInconclusiveError) Error() string {
 // ErrorNoApplicableTrustPolicy is used when there is no trust policy that
 // applies to the given artifact
 //
-// type ErrorNoApplicableTrustPolicy = NoApplicableTrustPolicyError
-//
 // Deprecated: Use NoApplicableTrustPolicyError instead.
-type ErrorNoApplicableTrustPolicy struct {
-	Msg string
-}
-
-func (e ErrorNoApplicableTrustPolicy) Error() string {
-	if e.Msg != "" {
-		return e.Msg
-	}
-	return "there is no applicable trust policy for the given artifact"
-}
+type ErrorNoApplicableTrustPolicy = NoApplicableTrustPolicyError
 
 // NoApplicableTrustPolicyError is used when there is no trust policy that
 // applies to the given artifact
@@ -106,19 +73,8 @@ func (e NoApplicableTrustPolicyError) Error() string {
 // ErrorSignatureRetrievalFailed is used when notation is unable to retrieve the
 // digital signature/s for the given artifact
 //
-// type ErrorSignatureRetrievalFailed = SignatureRetrievalFailedError
-//
 // Deprecated: Use SignatureRetrievalFailedError instead.
-type ErrorSignatureRetrievalFailed struct {
-	Msg string
-}
-
-func (e ErrorSignatureRetrievalFailed) Error() string {
-	if e.Msg != "" {
-		return e.Msg
-	}
-	return "unable to retrieve the digital signature from the registry"
-}
+type ErrorSignatureRetrievalFailed = SignatureRetrievalFailedError
 
 // SignatureRetrievalFailedError is used when notation is unable to retrieve the
 // digital signature/s for the given artifact
@@ -136,19 +92,8 @@ func (e SignatureRetrievalFailedError) Error() string {
 // ErrorVerificationFailed is used when it is determined that the digital
 // signature/s is not valid for the given artifact
 //
-// type ErrorVerificationFailed = VerificationFailedError
-//
 // Deprecated: Use VerificationFailedError instead.
-type ErrorVerificationFailed struct {
-	Msg string
-}
-
-func (e ErrorVerificationFailed) Error() string {
-	if e.Msg != "" {
-		return e.Msg
-	}
-	return "signature verification failed"
-}
+type ErrorVerificationFailed = VerificationFailedError
 
 // VerificationFailedError is used when it is determined that the digital
 // signature/s is not valid for the given artifact
@@ -166,19 +111,8 @@ func (e VerificationFailedError) Error() string {
 // ErrorUserMetadataVerificationFailed is used when the signature does not
 // contain the user specified metadata
 //
-// type ErrorUserMetadataVerificationFailed =  UserMetadataVerificationFailedError
-//
 // Deprecated: Use UserMetadataVerificationFailedError instead.
-type ErrorUserMetadataVerificationFailed struct {
-	Msg string
-}
-
-func (e ErrorUserMetadataVerificationFailed) Error() string {
-	if e.Msg != "" {
-		return e.Msg
-	}
-	return "unable to find specified metadata in the signature"
-}
+type ErrorUserMetadataVerificationFailed = UserMetadataVerificationFailedError
 
 // UserMetadataVerificationFailedError is used when the signature does not
 // contain the user specified metadata

--- a/errors.go
+++ b/errors.go
@@ -16,6 +16,8 @@ package notation
 // ErrorPushSignatureFailed is used when failed to push signature to the
 // target registry.
 //
+// type ErrorPushSignatureFailed = PushSignatureFailedError
+//
 // Deprecated: Use PushSignatureFailedError instead.
 type ErrorPushSignatureFailed struct {
 	Msg string
@@ -43,6 +45,8 @@ func (e PushSignatureFailedError) Error() string {
 
 // ErrorVerificationInconclusive is used when signature verification fails due
 // to a runtime error (e.g. a network error)
+//
+// type ErrorVerificationInconclusive = VerificationInconclusiveError
 //
 // Deprecated: Use VerificationInconclusiveError instead.
 type ErrorVerificationInconclusive struct {
@@ -72,6 +76,8 @@ func (e VerificationInconclusiveError) Error() string {
 // ErrorNoApplicableTrustPolicy is used when there is no trust policy that
 // applies to the given artifact
 //
+// type ErrorNoApplicableTrustPolicy = NoApplicableTrustPolicyError
+//
 // Deprecated: Use NoApplicableTrustPolicyError instead.
 type ErrorNoApplicableTrustPolicy struct {
 	Msg string
@@ -99,6 +105,8 @@ func (e NoApplicableTrustPolicyError) Error() string {
 
 // ErrorSignatureRetrievalFailed is used when notation is unable to retrieve the
 // digital signature/s for the given artifact
+//
+// type ErrorSignatureRetrievalFailed = SignatureRetrievalFailedError
 //
 // Deprecated: Use SignatureRetrievalFailedError instead.
 type ErrorSignatureRetrievalFailed struct {
@@ -128,6 +136,8 @@ func (e SignatureRetrievalFailedError) Error() string {
 // ErrorVerificationFailed is used when it is determined that the digital
 // signature/s is not valid for the given artifact
 //
+// type ErrorVerificationFailed = VerificationFailedError
+//
 // Deprecated: Use VerificationFailedError instead.
 type ErrorVerificationFailed struct {
 	Msg string
@@ -155,6 +165,8 @@ func (e VerificationFailedError) Error() string {
 
 // ErrorUserMetadataVerificationFailed is used when the signature does not
 // contain the user specified metadata
+//
+// type ErrorUserMetadataVerificationFailed =  UserMetadataVerificationFailedError
 //
 // Deprecated: Use UserMetadataVerificationFailedError instead.
 type ErrorUserMetadataVerificationFailed struct {

--- a/errors_test.go
+++ b/errors_test.go
@@ -91,3 +91,80 @@ func TestErrorMessages(t *testing.T) {
 		})
 	}
 }
+
+func TestCustomErrorPrintsCorrectMessage(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want string
+	}{
+		{
+			name: "PushSignatureFailedError with message",
+			err:  PushSignatureFailedError{Msg: "test message"},
+			want: "failed to push signature to registry with error: test message",
+		},
+		{
+			name: "PushSignatureFailedError without message",
+			err:  PushSignatureFailedError{},
+			want: "failed to push signature to registry",
+		},
+		{
+			name: "VerificationInconclusiveError with message",
+			err:  VerificationInconclusiveError{Msg: "test message"},
+			want: "test message",
+		},
+		{
+			name: "VerificationInconclusiveError without message",
+			err:  VerificationInconclusiveError{},
+			want: "signature verification was inclusive due to an unexpected error",
+		},
+		{
+			name: "NoApplicableTrustPolicyError with message",
+			err:  NoApplicableTrustPolicyError{Msg: "test message"},
+			want: "test message",
+		},
+		{
+			name: "NoApplicableTrustPolicyError without message",
+			err:  NoApplicableTrustPolicyError{},
+			want: "there is no applicable trust policy for the given artifact",
+		},
+		{
+			name: "SignatureRetrievalFailedError with message",
+			err:  SignatureRetrievalFailedError{Msg: "test message"},
+			want: "test message",
+		},
+		{
+			name: "SignatureRetrievalFailedError without message",
+			err:  SignatureRetrievalFailedError{},
+			want: "unable to retrieve the digital signature from the registry",
+		},
+		{
+			name: "VerificationFailedError with message",
+			err:  VerificationFailedError{Msg: "test message"},
+			want: "test message",
+		},
+		{
+			name: "VerificationFailedError without message",
+			err:  VerificationFailedError{},
+			want: "signature verification failed",
+		},
+		{
+			name: "UserMetadataVerificationFailedError with message",
+			err:  UserMetadataVerificationFailedError{Msg: "test message"},
+			want: "test message",
+		},
+		{
+			name: "UserMetadataVerificationFailedError without message",
+			err:  UserMetadataVerificationFailedError{},
+			want: "unable to find specified metadata in the signature",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.err.Error(); got != tt.want {
+				t.Errorf("Error() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This PR fixes https://github.com/notaryproject/notation-go/issues/528 and adds the following changes:

- add new custom errors (naming aligned with [Go convention](https://go.dev/doc/effective_go#errors))
- mark old custom error deprecated