### PR TITLE
bump: release v1.3.2

### DIFF
--- a/signer/signer.go
+++ b/signer/signer.go
@@ -34,7 +34,7 @@ import (
 )
 
 // signingAgent is the unprotected header field used by signature.
-const signingAgent = "notation-go/1.3.1"
+const signingAgent = "notation-go/1.3.2"
 
 // GenericSigner implements notation.Signer and embeds signature.Signer
 type GenericSigner struct {


### PR DESCRIPTION
## Release
This would mean tagging 34a1aba2261cbe97b597ec96e440a61f6aadc416 as `v1.3.2` to release.

## Vote
We need at least `4` approvals from `6` maintainers to release `notation-go v1.3.2`.

## What's Changed
* bump: release v1.3.1 by @Two-Hearts in https://github.com/notaryproject/notation-go/pull/517
* backport: from main to release-1.3 branch by @Two-Hearts in https://github.com/notaryproject/notation-go/pull/536

**Full Changelog**:
https://github.com/notaryproject/notation-go/compare/v1.3.1...34a1aba2261cbe97b597ec96e440a61f6aadc416

## New Contributors
* @qba73 made their first contribution in https://github.com/notaryproject/notation-go/pull/529

## Actions
Please review the PR and vote by approving.