### PR TITLE
fix: staticcheck complains - replace deprecated functions

### DIFF
--- a/example_localVerify_test.go
+++ b/example_localVerify_test.go
@@ -32,9 +32,9 @@ import (
 // examplePolicyDocument is an example of a valid trust policy document.
 // trust policy document should follow this spec:
 // https://github.com/notaryproject/notaryproject/blob/v1.0.0/specs/trust-store-trust-policy.md#trust-policy
-var examplePolicyDocument = trustpolicy.Document{
+var examplePolicyDocument = trustpolicy.OCIDocument{
 	Version: "1.0",
-	TrustPolicies: []trustpolicy.TrustPolicy{
+	TrustPolicies: []trustpolicy.OCITrustPolicy{
 		{
 			Name:                  "test-statement-name",
 			RegistryScopes:        []string{"example/software"},

--- a/example_remoteVerify_test.go
+++ b/example_remoteVerify_test.go
@@ -38,9 +38,9 @@ func Example_remoteVerify() {
 	// examplePolicyDocument is an example of a valid trust policy document.
 	// trust policy document should follow this spec:
 	// https://github.com/notaryproject/notaryproject/blob/v1.0.0/specs/trust-store-trust-policy.md#trust-policy
-	examplePolicyDocument := trustpolicy.Document{
+	examplePolicyDocument := trustpolicy.OCIDocument{
 		Version: "1.0",
-		TrustPolicies: []trustpolicy.TrustPolicy{
+		TrustPolicies: []trustpolicy.OCITrustPolicy{
 			{
 				Name:                  "test-statement-name",
 				RegistryScopes:        []string{"*"},

--- a/example_verifyWithTimestamp_test.go
+++ b/example_verifyWithTimestamp_test.go
@@ -39,9 +39,9 @@ func Example_verifyWithTimestamp() {
 	// timestamping configurations.
 	// trust policy document should follow this spec:
 	// https://github.com/notaryproject/notaryproject/blob/v1.0.0/specs/trust-store-trust-policy.md#trust-policy
-	examplePolicyDocument := trustpolicy.Document{
+	examplePolicyDocument := trustpolicy.OCIDocument{
 		Version: "1.0",
-		TrustPolicies: []trustpolicy.TrustPolicy{
+		TrustPolicies: []trustpolicy.OCITrustPolicy{
 			{
 				Name:           "test-statement-name",
 				RegistryScopes: []string{"*"},

--- a/notation_test.go
+++ b/notation_test.go
@@ -598,16 +598,16 @@ func TestVerifyBlobValid(t *testing.T) {
 	}
 }
 
-func dummyPolicyDocument() (policyDoc trustpolicy.Document) {
-	policyDoc = trustpolicy.Document{
+func dummyPolicyDocument() (policyDoc trustpolicy.OCIDocument) {
+	policyDoc = trustpolicy.OCIDocument{
 		Version:       "1.0",
-		TrustPolicies: []trustpolicy.TrustPolicy{dummyPolicyStatement()},
+		TrustPolicies: []trustpolicy.OCITrustPolicy{dummyPolicyStatement()},
 	}
 	return
 }
 
-func dummyPolicyStatement() (policyStatement trustpolicy.TrustPolicy) {
-	policyStatement = trustpolicy.TrustPolicy{
+func dummyPolicyStatement() (policyStatement trustpolicy.OCITrustPolicy) {
+	policyStatement = trustpolicy.OCITrustPolicy{
 		Name:                  "test-statement-name",
 		RegistryScopes:        []string{"registry.acme-rockets.io/software/net-monitor"},
 		SignatureVerification: trustpolicy.SignatureVerification{VerificationLevel: "strict"},


### PR DESCRIPTION
This PR fixes a part of `staticcheck` complains reported in  https://github.com/notaryproject/notation-go/issues/531 

The remaining issues will be addressed in a separate PRs.
